### PR TITLE
fix(agents): room installs inherit the whole native config; default model is the paid one

### DIFF
--- a/backend/__tests__/unit/services/dmService.agentRoomRuntime.test.js
+++ b/backend/__tests__/unit/services/dmService.agentRoomRuntime.test.js
@@ -12,28 +12,29 @@ jest.mock('../../../models/AgentRegistry', () => ({
 
 const chain = (value) => ({ sort: () => ({ lean: async () => value }) });
 
-describe('dmService.resolveInstallRuntime', () => {
+describe('dmService.resolveInstallInheritance', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('copies the runtime block from the agent\'s active install (plain object config)', async () => {
-    mockFindOne.mockReturnValue(chain({ config: { runtime: { runtimeType: 'native' }, heartbeat: { enabled: true } } }));
-    const { resolveInstallRuntime } = require('../../../services/dmService');
-    await expect(resolveInstallRuntime('scout', 'u20f7e33728')).resolves.toEqual({ runtimeType: 'native' });
+  it('copies everything the native runtime reads from the agent\'s active install, minus the projection\'s own keys', async () => {
+    mockFindOne.mockReturnValue(chain({ config: { runtime: { runtimeType: 'native' }, model: 'deepseek-v4-flash', systemPrompt: 'You are Scout.', heartbeat: { enabled: true }, autoJoinSource: 'signup' } }));
+    const { resolveInstallInheritance } = require('../../../services/dmService');
+    await expect(resolveInstallInheritance('scout', 'u20f7e33728')).resolves.toEqual({ runtime: { runtimeType: 'native' }, model: 'deepseek-v4-flash', systemPrompt: 'You are Scout.' });
     expect(mockFindOne).toHaveBeenCalledWith({
       agentName: 'scout', instanceId: 'u20f7e33728', status: 'active', 'config.runtime.runtimeType': { $exists: true },
     });
   });
 
   it('reads a Mongoose Map config the way the router does', async () => {
-    const config = new Map([['runtime', { runtimeType: 'native', host: 'cloud' }]]);
+    const config = new Map([['runtime', { runtimeType: 'native', host: 'cloud' }], ['model', 'deepseek-v4-flash'], ['heartbeat', { enabled: false }]]);
     mockFindOne.mockReturnValue(chain({ config }));
-    const { resolveInstallRuntime } = require('../../../services/dmService');
+    const { resolveInstallInheritance, resolveInstallRuntime } = require('../../../services/dmService');
+    await expect(resolveInstallInheritance('scout', 'abc')).resolves.toEqual({ runtime: { runtimeType: 'native', host: 'cloud' }, model: 'deepseek-v4-flash' });
     await expect(resolveInstallRuntime('scout', 'abc')).resolves.toEqual({ runtimeType: 'native', host: 'cloud' });
   });
 
   it('returns null when the agent has no install with a runtime, keeping the external queue', async () => {
     mockFindOne.mockReturnValue(chain(null));
-    const { resolveInstallRuntime } = require('../../../services/dmService');
-    await expect(resolveInstallRuntime('byo-agent', 'default')).resolves.toBeNull();
+    const { resolveInstallInheritance } = require('../../../services/dmService');
+    await expect(resolveInstallInheritance('byo-agent', 'default')).resolves.toBeNull();
   });
 });

--- a/backend/services/agentEventService.ts
+++ b/backend/services/agentEventService.ts
@@ -1060,10 +1060,18 @@ class AgentEventService {
             status: 'active',
             'config.runtime.runtimeType': { $exists: true },
           }).sort({ createdAt: -1 }).lean() as InstallationDoc | null;
-          const siblingRuntime = (sibling && normalizeConfig(sibling.config)?.runtime) as Record<string, unknown> | undefined;
+          const siblingCfg = (sibling && normalizeConfig(sibling.config)) || null;
+          const siblingRuntime = siblingCfg?.runtime as Record<string, unknown> | undefined;
           if (siblingRuntime?.runtimeType) {
+            // Inherit everything the native runtime reads (runtime, model,
+            // systemPrompt, tools, budgets), keeping the projection's own keys
+            // on top. A room install written before #1524/#1527 has only
+            // {heartbeat, autoJoinSource}; runtime alone made it route, but
+            // the run then fell to the default model with no system prompt.
+            const own = normalizeConfig(installationDoc.config) || {};
+            const { heartbeat: _h, autoJoinSource: _a, ...inheritable } = siblingCfg as Record<string, unknown>;
             installationRuntimeCfg = siblingRuntime;
-            installationDoc.config = { ...(normalizeConfig(installationDoc.config) || {}), runtime: siblingRuntime } as InstallationDoc['config'];
+            installationDoc.config = { ...inheritable, ...own, runtime: siblingRuntime } as InstallationDoc['config'];
           }
         }
         const installationRuntimeType = String(installationRuntimeCfg.runtimeType || '').toLowerCase();

--- a/backend/services/dmService.ts
+++ b/backend/services/dmService.ts
@@ -3,12 +3,17 @@ import User from '../models/User';
 import { AgentInstallation } from '../models/AgentRegistry';
 
 /**
- * The runtime block of an agent's existing active installation, so a new
- * projection (agent-room, DM) routes the same way the original does.
- * Returns null when the agent has no install with a runtime (BYO wrappers
- * that never declared one), which keeps today's external-queue behaviour.
+ * What a new projection of an agent (agent-room, DM) inherits from the
+ * agent's existing active installation: everything the native runtime reads
+ * — runtime, model, systemPrompt, tools, triggers, budgets — minus the keys
+ * that belong to the projection itself (heartbeat, autoJoinSource). Without
+ * this a room install carried only {heartbeat, autoJoinSource}: the router
+ * could not see a runtime (fixed in #1524), and once it could, the run fell
+ * to the default model with no system prompt. Returns null when the agent has
+ * no install with a runtime (BYO wrappers), which keeps today's behaviour.
  */
-export const resolveInstallRuntime = async (
+const PROJECTION_OWN_KEYS = new Set(['heartbeat', 'autoJoinSource']);
+export const resolveInstallInheritance = async (
   agentName: string,
   instanceId: string,
 ): Promise<Record<string, unknown> | null> => {
@@ -16,12 +21,23 @@ export const resolveInstallRuntime = async (
     const sibling = await AgentInstallation.findOne({
       agentName, instanceId, status: 'active', 'config.runtime.runtimeType': { $exists: true },
     }).sort({ createdAt: -1 }).lean() as { config?: unknown } | null;
-    const cfg = sibling?.config as { runtime?: Record<string, unknown>; get?: (k: string) => unknown } | undefined;
-    const runtime = (cfg && typeof cfg.get === 'function' ? cfg.get('runtime') : cfg?.runtime) as Record<string, unknown> | undefined;
-    return runtime && typeof runtime === 'object' ? { ...runtime } : null;
+    const raw = sibling?.config as { toObject?: () => Record<string, unknown> } | Record<string, unknown> | Map<string, unknown> | undefined;
+    if (!raw) return null;
+    let cfg: Record<string, unknown>;
+    if (raw instanceof Map) cfg = Object.fromEntries(raw);
+    else if (typeof (raw as { toObject?: unknown }).toObject === 'function') cfg = (raw as { toObject: () => Record<string, unknown> }).toObject();
+    else cfg = { ...(raw as Record<string, unknown>) };
+    const inherited: Record<string, unknown> = {};
+    Object.entries(cfg).forEach(([k, v]) => { if (!PROJECTION_OWN_KEYS.has(k) && v !== undefined) inherited[k] = v; });
+    return inherited.runtime ? inherited : null;
   } catch {
     return null;
   }
+};
+/** Back-compat alias for callers that only need the runtime block. */
+export const resolveInstallRuntime = async (agentName: string, instanceId: string): Promise<Record<string, unknown> | null> => {
+  const inherited = await resolveInstallInheritance(agentName, instanceId);
+  return (inherited?.runtime as Record<string, unknown>) || null;
 };
 
 let PGPod: { addMember: (podId: string, userId: unknown) => Promise<void>; create: (name: string, description: string, type: string, creatorId: unknown, podId: string) => Promise<void> } | null;
@@ -393,13 +409,13 @@ class DMService {
         // hosted Scout DM went silent this way (2026-08-28 .. 09-02: two
         // strangers, one smoke). Copy runtime from the agent's existing
         // active install; the room is a projection of the same agent.
-        const runtime = await resolveInstallRuntime(agentName.toLowerCase(), instanceId || 'default');
+        const inherited = await resolveInstallInheritance(agentName.toLowerCase(), instanceId || 'default');
         await AgentInstallation.install(agentName.toLowerCase(), roomPod._id, {
           version: '1.0.0',
           config: {
+            ...(inherited || {}),
             heartbeat: { enabled: false },
             autoJoinSource: 'agent-room-create',
-            ...(runtime ? { runtime } : {}),
           } as unknown as Map<string, unknown>,
           scopes: ['context:read', 'summaries:read', 'messages:write'],
           installedBy: requestingUserId as unknown as import('mongoose').Types.ObjectId,

--- a/backend/services/nativeRuntimeService.ts
+++ b/backend/services/nativeRuntimeService.ts
@@ -60,7 +60,12 @@ const MAX_WALL_CLOCK_MS = 60_000;
 // override (`installation.config.model`) for dev agents that legitimately
 // need paid Codex — but the platform-wide default never burns Codex quota
 // just because someone forgot to set the field.
-const DEFAULT_MODEL = 'openrouter/nvidia/nemotron-3-super-120b-a12b:free';
+// The default when an installation names no model. It used to be the free
+// OpenRouter tier; that key expired on 2026-09-03 and every hosted run with
+// no model fell into a 401 with no fallback group. Follow the chat model the
+// deployment already pays for, so "no model configured" means "the normal
+// model", never "the dead one".
+const DEFAULT_MODEL = process.env.LITELLM_CHAT_MODEL || 'deepseek-v4-flash';
 const LITELLM_TIMEOUT_MS = Number(process.env.NATIVE_RUNTIME_TIMEOUT_MS) || 45_000;
 
 // Guardrail opt-in for the native cloud-agent inference path. Unlike dev agents


### PR DESCRIPTION
## Why
Live proof after #1524 deployed: the smoke account's DM to its hosted Scout now routes native and is acked — and the run **fails in under a second**. AgentRun: `errorKind: llm_error`, LiteLLM 401, OpenRouter *API key expired*, model group `openrouter/nvidia/nemotron-3-super`, no fallback group. Cause: the room install carries only `{heartbeat, autoJoinSource}` while the workspace install carries `runtime, model (deepseek-v4-flash), systemPrompt, tools, triggers, maxTurns, maxTokens, wakeOnMessage, dailyRunCap`. #1524 inherited the runtime, so it routes; the run then fell to `DEFAULT_MODEL`, a free OpenRouter tier whose key is dead, with no system prompt.

## What
- `dmService.resolveInstallInheritance`: the room install is written with everything the native runtime reads from the agent's active install, minus the projection's own keys. `resolveInstallRuntime` stays as an alias.
- `agentEventService`: the routing fallback merges the whole sibling config under the projection's own keys — rows written before this answer without a backfill.
- `nativeRuntimeService.DEFAULT_MODEL` → `LITELLM_CHAT_MODEL || 'deepseek-v4-flash'`.

## Proof
`dmService.agentRoomRuntime` 3/3 (object config, Map config, no sibling); backend `tsc` clean. Live proof after deploy: the same smoke, expecting a reply — posted here.

## Ops note (not this PR)
The OpenRouter key is expired. Anything still pointed at the free tier is dead until it is rotated or retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHfcrzjN6MpeuCCAap5Qnb