### PR TITLE
fix(activity): make the page match the ruled canvas, not just its tokens

### DIFF
--- a/backend/__tests__/unit/services/attentionItemService.test.js
+++ b/backend/__tests__/unit/services/attentionItemService.test.js
@@ -7,7 +7,8 @@ const mockUserFind = jest.fn();
 
 jest.mock('../../../models/AttentionItem', () => ({ updateOne: mockUpdateOne, updateMany: mockUpdateMany, find: mockFind }));
 jest.mock('../../../models/Pod', () => ({ findById: mockPodFindById, find: mockPodFind }));
-jest.mock('../../../models/User', () => ({ find: mockUserFind }));
+const mockUserFindById = jest.fn();
+jest.mock('../../../models/User', () => ({ find: mockUserFind, findById: mockUserFindById }));
 
 const chain = (value) => ({ select: () => ({ lean: async () => value }) });
 const AttentionItemService = require('../../../services/attentionItemService');
@@ -32,6 +33,18 @@ describe('attentionItemService', () => {
     expect(mockUpdateOne).toHaveBeenCalledTimes(1);
     expect(mockUpdateOne.mock.calls[0][0]).toEqual({ recipientUserId: 'sam', 'source.type': 'message', 'source.id': '42' });
     expect(mockUpdateOne.mock.calls[0][1].$setOnInsert).toMatchObject({ kind: 'mention', title: 'Ada mentioned you', messageId: '42' });
+  });
+
+  it('names the author from the User row when the message carries only user_id (PG rows)', async () => {
+    mockPodFindById.mockReturnValue(chain({ _id: 'pod-1', name: 'Ship room', createdBy: 'owner', members: [{ userId: 'sam' }] }));
+    mockUserFind.mockReturnValue(chain([
+      { _id: 'owner', username: 'owner', isBot: false },
+      { _id: 'sam', username: 'Sam', isBot: false },
+    ]));
+    mockUserFindById.mockReturnValue(chain({ _id: 'owner', username: 'ada', botMetadata: { displayName: 'Ada Lovelace' } }));
+    await AttentionItemService.recordMentionedUsers({ id: 43, pod_id: 'pod-1', user_id: 'owner', content: '@sam one more' });
+    expect(mockUserFindById).toHaveBeenCalledWith('owner');
+    expect(mockUpdateOne.mock.calls[0][1].$setOnInsert).toMatchObject({ title: 'Ada Lovelace mentioned you', actorName: 'Ada Lovelace' });
   });
 
   it('does not read pod membership for a message with no mention marker', async () => {

--- a/backend/models/AttentionItem.ts
+++ b/backend/models/AttentionItem.ts
@@ -11,6 +11,7 @@ export interface IAttentionItem extends Document {
   title: string;
   detail?: string;
   podName?: string;
+  actorName?: string;
   messageId?: string;
   threadRootId?: string;
   options?: Array<{ label: string; description?: string; recommended?: boolean }>;
@@ -37,6 +38,7 @@ const attentionItemSchema = new Schema<IAttentionItem>({
   title: { type: String, required: true },
   detail: { type: String },
   podName: { type: String },
+  actorName: { type: String },
   messageId: { type: String },
   threadRootId: { type: String },
   options: [optionSchema],

--- a/backend/services/attentionItemService.ts
+++ b/backend/services/attentionItemService.ts
@@ -50,6 +50,7 @@ const recordForRecipients = async (
         title: payload.title,
         detail: payload.detail,
         podName: payload.podName,
+        actorName: payload.actorName,
         messageId: payload.messageId,
         threadRootId: payload.threadRootId,
         options: payload.options,
@@ -58,6 +59,16 @@ const recordForRecipients = async (
     },
     { upsert: true },
   )));
+};
+
+const resolveAuthorName = async (authorId: unknown): Promise<string> => {
+  if (!authorId) return 'Someone';
+  try {
+    const author = await User.findById(authorId).select('username botMetadata').lean();
+    return author?.botMetadata?.displayName || author?.username || 'Someone';
+  } catch {
+    return 'Someone';
+  }
 };
 
 export const recordMentionedUsers = async (message: any, options: MentionOptions = {}): Promise<void> => {
@@ -80,10 +91,12 @@ export const recordMentionedUsers = async (message: any, options: MentionOptions
     });
     if (!recipients.length) return;
     const pod = await Pod.findById(podId).select('name').lean();
-    const authorName = message?.username || message?.userId?.username || 'Someone';
+    // PG rows arrive with user_id only, so 'Someone' was what every live
+    // mention showed. Resolve the author the way chat renders them.
+    const authorName = message?.username || message?.userId?.username || await resolveAuthorName(authorId);
     await recordForRecipients(recipients, {
       podId, kind: 'mention' as Kind, sourceType: 'message' as SourceType, sourceId: sourceKey('message', messageId),
-      title: `${authorName} mentioned you`, detail: compact(content), podName: pod?.name || 'Pod',
+      title: `${authorName} mentioned you`, actorName: authorName, detail: compact(content), podName: pod?.name || 'Pod',
       messageId: String(messageId), threadRootId: String(message?.threadRootId || message?.thread_root_id || messageId),
     });
   } catch (error) {
@@ -101,7 +114,7 @@ export const recordApproval = async (approval: any): Promise<void> => {
     const agentName = approval?.agentMetadata?.agentName;
     await recordForRecipients(recipients, {
       podId, kind: 'approval' as Kind, sourceType: 'approval' as SourceType, sourceId: sourceKey('approval', id),
-      title: agentName ? `${agentName} requests approval` : 'Approval requested', detail: compact(approval?.content, 180), podName: pod?.name || 'Pod',
+      title: agentName ? `${agentName} requests approval` : 'Approval requested', actorName: agentName || undefined, detail: compact(approval?.content, 180), podName: pod?.name || 'Pod',
     });
   } catch (error) {
     console.warn('[attention] approval materialization failed:', (error as Error).message);
@@ -213,7 +226,7 @@ export const getOpenQueue = async (recipientUserId: unknown): Promise<{ items: a
     if (row.kind === 'mention' && mentionCount >= 8) continue;
     if (row.kind === 'mention') mentionCount += 1;
     picked.push({
-      id: String(row.source.id), attentionItemId: String(row._id), kind: row.kind, title: row.title, detail: row.detail || '',
+      id: String(row.source.id), attentionItemId: String(row._id), kind: row.kind, title: row.title, actorName: row.actorName || undefined, detail: row.detail || '',
       podId: String(row.podId), podName: (allowed.get(String(row.podId)) as any)?.name || row.podName || 'Pod',
       messageId: row.messageId, threadRootId: row.threadRootId, options: row.options || [], createdAt: row.createdAt,
     });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -47,7 +47,9 @@
       "send": "Send",
       "sendAriaLabel": "Send message",
       "working": "Sending…",
-      "actionFailed": "Your message could not be sent. Try again."
+      "actionFailed": "Your message could not be sent. Try again.",
+      "label": "Tell your agents",
+      "hint": "Posts as you · ⌘↵ to send"
     },
     "reply": {
       "placeholder": "Reply in thread…",
@@ -69,7 +71,8 @@
         "approval": "Approval",
         "decision": "Decision needed",
         "press": "Ready for your press"
-      }
+      },
+      "countLabel": "{{count}} waiting on you"
     },
     "dayZero": {
       "kind": "Get started",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -47,7 +47,9 @@
       "send": "发送",
       "sendAriaLabel": "发送消息",
       "working": "发送中…",
-      "actionFailed": "无法发送消息，请重试。"
+      "actionFailed": "无法发送消息，请重试。",
+      "label": "告诉你的智能体",
+      "hint": "以你的身份发布 · ⌘↵ 发送"
     },
     "reply": {
       "placeholder": "在话题中回复…",
@@ -69,7 +71,8 @@
         "approval": "审批",
         "decision": "待你决策",
         "press": "待你合并"
-      }
+      },
+      "countLabel": "{{count}} 项等你处理"
     },
     "dayZero": {
       "kind": "开始使用",

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -28,6 +28,7 @@ interface AgentRecap {
 interface NeedsYouItem {
   id: string;
   attentionItemId?: string;
+  actorName?: string;
   kind: 'mention' | 'approval' | 'decision';
   title: string;
   detail: string;
@@ -334,11 +335,8 @@ const V2ActivityPage: React.FC = () => {
       {!loading && !error && recap && (
         <>
           <section className="v2-activity__compose" aria-labelledby="activity-compose-title">
-            <div className="v2-activity__compose-heading">
-              <div>
-                <div className="v2-activity__eyebrow">{t('activity.compose.eyebrow')}</div>
-                <h2 id="activity-compose-title">{t('activity.compose.title')}</h2>
-              </div>
+            <div className="v2-activity__compose-top">
+              <h2 id="activity-compose-title" className="v2-activity__compose-label">{t('activity.compose.label')}</h2>
               <label className="v2-activity__compose-pod">
                 <span>{t('activity.compose.podLabel')}</span>
                 <select value={composePodId} onChange={(event) => setComposePodId(event.target.value)}>
@@ -346,16 +344,17 @@ const V2ActivityPage: React.FC = () => {
                 </select>
               </label>
             </div>
-            <div className="v2-activity__compose-entry">
-              <textarea
-                aria-label={t('activity.compose.placeholder')}
-                rows={3}
-                placeholder={t('activity.compose.placeholder')}
-                value={composeDraft}
-                onChange={(event) => setComposeDraft(event.target.value)}
-                onKeyDown={(event) => { if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') sendCompose(); }}
-                disabled={composing || !composePodId}
-              />
+            <textarea
+              aria-label={t('activity.compose.placeholder')}
+              rows={2}
+              placeholder={t('activity.compose.placeholder')}
+              value={composeDraft}
+              onChange={(event) => setComposeDraft(event.target.value)}
+              onKeyDown={(event) => { if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') sendCompose(); }}
+              disabled={composing || !composePodId}
+            />
+            <div className="v2-activity__compose-foot">
+              <span className="v2-activity__compose-hint">{t('activity.compose.hint')}</span>
               <button type="button" aria-label={t('activity.compose.sendAriaLabel')} onClick={sendCompose} disabled={composing || !composePodId || !composeDraft.trim()}>
                 {composing ? t('activity.compose.working') : t('activity.compose.send')}
               </button>
@@ -366,10 +365,8 @@ const V2ActivityPage: React.FC = () => {
           <div className="v2-activity__sections">
           <section className="v2-activity__section" aria-labelledby="activity-needs-you">
             <div className="v2-activity__section-heading">
-              <div>
-                <div className="v2-activity__eyebrow">{t('activity.needsYou.eyebrow')}</div>
-                <h2 id="activity-needs-you">{t('activity.needsYou.title')}</h2>
-              </div>
+              <h2 id="activity-needs-you">{t('activity.needsYou.title')}</h2>
+              {!isDayZero && queue.length > 0 && <span className="v2-activity__count" aria-label={t('activity.needsYou.countLabel', { count: queue.length })}>{queue.length}</span>}
               <p>{t('activity.needsYou.description')}</p>
             </div>
             {isDayZero ? (
@@ -425,10 +422,12 @@ const V2ActivityPage: React.FC = () => {
                       {item.kind === 'mention' ? '@' : item.kind === 'approval' ? '!' : '?'}
                     </span>
                     <div className="v2-activity__queue-copy">
-                      <div className="v2-activity__queue-kind">{t(`activity.needsYou.kinds.${item.kind}`)}</div>
-                      <strong>{item.title}</strong>
+                      {item.kind !== 'mention' && <div className="v2-activity__queue-kind">{t(`activity.needsYou.kinds.${item.kind}`)}</div>}
+                      <div className="v2-activity__queue-topline">
+                        <strong>{item.kind === 'mention' && item.actorName ? item.actorName : item.title}</strong>
+                        <span>{item.podName}{item.timestamp ? ` · ${relativeTime(item.timestamp)}` : ''}</span>
+                      </div>
                       {item.detail && <p>{item.detail}</p>}
-                      <span>{item.podName}{item.timestamp ? ` · ${relativeTime(item.timestamp)}` : ''}</span>
                     </div>
                     <div className="v2-activity__queue-actions">
                       {item.kind === 'approval' && (
@@ -461,7 +460,7 @@ const V2ActivityPage: React.FC = () => {
                               {replyingId === item.id ? t('activity.reply.working') : repliedIds.has(item.id) ? t('activity.reply.sent') : t('activity.reply.send')}
                             </button>
                           </div>
-                          <button type="button" className="v2-activity__queue-action--secondary" onClick={() => acknowledgeMention(item)} disabled={acknowledgingMentionId === item.id}>
+                          <button type="button" className="v2-activity__queue-action--thread" onClick={() => acknowledgeMention(item)} disabled={acknowledgingMentionId === item.id}>
                             {acknowledgingMentionId === item.id ? t('activity.mention.working') : t('activity.mention.acknowledge')}
                           </button>
                         </>
@@ -535,10 +534,7 @@ const V2ActivityPage: React.FC = () => {
 
           <section className="v2-activity__section" aria-labelledby="activity-agents">
             <div className="v2-activity__section-heading">
-              <div>
-                <div className="v2-activity__eyebrow">{t('activity.agents.eyebrow')}</div>
-                <h2 id="activity-agents">{t('activity.agents.title')}</h2>
-              </div>
+              <h2 id="activity-agents">{t('activity.agents.title')}</h2>
               <p>{t('activity.agents.description')}</p>
             </div>
             {recap.agents.length === 0 ? (
@@ -576,10 +572,7 @@ const V2ActivityPage: React.FC = () => {
 
           <section className="v2-activity__section" aria-labelledby="activity-board">
             <div className="v2-activity__section-heading">
-              <div>
-                <div className="v2-activity__eyebrow">{t('activity.board.eyebrow')}</div>
-                <h2 id="activity-board">{t('activity.board.title')}</h2>
-              </div>
+              <h2 id="activity-board">{t('activity.board.title')}</h2>
               <p>{t('activity.board.description')}</p>
             </div>
             {recap.board.length === 0 ? (

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9183,9 +9183,10 @@ body.modern-ui.v2-canvas {
 
   .v2-activity__header,
   .v2-activity__section-heading {
-    align-items: stretch;
-    flex-direction: column;
-    gap: 12px;
+    align-items: baseline;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
   }
 
   .v2-activity__controls {
@@ -9197,7 +9198,9 @@ body.modern-ui.v2-canvas {
   .v2-root button.v2-activity__window-button { flex: 1 1 0; }
   .v2-activity__scope select { width: 100%; max-width: none; }
   .v2-activity__compose-top { align-items: flex-start; flex-direction: column; gap: 8px; }
-  .v2-activity__compose-pod select { max-width: 100%; }
+  .v2-activity__compose-pod { width: 100%; }
+  .v2-activity__compose-pod > span { white-space: nowrap; }
+  .v2-activity__compose-pod select { flex: 1 1 auto; min-width: 0; max-width: none; }
   .v2-root .v2-activity__compose button { min-height: 44px; padding: 0 18px; }
   .v2-activity__section-heading { flex-wrap: wrap; }
   .v2-activity__section-heading > p { flex-basis: 100%; }

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8586,78 +8586,86 @@ body.modern-ui.v2-canvas {
   margin-top: 30px;
 }
 
+/* Composer (Sam ruled 2026-09-03 on the Shell Parity canvas, board 3): one
+   card, radius-lg, the textarea borderless inside it, a small ink Send in the
+   foot row. Focus is the halo on the CARD, not a harder border. */
 .v2-activity__compose {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   margin-top: 22px;
-  padding: 16px;
+  padding: 12px 14px;
   border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius);
+  border-radius: var(--v2-radius-lg);
   background: var(--v2-surface);
+  transition: box-shadow 120ms ease;
 }
 
 .v2-activity__compose:focus-within {
-  border-color: var(--v2-border-strong);
+  box-shadow: 0 0 0 4px rgba(47, 111, 235, 0.10);
 }
 
-.v2-activity__compose-heading,
-.v2-activity__compose-entry,
-.v2-activity__compose-pod {
+.v2-activity__compose-top,
+.v2-activity__compose-foot {
   display: flex;
-  align-items: end;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
 }
 
-.v2-activity__compose-heading {
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: 12px;
-}
-
-.v2-activity__compose h2 {
-  font-size: 17px;
-  line-height: 1.25;
-  letter-spacing: -0.015em;
-}
-
-.v2-activity__compose-pod {
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+.v2-activity__compose h2.v2-activity__compose-label {
+  margin: 0;
   color: var(--v2-text-muted);
   font-size: var(--v2-fs-label);
   line-height: var(--v2-lh-label);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.v2-activity__compose-pod {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--v2-text-muted);
+  font-size: var(--v2-fs-meta);
+  line-height: var(--v2-lh-meta);
 }
 
 .v2-activity__compose-pod select {
-  min-height: 36px;
+  height: 26px;
   max-width: 220px;
-  padding: 0 28px 0 10px;
+  padding: 0 24px 0 8px;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius-sm);
-  background: var(--v2-surface);
+  background: var(--v2-surface-hover);
   color: var(--v2-text-primary);
   font: inherit;
+  font-size: var(--v2-fs-meta);
   font-weight: 500;
 }
 
 .v2-root .v2-activity__compose textarea {
-  flex: 1 1 auto;
+  width: 100%;
   min-width: 0;
-  resize: vertical;
-  padding: 10px 12px;
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius-sm);
-  background: var(--v2-surface);
+  resize: none;
+  padding: 2px 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
   color: var(--v2-text-primary);
   font: inherit;
+  font-size: var(--v2-fs-body);
+  line-height: var(--v2-lh-body);
 }
 
-/* Halo focus (TASK-122): the global `.v2-root textarea:focus-visible` rule
-   carries the box-shadow halo; this only gives it an edge. <select> is outside
-   that global list, so the pod picker carries its own halo. No hard outline. */
+/* Halo focus (TASK-122): the card carries the halo (focus-within above), so
+   the textarea itself shows nothing; <select> is outside the global
+   focus-visible list and carries its own ring. */
 .v2-root .v2-activity__compose textarea:focus-visible {
-  border-color: var(--v2-accent);
+  outline: none;
+  box-shadow: none;
+  border-color: transparent;
 }
 
 .v2-activity__compose-pod select:focus-visible {
@@ -8666,11 +8674,17 @@ body.modern-ui.v2-canvas {
   border-color: var(--v2-accent);
 }
 
+.v2-activity__compose-hint {
+  color: var(--v2-text-muted);
+  font-size: var(--v2-fs-meta);
+  line-height: var(--v2-lh-meta);
+}
+
 .v2-root .v2-activity__compose button {
-  min-height: 44px;
-  padding: 0 16px;
+  min-height: 30px;
+  padding: 0 14px;
   border: 1px solid var(--v2-ink);
-  border-radius: var(--v2-radius);
+  border-radius: var(--v2-radius-sm);
   background: var(--v2-ink);
   color: var(--v2-on-ink);
   font-size: 13px;
@@ -8684,15 +8698,30 @@ body.modern-ui.v2-canvas {
 
 .v2-activity__section-heading {
   display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 14px;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .v2-activity__section-heading > p {
-  max-width: 440px;
-  text-align: right;
+  margin: 0;
+  color: var(--v2-text-muted);
+  font-size: var(--v2-fs-meta);
+  line-height: var(--v2-lh-meta);
+}
+
+.v2-activity__count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-ink);
+  color: var(--v2-on-ink);
+  font-size: var(--v2-fs-label);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
 
 .v2-activity__eyebrow {
@@ -8705,9 +8734,11 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-activity__section h2 {
-  font-size: 19px;
-  line-height: 1.2;
-  letter-spacing: -0.02em;
+  margin: 0;
+  font-size: 15px;
+  line-height: 20px;
+  font-weight: 600;
+  letter-spacing: 0;
 }
 
 .v2-activity__board-list {
@@ -8760,7 +8791,8 @@ body.modern-ui.v2-canvas {
 .v2-activity__queue-row--decision,
 .v2-activity__queue-row--approval {
   background: var(--v2-surface);
-  border-color: var(--v2-border);
+  border-color: var(--v2-border-strong);
+  border-radius: var(--v2-radius-lg);
   box-shadow: var(--v2-shadow-pending);
 }
 
@@ -8785,11 +8817,15 @@ body.modern-ui.v2-canvas {
   width: 28px;
   height: 28px;
   place-items: center;
-  border-radius: 50%;
+  border-radius: var(--v2-radius-sm);
   background: var(--v2-accent-soft);
   color: var(--v2-accent-text);
-  font-size: 13px;
-  font-weight: 800;
+  font-size: 12px;
+  font-weight: 700;
+}
+.v2-activity__queue-row--decision .v2-activity__queue-mark {
+  background: var(--v2-ink);
+  color: var(--v2-on-ink);
 }
 
 .v2-activity__queue-row--approval .v2-activity__queue-mark {
@@ -8811,6 +8847,7 @@ body.modern-ui.v2-canvas {
 
 .v2-activity__queue-kind,
 .v2-activity__queue-copy > span,
+.v2-activity__queue-topline > span,
 .v2-activity__agent-topline span,
 .v2-activity__board-meta,
 .v2-activity__task-id,
@@ -8854,13 +8891,13 @@ body.modern-ui.v2-canvas {
 
 .v2-activity__queue-row button,
 .v2-activity__board-meta button {
-  min-height: 32px;
-  padding: 0 10px;
+  min-height: 30px;
+  padding: 0 12px;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius-sm);
   color: var(--v2-text-primary);
-  font-size: 12px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .v2-root .v2-activity__queue-actions button {
@@ -8908,6 +8945,36 @@ body.modern-ui.v2-canvas {
   grid-column: 1 / -1;
   justify-content: flex-start;
   flex-wrap: wrap;
+}
+
+/* Mention rows (canvas board 3): the reply line sits UNDER the message,
+   indented past the mark, never squeezed beside it. The mark already says
+   "@", so the kind label is redundant and hidden. */
+.v2-activity__queue-row--mention {
+  align-items: start;
+}
+.v2-activity__queue-topline {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.v2-activity__queue-topline strong {
+  margin-top: 0;
+  font-weight: 600;
+}
+.v2-activity__queue-row--mention .v2-activity__queue-copy p {
+  color: var(--v2-text-primary);
+}
+.v2-activity__queue-row--mention .v2-activity__queue-actions {
+  grid-column: 2 / -1;
+  align-items: center;
+  margin-top: 4px;
+}
+.v2-root .v2-activity__queue-actions button:disabled {
+  opacity: 0.7;
+  cursor: default;
 }
 
 .v2-root .v2-activity__queue-actions button.v2-activity__option {
@@ -9129,11 +9196,11 @@ body.modern-ui.v2-canvas {
   .v2-activity__window { width: 100%; }
   .v2-root button.v2-activity__window-button { flex: 1 1 0; }
   .v2-activity__scope select { width: 100%; max-width: none; }
-  .v2-activity__compose-heading,
-  .v2-activity__compose-entry { align-items: stretch; flex-direction: column; }
-  .v2-activity__compose-pod select { max-width: none; width: 100%; }
-  .v2-root .v2-activity__compose button { width: 100%; }
-  .v2-activity__section-heading > p { text-align: left; }
+  .v2-activity__compose-top { align-items: flex-start; flex-direction: column; gap: 8px; }
+  .v2-activity__compose-pod select { max-width: 100%; }
+  .v2-root .v2-activity__compose button { min-height: 44px; padding: 0 18px; }
+  .v2-activity__section-heading { flex-wrap: wrap; }
+  .v2-activity__section-heading > p { flex-basis: 100%; }
   .v2-activity__agent-grid { grid-template-columns: minmax(0, 1fr); }
 
   .v2-activity__queue-row { grid-template-columns: 28px minmax(0, 1fr); }
@@ -9194,7 +9261,7 @@ body.modern-ui.v2-canvas {
 .v2-root:lang(zh) .v2-feature__legacy .MuiTypography-h6,
 .v2-root:lang(zh) .v2-team__title,
 .v2-root:lang(zh) .v2-activity__title,
-.v2-root:lang(zh) .v2-activity__compose h2,
+.v2-root:lang(zh) .v2-activity__compose-label,
 .v2-root:lang(zh) .v2-activity__section h2,
 .v2-root:lang(zh) .v2-activity__agent-card h3,
 .v2-root:lang(zh) .v2-activity__board-row h3,
@@ -9483,23 +9550,32 @@ body.modern-ui.v2-canvas {
    full width of the row so the thumb has something to hit. */
 .v2-activity__reply {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: 6px;
   flex: 1 1 260px;
   min-width: 0;
 }
+.v2-root .v2-activity__reply button {
+  flex: 0 0 auto;
+  min-width: max-content;
+  min-height: 32px;
+  padding: 0 12px;
+  white-space: nowrap;
+}
 .v2-root textarea.v2-activity__reply-input {
   flex: 1 1 auto;
   min-width: 0;
-  resize: vertical;
-  padding: 8px 10px;
-  font: inherit;
-  font-size: var(--v2-fs-body);
-  line-height: var(--v2-lh-body);
-  color: var(--v2-text-primary);
-  background: var(--v2-surface);
+  height: 32px;
+  min-height: 32px;
+  padding: 6px 10px;
+  resize: none;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: inherit;
+  font-size: 13px;
+  line-height: 18px;
 }
 .v2-root textarea.v2-activity__reply-input:focus-visible {
   border-color: var(--v2-accent); /* the global halo carries the ring; no hard outline */


### PR DESCRIPTION
## Why
Phase A (#1518) painted the new tokens over the old layout. Live, the page kept the big composer heading, a bordered textarea with a 44px ink block beside it, 19px section headings with eyebrows, circle marks, and the reply box squeezed into the right column. Sam, on seeing it: not close to the preview, and the dark button does not align with the style. He is right — the canvas after-side is a structure, not a palette.

## What
The after-side of the Shell Parity canvas (board 3, the ruling surface) as structure:
- **Composer**: one radius-lg card — uppercase 11px label + pod chip on top, borderless textarea, foot row with the hint and a 30px ink Send. Focus is the halo on the card.
- **Section headings**: 15/20 weight 600, ink count badge, description as muted meta on the same line. Eyebrows gone.
- **Rows**: name + meta on the top line, body in ink, the reply line **under** the message (32px input, ink Send, quiet Acknowledge / Open thread). Square marks. Pending decision/approval cards radius-lg with the strong ring.
- **Producer**: `AttentionItem.actorName`, resolved from the User row when a PG message carries only `user_id` — every live mention read *Someone mentioned you*. The row is now headed by who said it.

## Proof
- Frontend: `V2ActivityPage`, `v2-layout-invariants`, `translationKeys` — 86/86; `tsc --noEmit` clean.
- Backend: `attentionItemService` 9/9 including the new author-lookup case.
- Real-browser render at 1440 against the production API through a local proxy, compared to the canvas: composer, headings and rows match; Sam has the screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHfcrzjN6MpeuCCAap5Qnb