### PR TITLE
style(v2): apply ruled craft pass

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1563,7 +1563,7 @@
   },
   "podsSidebar": {
     "title": "Pods",
-    "newPod": "New Pod",
+    "newPod": "New pod",
     "closeTitle": "Close pods",
     "closeAriaLabel": "Close pods list",
     "searchPlaceholder": "Search pods...",
@@ -1687,7 +1687,7 @@
       "kicker": "{{agents}} · {{active}} active this week"
     },
     "actions": {
-      "hire": "+ Hire an agent",
+      "hire": "Hire an agent",
       "addComputer": "Add a computer",
       "cancel": "Cancel"
     },
@@ -1743,9 +1743,9 @@
       "workingNow": "Working now",
       "team": "Team",
       "quiet": "Quiet",
-      "internal": "Internal seats",
+      "internal": "Connected agents",
       "quietCount": "Quiet ({{count}})",
-      "internalCount": "Internal seats ({{count}})",
+      "internalCount": "Connected agents ({{count}})",
       "activeMeta_one": "Active {{time}} · {{count}} pod",
       "activeMeta_other": "Active {{time}} · {{count}} pods"
     }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1681,7 +1681,7 @@
       "kicker": "{{agents}} · 本周活跃 {{active}} 个"
     },
     "actions": {
-      "hire": "+ 雇佣智能体",
+      "hire": "雇佣智能体",
       "addComputer": "添加电脑",
       "cancel": "取消"
     },
@@ -1737,9 +1737,9 @@
       "workingNow": "正在工作",
       "team": "团队",
       "quiet": "沉寂",
-      "internal": "内部席位",
+      "internal": "已连接的智能体",
       "quietCount": "沉寂（{{count}}）",
-      "internalCount": "内部席位（{{count}}）",
+      "internalCount": "已连接的智能体（{{count}}）",
       "activeMeta_one": "活跃于{{time}} · {{count}} 个 Pod",
       "activeMeta_other": "活跃于{{time}} · {{count}} 个 Pod"
     }

--- a/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
+++ b/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
@@ -50,6 +50,13 @@ describe('the connect flow states what it does not do', () => {
     expect(zhCN.yourTeam.activity.neverConnected).not.toBe(zhCN.yourTeam.activity.noRecent);
   });
 
