### PR TITLE
fix(auth): admit unverified users with a shell reminder

### DIFF
--- a/backend/__tests__/service/auth.test.js
+++ b/backend/__tests__/service/auth.test.js
@@ -276,7 +276,7 @@ describe('Auth Routes Integration Tests', () => {
       expect(response.body.verified).toBe(true);
     });
 
-    it('should not login an unverified user', async () => {
+    it('should login an unverified user and return its verification state', async () => {
       // Create an unverified user
       const user = new User({
         username: 'testuser',
@@ -294,9 +294,14 @@ describe('Auth Routes Integration Tests', () => {
       const response = await request(app)
         .post('/api/auth/login')
         .send(loginData)
-        .expect(400);
+        .expect(200);
 
-      expect(response.body.error).toContain('Email not verified');
+      expect(response.body.token).toBeDefined();
+      expect(response.body.verified).toBe(false);
+      expect(response.body.user).toMatchObject({
+        email: 'test@example.com',
+        verified: false,
+      });
     });
 
     it('should not login with incorrect password', async () => {

--- a/backend/__tests__/unit/controllers/authController.test.js
+++ b/backend/__tests__/unit/controllers/authController.test.js
@@ -286,12 +286,13 @@ describe('Auth Controller Tests', () => {
             username: 'testuser',
             email: 'test@example.com',
             profilePicture: expect.any(String),
+            verified: true,
           }),
         }),
       );
     });
 
-    it('should not login an unverified user', async () => {
+    it('starts a session for an unverified user and marks it in the response', async () => {
       // Mock an unverified user
       const user = {
         _id: 'testUserId',
@@ -318,13 +319,17 @@ describe('Auth Controller Tests', () => {
 
       await authController.login(req, res);
 
-      expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          error: expect.stringContaining('Email not verified'),
-          code: 'EMAIL_UNVERIFIED',
+          token: 'test-jwt-token',
+          verified: false,
+          user: expect.objectContaining({
+            email: 'test@example.com',
+            verified: false,
+          }),
         }),
       );
+      expect(res.status).not.toHaveBeenCalled();
     });
 
     it('should not login with incorrect password', async () => {

--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -686,15 +686,9 @@ exports.login = async (req: any, res: any) => {
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) return res.status(400).json({ error: 'Invalid credentials' });
 
-    // Verify the password before exposing an account's verification state.
-    // A genuine signer gets an actionable code; an attacker gets the same
-    // invalid-credential result for every account state.
-    if (!user.verified) {
-      return res.status(400).json({
-        error: 'Email not verified. Please check your inbox.',
-        code: 'EMAIL_UNVERIFIED',
-      });
-    }
+    // Verification is a post-login reminder, not an authentication wall.
+    // A correct password always starts a session; the shell receives the
+    // verified bit and keeps the user informed until their email is confirmed.
 
     const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, {
       expiresIn: '7d',
@@ -709,6 +703,7 @@ exports.login = async (req: any, res: any) => {
         email: user.email,
         profilePicture: user.profilePicture,
         role: user.role,
+        verified: user.verified,
       },
     });
   } catch (err: any) {

--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -65,13 +65,13 @@ test('logout clears token and user', () => {
   expect(global.testAuth.currentUser).toBeNull();
 });
 
-test('login stores token and user', async () => {
-  axios.post.mockResolvedValueOnce({ data: { token: 'tok', user: { name: 'Alice' } } });
+test('login stores token, user, and verification state', async () => {
+  axios.post.mockResolvedValueOnce({ data: { token: 'tok', user: { name: 'Alice', verified: false } } });
   await act(async () => {
     await global.testAuth.login('a', 'b');
   });
   expect(localStorage.getItem('token')).toBe('tok');
-  expect(global.testAuth.currentUser).toEqual({ name: 'Alice' });
+  expect(global.testAuth.currentUser).toEqual({ name: 'Alice', verified: false });
   expect(axios.post).toHaveBeenCalledWith('/api/auth/login', { email: 'a', password: 'b' });
 });
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -9,6 +9,7 @@ interface User {
   profilePicture?: string;
   role?: string;
   isBot?: boolean;
+  verified?: boolean;
   [key: string]: unknown;
 }
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -141,6 +141,14 @@
       "email": "Email",
       "password": "Password"
     },
+    "verificationBanner": {
+      "message": "Verify your email — we sent a link to {{email}}.",
+      "resend": "Resend",
+      "sending": "Sending…",
+      "resent": "Verification link requested.",
+      "resendFailed": "Could not request another link.",
+      "dismiss": "Hide verification reminder for this session"
+    },
     "login": {
       "title": "Sign in",
       "subtitle": "Commonly is the shared space where agents and humans collaborate.",
@@ -149,13 +157,6 @@
       "forgotPassword": "Forgot password?",
       "newToCommonly": "New to Commonly?",
       "createAccount": "Create an account",
-      "verification": {
-        "pending": "{{email}} has not been verified yet. Check that inbox, or request a new link.",
-        "resend": "Resend verification email",
-        "sending": "Sending verification email…",
-        "sent": "Verification email sent to {{email}}.",
-        "failed": "Could not resend the verification email."
-      },
       "errors": {
         "failed": "Login failed"
       },
@@ -186,8 +187,8 @@
         "ready": "Your account is ready. Sign in to continue.",
         "checkEmailTitle": "Check your email",
         "createdTitle": "Account created",
-        "checkEmailMessage": "Your account is almost ready. Verify your email to continue.",
-        "verifyThenSignIn": "We sent a verification link to your email. Verify your address, then <signIn>sign in</signIn>.",
+        "checkEmailMessage": "We sent a verification link to your email.",
+        "verifyThenSignIn": "You can <signIn>sign in now</signIn>; a reminder stays visible until you verify.",
         "continue": "Continue to sign in"
       }
     },

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -141,6 +141,14 @@
       "email": "邮箱",
       "password": "密码"
     },
+    "verificationBanner": {
+      "message": "请验证你的邮箱 — 我们已向 {{email}} 发送链接。",
+      "resend": "重新发送",
+      "sending": "正在发送…",
+      "resent": "已请求发送验证链接。",
+      "resendFailed": "无法请求新的验证链接。",
+      "dismiss": "在本次会话中隐藏验证提醒"
+    },
     "login": {
       "title": "登录",
       "subtitle": "Commonly 是智能体与人共同协作的空间。",
@@ -149,13 +157,6 @@
       "forgotPassword": "忘记密码？",
       "newToCommonly": "还没有 Commonly 账号？",
       "createAccount": "注册",
-      "verification": {
-        "pending": "{{email}} 尚未验证。请查看该邮箱，或重新请求验证链接。",
-        "resend": "重新发送验证邮件",
-        "sending": "正在发送验证邮件…",
-        "sent": "验证邮件已发送至 {{email}}。",
-        "failed": "无法重新发送验证邮件。"
-      },
       "errors": {
         "failed": "登录失败"
       },
@@ -186,8 +187,8 @@
         "ready": "注册完成，可以登录了。",
         "checkEmailTitle": "查看邮箱",
         "createdTitle": "注册完成",
-        "checkEmailMessage": "账号即将就绪，请先验证邮箱。",
-        "verifyThenSignIn": "验证链接已发送到你的邮箱。验证邮箱后即可<signIn>登录</signIn>。",
+        "checkEmailMessage": "验证链接已发送到你的邮箱。",
+        "verifyThenSignIn": "你可以立即<signIn>登录</signIn>；在完成验证前，提醒会一直显示。",
         "continue": "继续登录"
       }
     },

--- a/frontend/src/v2/V2App.tsx
+++ b/frontend/src/v2/V2App.tsx
@@ -41,6 +41,7 @@ import PodContextDevPage from '../components/PodContextDevPage';
 import GlobalIntegrations from '../components/admin/GlobalIntegrations';
 import V2AdminUsers from './components/V2AdminUsers';
 import V2AdminAnalytics from './components/V2AdminAnalytics';
+import V2EmailVerificationBanner from './components/V2EmailVerificationBanner';
 import ProtectedRoute from '../components/ProtectedRoute';
 import './v2.css';
 
@@ -92,6 +93,13 @@ const V2Boot: React.FC = () => (
   </div>
 );
 
+const V2AuthenticatedShell: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="v2-authenticated-shell">
+    <V2EmailVerificationBanner />
+    <div className="v2-authenticated-shell__content">{children}</div>
+  </div>
+);
+
 const V2RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { isAuthenticated, loading } = useAuth();
   const location = useLocation();
@@ -104,7 +112,7 @@ const V2RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     return <Navigate to="/v2/login" state={{ from: location }} replace />;
   }
 
-  return <>{children}</>;
+  return <V2AuthenticatedShell>{children}</V2AuthenticatedShell>;
 };
 
 // Index gate at `/v2`. Logged-out visitors see the public landing (the front
@@ -122,7 +130,7 @@ const V2Home: React.FC = () => {
     return <Navigate to="/" replace />;
   }
 
-  return <V2Layout selectionMode="auto" />;
+  return <V2AuthenticatedShell><V2Layout selectionMode="auto" /></V2AuthenticatedShell>;
 };
 
 const V2UseCaseRedirect: React.FC = () => {

--- a/frontend/src/v2/__tests__/V2EmailVerificationBanner.test.tsx
+++ b/frontend/src/v2/__tests__/V2EmailVerificationBanner.test.tsx
@@ -41,7 +41,7 @@ describe('V2EmailVerificationBanner', () => {
     jest.clearAllMocks();
   });
 
-  test('is a session-dismissible status reminder and resends without exposing an alert', async () => {
+  test('is a session-dismissible status reminder with a visible resend confirmation', async () => {
     (axios.post as jest.Mock).mockResolvedValueOnce({ data: { message: 'sent' } });
     const view = renderBanner();
 
@@ -54,7 +54,7 @@ describe('V2EmailVerificationBanner', () => {
       '/api/auth/resend-verification',
       { email: 'person@example.com' },
     ));
-    expect(banner).toHaveTextContent('Verification link requested.');
+    expect(screen.getByText('Verification link requested.')).toHaveClass('v2-verification-banner__notice');
 
     fireEvent.click(screen.getByRole('button', { name: /hide verification reminder/i }));
     expect(screen.queryByRole('status')).not.toBeInTheDocument();

--- a/frontend/src/v2/__tests__/V2EmailVerificationBanner.test.tsx
+++ b/frontend/src/v2/__tests__/V2EmailVerificationBanner.test.tsx
@@ -1,0 +1,66 @@
+// @ts-nocheck
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { AuthContext } from '../../context/AuthContext';
+import V2EmailVerificationBanner from '../components/V2EmailVerificationBanner';
+
+jest.mock('axios', () => {
+  const mock = {
+    post: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+const auth = {
+  currentUser: { _id: 'unverified-user', email: 'person@example.com', verified: false },
+  user: { _id: 'unverified-user', email: 'person@example.com', verified: false },
+  token: 'token',
+  loading: false,
+  error: null,
+  isAuthenticated: true,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+const renderBanner = () => render(
+  <AuthContext.Provider value={auth}>
+    <V2EmailVerificationBanner />
+  </AuthContext.Provider>,
+);
+
+describe('V2EmailVerificationBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('is a session-dismissible status reminder and resends without exposing an alert', async () => {
+    (axios.post as jest.Mock).mockResolvedValueOnce({ data: { message: 'sent' } });
+    const view = renderBanner();
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('Verify your email — we sent a link to person@example.com.');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^resend$/i }));
+    await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
+      '/api/auth/resend-verification',
+      { email: 'person@example.com' },
+    ));
+    expect(banner).toHaveTextContent('Verification link requested.');
+
+    fireEvent.click(screen.getByRole('button', { name: /hide verification reminder/i }));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    view.unmount();
+    renderBanner();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import axios from 'axios';
 import { AuthContext } from '../../context/AuthContext';
@@ -74,27 +74,6 @@ describe('V2 routing', () => {
     expect(screen.getByRole('heading', { name: /^Sign in$/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
-  });
-
-  test('names an unverified address in an alert and resends its link', async () => {
-    const login = jest.fn().mockRejectedValue({
-      response: { data: { error: 'Email not verified. Please check your inbox.', code: 'EMAIL_UNVERIFIED' } },
-    });
-    (axios.post as jest.Mock).mockResolvedValueOnce({ data: { message: 'sent' } });
-    renderAt('/v2/login', { ...baseAuth, login });
-
-    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'person@example.com' } });
-    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'Password123!' } });
-    fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }));
-
-    expect(await screen.findByRole('alert')).toHaveTextContent('person@example.com has not been verified yet');
-    fireEvent.click(screen.getByRole('button', { name: /resend verification email/i }));
-
-    await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
-      '/api/auth/resend-verification',
-      { email: 'person@example.com' },
-    ));
-    expect(await screen.findByRole('status')).toHaveTextContent('Verification email sent to person@example.com.');
   });
 
   test('index route shows the public landing when not authenticated', async () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -133,12 +133,25 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(phoneBlock).toMatch(/\.v2-root button\.v2-login__submit \{[\s\S]*?min-height: 44px;[\s\S]*?font-size: 16px;/);
   });
 
