### PR TITLE
docs(adr-027): name ADR-025's Draft status where ADR-027 inherits from it

### DIFF
--- a/docs/adr/ADR-027-pm-tool-projection-contract.md
+++ b/docs/adr/ADR-027-pm-tool-projection-contract.md
@@ -18,7 +18,14 @@ architecture.
 status, assignees, provenance) project two-way between a Commonly pod and an
 external PM surface. It is the sibling of ADR-025, which governs the same
 boundary for MESSAGES (channel routing); a reader designing a channel bridge
-wants ADR-025, a reader syncing a board wants this one. It does not govern
+wants ADR-025, a reader syncing a board wants this one. **ADR-025 is itself
+`Draft / Proposed`** — its own status line reads D1–D7 as the substrate
+audit's proposals, and D8–D16 arrived through Sam's 2026-09-02 fold
+carrying that same status. So the ADR-025 decisions this document inherits
+(D6 for credentials behind a secret reference, D9 for transport-is-kernel,
+D10 for the relayMap routing table) are premises, not settled rulings:
+ratifying this ADR does not ratify them, and if D9 or D10 move, D2 and the
+attribution rule move with them. It does not govern
 the attention gate (ADR-017/018), and it uses — not changes — the Installable
 taxonomy (ADR-001) and the task board (`/api/v1/tasks`).
 


### PR DESCRIPTION
Docs-only, one paragraph, in place in the existing scope-boundary block. Closes the remaining half of #1424.

**The citation half of #1424 is already fixed and I verified it on `origin/main` before writing this.** Sam's fold ruling executed via #1295 (`702bc638`): `git ls-tree origin/main docs/adr/` returns exactly ONE `ADR-025` file, and all four ADR-027 citations resolve —

- `D3` → **`D10`** (relayMap is the routing table)
- `D2` → **`D9`** (transport is kernel; curation is agent), both sites
- `D6` — untouched, correctly. The fold left `D1`–`D7` fixed, which is what the `D8+` numbering was chosen for.

`ADR-025` now also carries an `### Alternatives rejected` section whose "Commander agent as transport: see D9" is the target of ADR-027's *"ADR-025 D9's rejection"*. So that citation resolves on the number **and** on the claim it asserts.

**What is left, and what this PR writes.** #1424's other half is the Draft inheritance. ADR-027 cites three ADR-025 decisions as premises; `ADR-025` is `**Status:** **Draft / Proposed — two halves, one number.**` and says in its own text that `D1`–`D7` are proposals. `D8`–`D16` arrived through the fold carrying the same status. A reader arriving at ADR-027 through those citations has no signal that any of it is unratified.

ADR-027's status line is already precise about *its own* unknowns — it enumerates three and says "Ratifying this ADR does not settle any of these", which is the ADR-028 pattern #1424 asked for. The gap is one level out: nothing states that a dependency is unratified. The scope-boundary block already names ADR-025 as the sibling, so the qualifier goes there rather than in a new section.

**Deliberately not done.** No citation is repointed — they are all correct. No decision text is touched. This adds a status qualifier and nothing else; if `ADR-025 D9` or `D10` are ratified or move, this paragraph is the one place that needs updating.

Diff: `+8 / -1`, 276 → 283 lines, header count unchanged at 6, tail verified intact. No open PR edits `ADR-027` (checked by path; the two open `ADR-025` PRs, #1478 and #1512, do not touch this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)