+  test('internal seats are named as connected agents in both locales', () => {
+    expect(en.yourTeam.tiers.internal).toBe('Connected agents');
+    expect(en.yourTeam.tiers.internalCount).toBe('Connected agents ({{count}})');
+    expect(zhCN.yourTeam.tiers.internal).toBe('已连接的智能体');
+    expect(zhCN.yourTeam.tiers.internalCount).toBe('已连接的智能体（{{count}}）');
+  });
+
   test('Your Team renders the never-connected state for a null heartbeat', () => {
     const src = read('../components/V2YourTeamPage.tsx');
     // `lastHeartbeatAt` is derived from heartbeat events, so null means the

--- a/frontend/src/v2/__tests__/V2PodBoard.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodBoard.test.tsx
@@ -79,6 +79,11 @@ describe('V2PodBoard', () => {
   test('renders four canonical columns and places alias statuses in them', async () => {
     renderBoard();
 
+    // The craft pass uses icon components, not unicode arrow/plus glyphs, so
+    // the accessible button names stay sentence-case labels.
+    expect(screen.getByRole('button', { name: 'Back to chat' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New task' })).toBeInTheDocument();
+
     const pending = await screen.findByRole('region', { name: 'Pending' });
     const inProgress = screen.getByRole('region', { name: 'In Progress' });
     const done = screen.getByRole('region', { name: 'Done' });

--- a/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodChatComposer.test.tsx
@@ -75,6 +75,28 @@ const renderChat = (detail) => render(
 );
 
 describe('V2PodChat composer send button', () => {
+  test('only shows a no-heartbeat state when the pod has an installed agent', () => {
+    const view = renderChat(makeDetail({
+      pod: { _id: 'p1', name: 'My Workspace', type: 'chat', description: 'Team discussion' },
+    }));
+
+    // A human-only pod is not waiting on anyone to heartbeat.
+    expect(view.container.querySelector('.v2-chat__goal-meta')).toBeNull();
+
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2PodChat detail={makeDetail({
+            pod: { _id: 'p1', name: 'My Workspace', type: 'chat', description: 'Team discussion' },
+            agents: [{ agentName: 'scout', instanceId: 'default', displayName: 'Scout' }],
+          })} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+
+    expect(view.container.querySelector('.v2-chat__goal-meta')).toHaveTextContent('No recent heartbeats');
+  });
+
   test('clicking the send button sends the drafted text', async () => {
     const detail = makeDetail();
     renderChat(detail);

--- a/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebarCreate.test.tsx
@@ -92,7 +92,7 @@ describe('V2PodsSidebar create flow', () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'New Pod' }));
+    fireEvent.click(screen.getByRole('button', { name: 'New pod' }));
 
     // The audience choice is gone — it set one field, could not be honoured
     // for non-admins, and asked a stranger to decide before they had content.

--- a/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
+++ b/frontend/src/v2/__tests__/V2YourTeamTiers.test.tsx
@@ -115,12 +115,21 @@ describe('Your Team tiers', () => {
     // hosted-smoke was active 1 minute ago and still must NOT be featured.
     expect(screen.queryByText('Hosted Smoke')).not.toBeInTheDocument();
     const toggle = screen.getByTestId('team-internal-toggle');
-    expect(toggle).toHaveTextContent('Internal seats (1)');
+    expect(toggle).toHaveTextContent('Connected agents (1)');
     // smoke-widget matches the old client-side name pattern but has no server
     // flag: it stays on the open roster, not behind the disclosure.
     expect(screen.getByText('Smoke Widget')).toBeInTheDocument();
     fireEvent.click(toggle);
     expect(screen.getByText('Hosted Smoke')).toBeInTheDocument();
+  });
+
+  test('the invite-gated notice stays a quiet line with its code link', async () => {
+    renderPage();
+    const noticeText = await screen.findByText('Hosted agents are invite-gated during beta.');
+    const notice = noticeText.closest('.v2-team__entitlement-notice');
+
+    expect(notice).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Have an invitation code?' })).toBeInTheDocument();
   });
 
   test('header kicker reports real numbers: total and active this week, internal excluded', async () => {
@@ -134,7 +143,7 @@ describe('Your Team tiers', () => {
   test('header offers exactly hire + add-a-computer — channels have no CTA here (Sam 2026-09-01)', async () => {
     renderPage();
     await waitFor(() => expect(screen.getByText('Fable')).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: '+ Hire an agent' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hire an agent' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add a computer' })).toBeInTheDocument();
     // "Connect" (the channels page) must not sit next to an agent-runtime CTA
     // — same verb, different concept was the confusion being removed.

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -50,6 +50,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   const showcase = read('../showcase/v2-showcase.css');
   const aprofile = read('../agents/v2-agent-profile.css');
   const landing = read('../landing/v2-landing.css');
+  const podChat = read('../components/V2PodChat.tsx');
+  const podBoard = read('../components/V2PodBoard.tsx');
+  const yourTeam = read('../components/V2YourTeamPage.tsx');
 
   test('Your Team card name owns its line so the category chip cannot crush it', () => {
     const rule = ruleBody(v2, '.v2-team-card__name');
@@ -501,6 +504,37 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(title).toContain('-webkit-line-clamp: 3');
     expect(title).toContain('-webkit-box-orient: vertical');
     expect(title).toContain('overflow: hidden');
+  });
+
+  test('craft-pass board action chips keep their 32px target and 12px type', () => {
+    // These compact controls are repeated on every board card and in the
+    // detail dialog. A declaration on the shared selector keeps both paths
+    // aligned and guards the 25px control regression measured at 390px.
+    const chip = ruleBody(v2, '.v2-root button.v2-board__card-move');
+    expect(chip).toContain('min-height: 32px');
+    expect(chip).toContain('font-size: 12px');
+  });
+
+  test('craft-pass buttons use icon components instead of unicode glyphs', () => {
+    // This is structural: accessible labels cannot prove a literal glyph has
+    // left the JSX. The MUI imports and icon nodes are the implementation
+    // contract for the three ruled buttons.
+    expect(podBoard).toContain("import AddIcon from '@mui/icons-material/Add'");
+    expect(podBoard).toContain("import ArrowBackIcon from '@mui/icons-material/ArrowBack'");
+    expect(podBoard).toContain('<ArrowBackIcon fontSize="small" aria-hidden="true" />');
+    expect(podBoard).toContain('<AddIcon fontSize="small" aria-hidden="true" />');
+    expect(podBoard).not.toContain('← {t(\'board.backToChat\')}');
+    expect(podBoard).not.toContain('+ {t(\'board.newTask\')}');
+    expect(yourTeam).toContain("import AddIcon from '@mui/icons-material/Add'");
+    expect(yourTeam).toContain('<AddIcon fontSize="small" aria-hidden="true" />');
+  });
+
+  test('the chat heartbeat subtitle is guarded by an installed agent', () => {
+    // A zero-agent pod has nobody expected to heartbeat; showing "No recent"
+    // there was a false failure state. Pin both the predicate and its render
+    // guard so a later copy-only edit cannot restore the dangling separator.
+    expect(podChat).toContain('const liveState = agents.length > 0');
+    expect(podChat).toContain('{liveState && <span className="v2-chat__goal-meta"> · {liveState}</span>}');
   });
 
   test('the Community sub-tabs and Discover rows shrink inside the narrow sidebar', () => {

--- a/frontend/src/v2/components/V2PodBoard.tsx
+++ b/frontend/src/v2/components/V2PodBoard.tsx
@@ -15,6 +15,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import AddIcon from '@mui/icons-material/Add';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useV2Api } from '../hooks/useV2Api';
 import { useSocket } from '../../context/SocketContext';
 
@@ -231,7 +233,8 @@ const V2PodBoard: React.FC = () => {
           className="v2-board__back"
           onClick={() => navigate(`/v2/pods/${podId}`)}
         >
-          ← {t('board.backToChat')}
+          <ArrowBackIcon fontSize="small" aria-hidden="true" />
+          {t('board.backToChat')}
         </button>
         <div className="v2-board__title-wrap">
           <h1 className="v2-board__title">{podName || t('board.title')}</h1>
@@ -244,7 +247,8 @@ const V2PodBoard: React.FC = () => {
           className="v2-board__new"
           onClick={openCreateTask}
         >
-          + {t('board.newTask')}
+          <AddIcon fontSize="small" aria-hidden="true" />
+          {t('board.newTask')}
         </button>
       </header>
 

--- a/frontend/src/v2/components/V2PodChat.tsx
+++ b/frontend/src/v2/components/V2PodChat.tsx
@@ -1141,12 +1141,17 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   const onlineAgentCount = agents.filter((agent) => (
     !!agent.lastHeartbeatAt && Date.now() - new Date(agent.lastHeartbeatAt).getTime() < 10 * 60 * 1000
   )).length;
-  const liveState = onlineAgentCount > 0
-    ? t('podChat.heartbeat.recent', {
-      count: onlineAgentCount,
-      formattedCount: numberFormatter.format(onlineAgentCount),
-    })
-    : t('podChat.heartbeat.none');
+  // A no-heartbeat state has meaning only when this pod has an installed
+  // agent. Human-only pods otherwise read as broken despite having nobody
+  // expected to check in.
+  const liveState = agents.length > 0
+    ? onlineAgentCount > 0
+      ? t('podChat.heartbeat.recent', {
+        count: onlineAgentCount,
+        formattedCount: numberFormatter.format(onlineAgentCount),
+      })
+      : t('podChat.heartbeat.none')
+    : null;
   const starterPrompts = STARTER_PROMPT_KEYS.map((key) => t(key));
 
   return (
@@ -1235,7 +1240,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
           {pod.description && (
             <div className="v2-chat__goal">
               {pod.description}
-              <span className="v2-chat__goal-meta"> · {liveState}</span>
+              {liveState && <span className="v2-chat__goal-meta"> · {liveState}</span>}
             </div>
           )}
         </header>

--- a/frontend/src/v2/components/V2YourTeamPage.tsx
+++ b/frontend/src/v2/components/V2YourTeamPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import axios from 'axios';
+import AddIcon from '@mui/icons-material/Add';
 import V2Avatar from './V2Avatar';
 import { useAuth } from '../../context/AuthContext';
 
@@ -473,6 +474,7 @@ const V2YourTeamPage: React.FC = () => {
             className="v2-team__hire-cta"
             onClick={() => navigate(primaryHirePath)}
           >
+            <AddIcon fontSize="small" aria-hidden="true" />
             {t('yourTeam.actions.hire')}
           </button>
           <button
@@ -486,7 +488,7 @@ const V2YourTeamPage: React.FC = () => {
       </header>
 
       {!isEntitled && (
-        <div className="v2-team__redeem">
+        <div className="v2-team__entitlement-notice">
           {redeemOpen ? (
             <form className="v2-team__redeem-form" onSubmit={handleRedeem}>
               <input

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5984,6 +5984,9 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-root button.v2-team__hire-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   background: var(--v2-accent);
   color: #fff;
   border: none;
@@ -6035,8 +6038,16 @@ body.modern-ui.v2-canvas {
   margin-bottom: 20px;
 }
 
-/* Invite-code redemption strip — shown to BYO-tier users; a valid code
-   unlocks hosted agents (entitlements.cloudAgents). */
+/* Invite-code access is a quiet line under the roster title, not a notice
+   card competing with the team's primary work. The linked code path remains
+   available when a user has one. */
+.v2-team__entitlement-notice {
+  margin: -12px 0 20px;
+  color: var(--v2-text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 .v2-team__redeem {
   padding: 10px 14px;
   background: var(--v2-bg-subtle);
@@ -7639,6 +7650,9 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-root button.v2-board__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   border: none;
   background: none;
   color: var(--v2-text-secondary);
@@ -7680,6 +7694,9 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-root button.v2-board__new {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   border: none;
   background: var(--v2-accent);
   color: #fff;
@@ -7812,7 +7829,8 @@ body.modern-ui.v2-canvas {
   border: 1px solid var(--v2-border);
   background: var(--v2-surface);
   color: var(--v2-text-secondary);
-  font-size: 11.5px;
+  min-height: 32px;
+  font-size: 12px;
   font-weight: 600;
   border-radius: 6px;
   padding: 3px 10px;


### PR DESCRIPTION
Implements the eight TASK-110 changes ruled APPLY: chat copy and heartbeat guard; Your Team CTA, entitlement notice, and connected-agent terminology; board icons and 32px action chips.\n\nTests: focused v2 suite (103), typecheck, production build. Mutation-verified the heartbeat guard, board chip minimum height, and icon-component invariant.\n\nUX 1440/390 AFTER-panel gate pending from ux-lead.