-  test('unverified shell banner stays a one-line 44px reminder on phones', () => {
+  test('unverified shell banner keeps the named address visible on phones', () => {
     const phoneStart = v2.indexOf('@media (max-width: 480px)');
     const phoneBlock = v2.slice(phoneStart, v2.indexOf('@media', phoneStart + 10));
-    expect(phoneBlock).toMatch(/\.v2-verification-banner \{[\s\S]*?height: 44px;[\s\S]*?font-size: 16px;/);
-    expect(ruleBody(v2, '.v2-verification-banner__text')).toContain('white-space: nowrap');
-    expect(ruleBody(v2, '.v2-verification-banner__text')).toContain('text-overflow: ellipsis');
+    const shell = ruleBody(v2, '.v2-authenticated-shell');
+    const banner = ruleBody(v2, '.v2-verification-banner');
+    const text = ruleBody(v2, '.v2-verification-banner__text');
+    const notice = ruleBody(v2, '.v2-verification-banner__notice');
+
+    expect(shell).toContain('grid-template-columns: minmax(0, 1fr)');
+    expect(banner).toContain('grid-template-columns: minmax(0, 1fr) auto auto');
+    expect(banner).toContain('min-width: 0');
+    expect(text).toContain('overflow-wrap: anywhere');
+    expect(text).not.toContain('white-space: nowrap');
+    expect(text).not.toContain('text-overflow: ellipsis');
+    expect(notice).not.toContain('position: absolute');
+    expect(phoneBlock).toMatch(/\.v2-verification-banner \{[\s\S]*?grid-template-areas:[\s\S]*?"content dismiss"[\s\S]*?"resend resend"[\s\S]*?font-size: 16px;/);
+    expect(phoneBlock).toMatch(/\.v2-root button\.v2-verification-banner__resend \{[\s\S]*?justify-self: start;/);
+    expect(ruleBody(v2, '.v2-root button.v2-verification-banner__resend,\n.v2-root button.v2-verification-banner__dismiss')).toContain('min-height: 44px');
+    expect(v2).toMatch(/\.v2-root button\.v2-verification-banner__dismiss \{[\s\S]*?width: 44px;/);
   });
 
   test('Activity queue actions stay in the row grammar and wrap on narrow screens', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -133,6 +133,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(phoneBlock).toMatch(/\.v2-root button\.v2-login__submit \{[\s\S]*?min-height: 44px;[\s\S]*?font-size: 16px;/);
   });
 
+  test('unverified shell banner stays a one-line 44px reminder on phones', () => {
+    const phoneStart = v2.indexOf('@media (max-width: 480px)');
+    const phoneBlock = v2.slice(phoneStart, v2.indexOf('@media', phoneStart + 10));
+    expect(phoneBlock).toMatch(/\.v2-verification-banner \{[\s\S]*?height: 44px;[\s\S]*?font-size: 16px;/);
+    expect(ruleBody(v2, '.v2-verification-banner__text')).toContain('white-space: nowrap');
+    expect(ruleBody(v2, '.v2-verification-banner__text')).toContain('text-overflow: ellipsis');
+  });
+
   test('Activity queue actions stay in the row grammar and wrap on narrow screens', () => {
     // Day-zero onboarding and approval actions share the queue row. Keeping
     // their action cluster explicit prevents a later button refactor from

--- a/frontend/src/v2/components/V2EmailVerificationBanner.tsx
+++ b/frontend/src/v2/components/V2EmailVerificationBanner.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../context/AuthContext';
+import axios from '../../utils/axiosConfig';
+
+const V2EmailVerificationBanner: React.FC = () => {
+  const { currentUser } = useAuth();
+  const { t } = useTranslation();
+  const [dismissed, setDismissed] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const needsVerification = currentUser?.verified === false;
+
+  useEffect(() => {
+    setNotice(null);
+    // Keep a dismissal through route changes in this mounted app shell, but
+    // restore the reminder on the next page load as the product ruling says.
+    setDismissed(false);
+  }, [currentUser?._id, currentUser?.id, needsVerification]);
+
+  if (!needsVerification || dismissed || !currentUser?.email) return null;
+
+  const dismiss = () => {
+    setDismissed(true);
+  };
+
+  const resend = async () => {
+    if (resending) return;
+    setResending(true);
+    setNotice(null);
+    try {
+      await axios.post('/api/auth/resend-verification', { email: currentUser.email });
+      setNotice(t('auth.verificationBanner.resent'));
+    } catch {
+      setNotice(t('auth.verificationBanner.resendFailed'));
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <div className="v2-verification-banner" role="status" aria-live="polite">
+      <span className="v2-verification-banner__text">
+        {t('auth.verificationBanner.message', { email: currentUser.email })}
+      </span>
+      {notice && <span className="v2-verification-banner__notice">{notice}</span>}
+      <button
+        type="button"
+        className="v2-verification-banner__resend"
+        onClick={resend}
+        disabled={resending}
+      >
+        {resending ? t('auth.verificationBanner.sending') : t('auth.verificationBanner.resend')}
+      </button>
+      <button
+        type="button"
+        className="v2-verification-banner__dismiss"
+        onClick={dismiss}
+        aria-label={t('auth.verificationBanner.dismiss')}
+      >
+        <CloseIcon fontSize="small" aria-hidden="true" />
+      </button>
+    </div>
+  );
+};
+
+export default V2EmailVerificationBanner;

--- a/frontend/src/v2/components/V2EmailVerificationBanner.tsx
+++ b/frontend/src/v2/components/V2EmailVerificationBanner.tsx
@@ -42,10 +42,12 @@ const V2EmailVerificationBanner: React.FC = () => {
 
   return (
     <div className="v2-verification-banner" role="status" aria-live="polite">
-      <span className="v2-verification-banner__text">
-        {t('auth.verificationBanner.message', { email: currentUser.email })}
-      </span>
-      {notice && <span className="v2-verification-banner__notice">{notice}</span>}
+      <div className="v2-verification-banner__content">
+        <span className="v2-verification-banner__text">
+          {t('auth.verificationBanner.message', { email: currentUser.email })}
+        </span>
+        {notice && <span className="v2-verification-banner__notice">{notice}</span>}
+      </div>
       <button
         type="button"
         className="v2-verification-banner__resend"

--- a/frontend/src/v2/components/V2Login.tsx
+++ b/frontend/src/v2/components/V2Login.tsx
@@ -4,7 +4,6 @@ import { useAuth } from '../../context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import V2OAuthButtons from './V2OAuthButtons';
 import V2AuthBrand from './V2AuthBrand';
-import axios from '../../utils/axiosConfig';
 
 interface LocationState {
   from?: { pathname?: string };
@@ -32,15 +31,10 @@ const V2Login: React.FC = () => {
   const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
-  const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
-  const [resending, setResending] = useState(false);
-  const [resendNotice, setResendNotice] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLocalError(null);
-    setUnverifiedEmail(null);
-    setResendNotice(null);
     setSubmitting(true);
     try {
       await login(email.trim(), password);
@@ -55,33 +49,10 @@ const V2Login: React.FC = () => {
       const dest = next && next.startsWith('/') ? next : fallback;
       navigate(dest, { replace: true });
     } catch (err) {
-      const e1 = err as { response?: { data?: { error?: string; msg?: string; code?: string } }; message?: string };
-      if (e1.response?.data?.code === 'EMAIL_UNVERIFIED') {
-        setUnverifiedEmail(email.trim());
-      }
+      const e1 = err as { response?: { data?: { error?: string; msg?: string } }; message?: string };
       setLocalError(e1.response?.data?.error || e1.response?.data?.msg || e1.message || t('auth.login.errors.failed'));
     } finally {
       setSubmitting(false);
-    }
-  };
-
-  const handleResendVerification = async () => {
-    if (!unverifiedEmail) return;
-    setResending(true);
-    setResendNotice(null);
-    try {
-      await axios.post('/api/auth/resend-verification', { email: unverifiedEmail });
-      setResendNotice(t('auth.login.verification.sent', { email: unverifiedEmail }));
-    } catch (err) {
-      const e1 = err as { response?: { data?: { error?: string; message?: string } }; message?: string };
-      setResendNotice(
-        e1.response?.data?.error
-        || e1.response?.data?.message
-        || e1.message
-        || t('auth.login.verification.failed'),
-      );
-    } finally {
-      setResending(false);
     }
   };
 
@@ -139,24 +110,7 @@ const V2Login: React.FC = () => {
           <Link to="/v2/forgot-password" className="v2-login__link">{t('auth.login.forgotPassword')}</Link>
         </div>
 
-        {unverifiedEmail ? (
-          <div className="v2-login__error" role="alert">
-            <div>
-              {t('auth.login.verification.pending', { email: unverifiedEmail })}
-            </div>
-            <button
-              type="button"
-              className="v2-login__resend"
-              onClick={handleResendVerification}
-              disabled={resending}
-            >
-              {resending
-                ? t('auth.login.verification.sending')
-                : t('auth.login.verification.resend')}
-            </button>
-            {resendNotice && <div className="v2-login__resend-notice" role="status">{resendNotice}</div>}
-          </div>
-        ) : errorMessage && <div className="v2-login__error" role="alert">{errorMessage}</div>}
+        {errorMessage && <div className="v2-login__error" role="alert">{errorMessage}</div>}
 
         <V2OAuthButtons next={nextPath} />
 

--- a/frontend/src/v2/components/V2Register.tsx
+++ b/frontend/src/v2/components/V2Register.tsx
@@ -71,10 +71,9 @@ const V2Register: React.FC = () => {
       const message = data?.message || t('auth.register.success.ready');
       // The backend only sends a verification email (and withholds a usable
       // session) when SMTP is configured — its message says to check email in
-      // that case. When auto-verified, no email is sent and sign-in works
-      // immediately. Branch the success screen on that signal so we never tell
-      // a still-unverified user to "Continue to sign in" (which yields
-      // "Email not verified" at login).
+      // that case. The login shell admits unverified users and keeps a
+      // persistent verification reminder visible, so the success screen can
+      // take them directly to sign-in without creating a dead end.
       setVerifyPending(message.toLowerCase().includes('check your email'));
       setDone(message);
     } catch (err) {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -370,6 +370,91 @@ body.modern-ui.v2-canvas {
 
 /* ---------- Layout shell ---------- */
 
+/* Authenticated v2 routes reserve a compact shell row for the email
+   verification reminder. The inner shell/panes must use the remaining space,
+   not 100vh, or the composer and feature-page footers would clip. */
+.v2-authenticated-shell {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100vh;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.v2-authenticated-shell__content {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.v2-authenticated-shell__content > .v2-shell,
+.v2-authenticated-shell__content .v2-pane {
+  height: 100%;
+}
+
+.v2-verification-banner {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 4px 16px;
+  border-bottom: 1px solid var(--v2-border-soft);
+  background: var(--v2-warning-soft);
+  color: var(--v2-text-primary);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.v2-verification-banner__text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Resend feedback belongs to the banner's status announcement, but it must
+   not replace the required named-address reminder or consume its 44px phone
+   row. */
+.v2-verification-banner__notice {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.v2-root button.v2-verification-banner__resend,
+.v2-root button.v2-verification-banner__dismiss {
+  flex: none;
+  border: 0;
+  background: transparent;
+  color: var(--v2-accent-text);
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.v2-root button.v2-verification-banner__resend {
+  min-height: 32px;
+  padding: 4px 2px;
+}
+
+.v2-root button.v2-verification-banner__dismiss {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  place-items: center;
+  color: var(--v2-text-secondary);
+}
+
+.v2-root button.v2-verification-banner__resend:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
 .v2-shell {
   display: grid;
   grid-template-columns: var(--v2-rail-w) var(--v2-pods-w) 1fr var(--v2-inspector-w);
@@ -4565,6 +4650,13 @@ body.modern-ui.v2-canvas {
 }
 
 @media (max-width: 480px) {
+  .v2-verification-banner {
+    height: 44px;
+    min-height: 44px;
+    padding: 4px 12px;
+    font-size: 16px;
+  }
+
   /* Auth is a primary phone flow: 16px prevents Safari's focus zoom and a
      44px target keeps signup usable with a thumb. */
   .v2-login__input {
@@ -4871,29 +4963,6 @@ body.modern-ui.v2-canvas {
   background: rgba(239, 68, 68, 0.1);
   color: var(--v2-danger);
   font-size: 12px;
-}
-
-.v2-root button.v2-login__resend {
-  min-height: 32px;
-  margin-top: 8px;
-  padding: 6px 0;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  font-weight: 700;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
-.v2-root button.v2-login__resend:disabled {
-  cursor: progress;
-  opacity: 0.7;
-}
-
-.v2-login__resend-notice {
-  margin-top: 6px;
-  color: var(--v2-text-secondary);
 }
 
 .v2-login__forgot {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -375,6 +375,7 @@ body.modern-ui.v2-canvas {
    not 100vh, or the composer and feature-page footers would clip. */
 .v2-authenticated-shell {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   height: 100vh;
   min-height: 0;
@@ -382,6 +383,7 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-authenticated-shell__content {
+  min-width: 0;
   min-height: 0;
   overflow: hidden;
 }
@@ -393,9 +395,12 @@ body.modern-ui.v2-canvas {
 
 .v2-verification-banner {
   box-sizing: border-box;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-areas: "content resend dismiss";
   align-items: center;
   gap: 8px;
+  min-width: 0;
   min-height: 40px;
   padding: 4px 16px;
   border-bottom: 1px solid var(--v2-border-soft);
@@ -405,29 +410,30 @@ body.modern-ui.v2-canvas {
   line-height: 20px;
 }
 
-.v2-verification-banner__text {
+.v2-verification-banner__content {
+  grid-area: content;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-/* Resend feedback belongs to the banner's status announcement, but it must
-   not replace the required named-address reminder or consume its 44px phone
-   row. */
+.v2-verification-banner__text {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+/* Resend feedback stays in the visible status reminder so a sighted person
+   receives the same confirmation as assistive technology. */
 .v2-verification-banner__notice {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
+  display: block;
+  margin-top: 2px;
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  line-height: 18px;
 }
 
 .v2-root button.v2-verification-banner__resend,
 .v2-root button.v2-verification-banner__dismiss {
   flex: none;
+  min-height: 44px;
   border: 0;
   background: transparent;
   color: var(--v2-accent-text);
@@ -437,14 +443,15 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-root button.v2-verification-banner__resend {
-  min-height: 32px;
-  padding: 4px 2px;
+  grid-area: resend;
+  padding: 4px 4px;
 }
 
 .v2-root button.v2-verification-banner__dismiss {
+  grid-area: dismiss;
   display: grid;
-  width: 32px;
-  height: 32px;
+  width: 44px;
+  height: 44px;
   padding: 0;
   place-items: center;
   color: var(--v2-text-secondary);
@@ -4651,10 +4658,19 @@ body.modern-ui.v2-canvas {
 
 @media (max-width: 480px) {
   .v2-verification-banner {
-    height: 44px;
-    min-height: 44px;
-    padding: 4px 12px;
+    grid-template-columns: minmax(0, 1fr) 44px;
+    grid-template-areas:
+      "content dismiss"
+      "resend resend";
+    align-items: start;
+    gap: 6px 8px;
+    min-height: 0;
+    padding: 8px 12px;
     font-size: 16px;
+  }
+
+  .v2-root button.v2-verification-banner__resend {
+    justify-self: start;
   }
 
   /* Auth is a primary phone flow: 16px prevents Safari's focus zoom and a


### PR DESCRIPTION
## Why

Sam’s TASK-103 ruling replaces the unverified-email login wall: a correct password starts a session, with the verification state carried into the shell.

## What

- returns `user.verified` from password login and admits unverified users
- replaces the login-wall resend state with a persistent, dismissible v2 status banner and resend action
- keeps the named address visible, restores the reminder on the next page load, and pins the 390px 44px/16px layout floor
- updates registration copy and removes the retired login-wall path

## Verification

- `backend: npm test -- --runInBand __tests__/unit/controllers/authController.test.js` (20/20)
- `frontend: npx jest --runInBand src/v2/__tests__/V2EmailVerificationBanner.test.tsx src/v2/__tests__/V2Login.test.tsx src/v2/__tests__/v2-layout-invariants.test.ts src/context/AuthContext.test.tsx` (134/134)
- `frontend: npm run typecheck`
- `frontend: npm run build`
- mutation checks: restoring the server login wall makes exactly its unverified-session test fail; reversing the banner predicate makes its banner test fail

`backend/__tests__/service/auth.test.js` remains blocked before test execution by the existing Node 26/jsonwebtoken `buffer-equal-constant-time` loader error.