### PR TITLE
fix(agents): agent-room installs inherit the agent's runtime — hosted DMs went silent

### DIFF
--- a/backend/__tests__/unit/services/dmService.agentRoomRuntime.test.js
+++ b/backend/__tests__/unit/services/dmService.agentRoomRuntime.test.js
@@ -1,0 +1,39 @@
+// An agent-room is a projection of an agent that already has an install
+// somewhere. Its install must carry that agent's runtime, or the event router
+// finds the pod-scoped row, sees no runtimeType, and parks every wake in the
+// external queue where nothing consumes it — which is how every hosted Scout
+// DM went silent between 2026-08-28 and 2026-09-02.
+const mockFindOne = jest.fn();
+
+jest.mock('../../../models/AgentRegistry', () => ({
+  AgentInstallation: { findOne: mockFindOne, install: jest.fn() },
+  AgentRegistry: { findOne: jest.fn() },
+}));
+
+const chain = (value) => ({ sort: () => ({ lean: async () => value }) });
+
+describe('dmService.resolveInstallRuntime', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('copies the runtime block from the agent\'s active install (plain object config)', async () => {
+    mockFindOne.mockReturnValue(chain({ config: { runtime: { runtimeType: 'native' }, heartbeat: { enabled: true } } }));
+    const { resolveInstallRuntime } = require('../../../services/dmService');
+    await expect(resolveInstallRuntime('scout', 'u20f7e33728')).resolves.toEqual({ runtimeType: 'native' });
+    expect(mockFindOne).toHaveBeenCalledWith({
+      agentName: 'scout', instanceId: 'u20f7e33728', status: 'active', 'config.runtime.runtimeType': { $exists: true },
+    });
+  });
+
+  it('reads a Mongoose Map config the way the router does', async () => {
+    const config = new Map([['runtime', { runtimeType: 'native', host: 'cloud' }]]);
+    mockFindOne.mockReturnValue(chain({ config }));
+    const { resolveInstallRuntime } = require('../../../services/dmService');
+    await expect(resolveInstallRuntime('scout', 'abc')).resolves.toEqual({ runtimeType: 'native', host: 'cloud' });
+  });
+
+  it('returns null when the agent has no install with a runtime, keeping the external queue', async () => {
+    mockFindOne.mockReturnValue(chain(null));
+    const { resolveInstallRuntime } = require('../../../services/dmService');
+    await expect(resolveInstallRuntime('byo-agent', 'default')).resolves.toBeNull();
+  });
+});

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -1049,7 +1049,23 @@ class AgentEventService {
         status: 'active',
       }).lean() as InstallationDoc | null;
       if (installationDoc) {
-        const installationRuntimeCfg = (normalizeConfig(installationDoc.config)?.runtime || {}) as Record<string, unknown>;
+        let installationRuntimeCfg = (normalizeConfig(installationDoc.config)?.runtime || {}) as Record<string, unknown>;
+        if (!installationRuntimeCfg.runtimeType) {
+          // A projection written without its runtime (agent-room installs
+          // before 2026-09-03 did this) must still route like the agent it
+          // projects, or the wake parks in the external queue forever.
+          const sibling = await AgentInstallation.findOne({
+            agentName: agentName.toLowerCase(),
+            instanceId,
+            status: 'active',
+            'config.runtime.runtimeType': { $exists: true },
+          }).sort({ createdAt: -1 }).lean() as InstallationDoc | null;
+          const siblingRuntime = (sibling && normalizeConfig(sibling.config)?.runtime) as Record<string, unknown> | undefined;
+          if (siblingRuntime?.runtimeType) {
+            installationRuntimeCfg = siblingRuntime;
+            installationDoc.config = { ...(normalizeConfig(installationDoc.config) || {}), runtime: siblingRuntime } as InstallationDoc['config'];
+          }
+        }
         const installationRuntimeType = String(installationRuntimeCfg.runtimeType || '').toLowerCase();
         if (installationRuntimeType === 'native') {
           routedToNative = true;

--- a/backend/services/dmService.ts
+++ b/backend/services/dmService.ts
@@ -2,6 +2,28 @@ import Pod from '../models/Pod';
 import User from '../models/User';
 import { AgentInstallation } from '../models/AgentRegistry';
 
+/**
+ * The runtime block of an agent's existing active installation, so a new
+ * projection (agent-room, DM) routes the same way the original does.
+ * Returns null when the agent has no install with a runtime (BYO wrappers
+ * that never declared one), which keeps today's external-queue behaviour.
+ */
+export const resolveInstallRuntime = async (
+  agentName: string,
+  instanceId: string,
+): Promise<Record<string, unknown> | null> => {
+  try {
+    const sibling = await AgentInstallation.findOne({
+      agentName, instanceId, status: 'active', 'config.runtime.runtimeType': { $exists: true },
+    }).sort({ createdAt: -1 }).lean() as { config?: unknown } | null;
+    const cfg = sibling?.config as { runtime?: Record<string, unknown>; get?: (k: string) => unknown } | undefined;
+    const runtime = (cfg && typeof cfg.get === 'function' ? cfg.get('runtime') : cfg?.runtime) as Record<string, unknown> | undefined;
+    return runtime && typeof runtime === 'object' ? { ...runtime } : null;
+  } catch {
+    return null;
+  }
+};
+
 let PGPod: { addMember: (podId: string, userId: unknown) => Promise<void>; create: (name: string, description: string, type: string, creatorId: unknown, podId: string) => Promise<void> } | null;
 try {
   // eslint-disable-next-line global-require
@@ -365,11 +387,19 @@ class DMService {
     // (they fire on user message, not on a schedule).
     if (agentName) {
       try {
+        // The room install must carry the agent's RUNTIME, or the event
+        // router finds this pod-scoped row, sees no runtimeType, and parks
+        // the wake in the external queue where nothing consumes it. Every
+        // hosted Scout DM went silent this way (2026-08-28 .. 09-02: two
+        // strangers, one smoke). Copy runtime from the agent's existing
+        // active install; the room is a projection of the same agent.
+        const runtime = await resolveInstallRuntime(agentName.toLowerCase(), instanceId || 'default');
         await AgentInstallation.install(agentName.toLowerCase(), roomPod._id, {
           version: '1.0.0',
           config: {
             heartbeat: { enabled: false },
             autoJoinSource: 'agent-room-create',
+            ...(runtime ? { runtime } : {}),
           } as unknown as Map<string, unknown>,
           scopes: ['context:read', 'summaries:read', 'messages:write'],
           installedBy: requestingUserId as unknown as import('mongoose').Types.ObjectId,


### PR DESCRIPTION
## Why
Two real strangers (2026-08-28, 09-01) and our smoke account (09-02, four messages) typed to Scout and got nothing. Silence detector: `enqueued-never-answered`, no alert recipient configured. Cause measured in production: the hire writes a native-runtime install on the workspace pod; opening the DM writes a second install on the agent-room pod with `heartbeat + autoJoinSource` only — **no `config.runtime`**. `agentEventService` resolves the install by pod, finds the copy, sees no `runtimeType`, and parks the wake in the external queue. Nothing consumes it.

## What
- `dmService`: the agent-room install copies `config.runtime` from the agent's existing active install (`resolveInstallRuntime`). Agents with no declared runtime keep today's behaviour.
- `agentEventService`: if the pod-scoped install has no `runtimeType`, route by the agent's sibling install that has one. Existing broken rows answer after deploy, no backfill.

## Proof
`dmService.agentRoomRuntime.test.js`: plain config, Mongoose Map config, no sibling → 3/3. Backend `tsc` clean. Live proof after deploy: a fresh account DMs Scout and gets a reply within a minute — I run that smoke and post it here.

## Follow-up (not in this PR)
`SILENCE_ALERT_*` recipient is unset in production, so the detector has been finding these and telling nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHfcrzjN6MpeuCCAap5Qnb