### PR TITLE
feat(slack): add installable connector page flow

### DIFF
--- a/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
@@ -81,7 +81,12 @@ const renderPage = () => render(
 );
 
 describe('V2ConnectorsPage', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(window, 'open').mockReturnValue(null);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
 
   it('lists connectors with grouped code, copy command, and dot status', async () => {
     mockGets();
@@ -352,6 +357,29 @@ describe('V2ConnectorsPage', () => {
       expect.objectContaining({ withCredentials: true }),
     ));
     expect(await screen.findByText('Could not begin Slack authorization. Try again in a moment.')).toBeInTheDocument();
+  });
+
+  it('opens Slack in a separate tab so the pending confirmation stays on this page', async () => {
+    const slackWindow = {
+      location: { assign: jest.fn() },
+      close: jest.fn(),
+      opener: window,
+    };
+    jest.mocked(window.open).mockReturnValue(slackWindow as unknown as Window);
+    mockGets([{
+      _id: 'i-slack-authorize',
+      installationId: 'install-slack-u1',
+      type: 'slack',
+      status: 'pending',
+      config: { connectCode: 'a'.repeat(32), connectCodeExpiresAt: new Date(Date.now() + 60_000).toISOString() },
+      podId: { _id: 'p1', name: 'Rewire Live Demo' },
+    }]);
+    axios.post.mockResolvedValue({ data: { authorizeUrl: 'https://slack.test/oauth?state=secret' } });
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: 'Authorize in Slack' }));
+
+    await waitFor(() => expect(slackWindow.location.assign).toHaveBeenCalledWith('https://slack.test/oauth?state=secret'));
+    expect(slackWindow.opener).toBeNull();
   });
 
   it('lets the owner reject a pending Slack authorization', async () => {

--- a/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
@@ -84,6 +84,7 @@ describe('V2ConnectorsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(window, 'open').mockReturnValue(null);
+    window.history.replaceState({}, '', '/v2/connectors');
   });
 
   afterEach(() => jest.restoreAllMocks());
@@ -397,6 +398,50 @@ describe('V2ConnectorsPage', () => {
     await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
       '/api/installables/slack/reject',
       {},
+      expect.anything(),
+    ));
+  });
+
+  it('shows a generic Slack callback failure and clears its opaque query code', async () => {
+    window.history.replaceState({}, '', '/v2/connectors?slack=error&code=invalid_state');
+    mockGets([]);
+
+    renderPage();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Slack authorization didn’t complete — try again.');
+    expect(window.location.search).toBe('');
+  });
+
+  it('reloads connectors after a successful Slack callback and clears its query', async () => {
+    window.history.replaceState({}, '', '/v2/connectors?slack=pending');
+    mockGets([]);
+
+    renderPage();
+
+    await waitFor(() => expect(
+      axios.get.mock.calls.filter(([url]) => url === '/api/integrations/user/all').length,
+    ).toBeGreaterThanOrEqual(2));
+    expect(window.location.search).toBe('');
+  });
+
+  it('keeps an error-gated Slack row manageable so the user can disconnect and reconnect', async () => {
+    mockGets([{
+      _id: 'i-slack-error',
+      installationId: 'install-slack-u1',
+      type: 'slack',
+      status: 'error',
+      config: { teamName: 'Commonly HQ', chatId: 'D1', chatType: 'im' },
+      podId: { _id: 'p1', name: 'Rewire Live Demo' },
+    }]);
+    axios.delete.mockResolvedValue({ data: { status: 'uninstalled' } });
+    renderPage();
+
+    expect(await screen.findByText('Connection error — reconnect')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Manage' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+    fireEvent.click(screen.getByRole('button', { name: /Really disconnect/ }));
+    await waitFor(() => expect(axios.delete).toHaveBeenCalledWith(
+      '/api/installables/slack/install',
       expect.anything(),
     ));
   });

--- a/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
@@ -168,6 +168,20 @@ describe('V2ConnectorsPage', () => {
     ));
   });
 
+  it('installs Slack for the selected pod through the lifecycle verb', async () => {
+    mockGets([]);
+    axios.post.mockResolvedValue({ data: { integration: { _id: 'slack-new' } } });
+    renderPage();
+    await screen.findByText(/Link a channel/);
+    fireEvent.click(screen.getByRole('button', { name: /Slack/ }));
+    fireEvent.click(screen.getByText('New Slack connector'));
+    await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
+      '/api/installables/slack/install',
+      { podId: 'p1' },
+      expect.anything(),
+    ));
+  });
+
   it('keeps the add form open while an install claim is in progress', async () => {
     mockGets([]);
     axios.post.mockResolvedValue({ data: { status: 'installing' } });
@@ -245,6 +259,26 @@ describe('V2ConnectorsPage', () => {
     ));
   });
 
+  it('disconnects an installable Slack connector through Slack\'s lifecycle verb', async () => {
+    mockGets([{
+      _id: 'i-slack',
+      installationId: 'install-slack-u1',
+      type: 'slack',
+      status: 'connected',
+      config: { chatTitle: 'Commonly DM', liveRelay: true },
+      podId: { _id: 'p1', name: 'Rewire Live Demo' },
+    }]);
+    axios.delete.mockResolvedValue({ data: { status: 'uninstalled' } });
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: 'Manage' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+    fireEvent.click(screen.getByRole('button', { name: /Really disconnect/ }));
+    await waitFor(() => expect(axios.delete).toHaveBeenCalledWith(
+      '/api/installables/slack/install',
+      expect.anything(),
+    ));
+  });
+
   it('derives the installable lifecycle target from the connector row type', () => {
     expect(installableLifecyclePath('slack')).toBe('/api/installables/slack/install');
   });
@@ -274,7 +308,68 @@ describe('V2ConnectorsPage', () => {
     mockGets([]);
     renderPage();
     await screen.findByText(/Link a channel/);
-    expect(screen.queryByRole('button', { name: /Slack/ })).toBeNull();
+    expect(screen.getByRole('button', { name: /Slack/ })).toBeInTheDocument();
     expect(screen.getAllByText('SOON').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows owner confirmation controls for a pending Slack authorization', async () => {
+    mockGets([{
+      _id: 'i-slack-pending',
+      installationId: 'install-slack-u1',
+      type: 'slack',
+      status: 'pending',
+      config: {
+        pendingBind: { teamName: 'Commonly HQ', slackUserName: 'sam', expiresAt: new Date(Date.now() + 60_000).toISOString() },
+      },
+      podId: { _id: 'p1', name: 'Rewire Live Demo' },
+    }]);
+    axios.post.mockResolvedValue({ data: { status: 'connected' } });
+    renderPage();
+    expect(await screen.findByText('Commonly HQ wants to connect as @sam.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm connection' }));
+    await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
+      '/api/installables/slack/confirm',
+      {},
+      expect.anything(),
+    ));
+  });
+
+  it('requests the server-built Slack authorization URL from the pending card', async () => {
+    mockGets([{
+      _id: 'i-slack-authorize',
+      installationId: 'install-slack-u1',
+      type: 'slack',
+      status: 'pending',
+      config: { connectCode: 'a'.repeat(32), connectCodeExpiresAt: new Date(Date.now() + 60_000).toISOString() },
+      podId: { _id: 'p1', name: 'Rewire Live Demo' },
+    }]);
+    axios.post.mockRejectedValue({ response: { status: 503 } });
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: 'Authorize in Slack' }));
+    await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
+      '/api/installables/slack/authorize-url',
+      {},
+      expect.anything(),
+    ));
+    expect(await screen.findByText('Could not begin Slack authorization. Try again in a moment.')).toBeInTheDocument();
+  });
+
+  it('lets the owner reject a pending Slack authorization', async () => {
+    mockGets([{
+      _id: 'i-slack-pending',
+      installationId: 'install-slack-u1',
+      type: 'slack',
+      status: 'pending',
+      config: { pendingBind: { teamName: 'Commonly HQ', slackUserName: 'sam' } },
+      podId: { _id: 'p1', name: 'Rewire Live Demo' },
+    }]);
+    axios.post.mockResolvedValue({ data: { status: 'rejected' } });
+    renderPage();
+    fireEvent.click(await screen.findByRole('button', { name: 'This is not me' }));
+    await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
+      '/api/installables/slack/reject',
+      {},
+      expect.anything(),
+    ));
   });
 });

--- a/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ConnectorsPage.test.tsx
@@ -349,7 +349,7 @@ describe('V2ConnectorsPage', () => {
     await waitFor(() => expect(axios.post).toHaveBeenCalledWith(
       '/api/installables/slack/authorize-url',
       {},
-      expect.anything(),
+      expect.objectContaining({ withCredentials: true }),
     ));
     expect(await screen.findByText('Could not begin Slack authorization. Try again in a moment.')).toBeInTheDocument();
   });

--- a/frontend/src/v2/components/V2ConnectorsPage.tsx
+++ b/frontend/src/v2/components/V2ConnectorsPage.tsx
@@ -20,6 +20,13 @@ interface ConnectorConfig {
   connectCodeExpiresAt?: string;
   liveRelay?: boolean;
   relayAllAgentMessages?: boolean;
+  teamName?: string;
+  slackUserName?: string;
+  pendingBind?: {
+    teamName?: string;
+    slackUserName?: string;
+    expiresAt?: string;
+  };
 }
 
 interface Connector {
@@ -44,6 +51,10 @@ interface InstallErrorResponse {
   boundPodId?: string;
 }
 
+interface SlackAuthorizeResponse {
+  authorizeUrl?: string;
+}
+
 const TYPE_LABELS: Record<string, string> = {
   telegram: 'Telegram',
   discord: 'Discord',
@@ -55,11 +66,11 @@ const TYPE_LABELS: Record<string, string> = {
   instagram: 'Instagram',
 };
 
-// Spec §2.3 — only Telegram is self-serve today; the rest render as SOON
-// tiles (45% opacity, not buttons — no dead clicks).
+// Telegram and Slack are self-serve. The remaining provider tiles stay
+// present as honest, non-interactive previews rather than dead buttons.
 const ADD_PLATFORMS: { type: string; enabled: boolean }[] = [
   { type: 'telegram', enabled: true },
-  { type: 'slack', enabled: false },
+  { type: 'slack', enabled: true },
   { type: 'discord', enabled: false },
   { type: 'whatsapp', enabled: false },
 ];
@@ -111,7 +122,7 @@ const V2ConnectorsPage: React.FC = () => {
   const [connectors, setConnectors] = useState<Connector[]>([]);
   const [pods, setPods] = useState<V2Pod[]>([]);
   const [newPodId, setNewPodId] = useState('');
-  const [adding, setAdding] = useState(false);
+  const [addingType, setAddingType] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -120,6 +131,7 @@ const V2ConnectorsPage: React.FC = () => {
   const [copied, setCopied] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const adding = addingType !== null;
 
   const load = useCallback(async () => {
     try {
@@ -135,8 +147,12 @@ const V2ConnectorsPage: React.FC = () => {
 
   useEffect(() => { load(); }, [load]);
 
-  // Spec §2.3 step 3: poll while any code is pending; stop when it connects.
-  const hasPending = connectors.some((c) => c.status !== 'connected' && codeIsLive(c));
+  // Poll while a provider can finish binding: Telegram has a copied code;
+  // Slack either has an OAuth state or is awaiting the owner's confirmation.
+  const hasPending = connectors.some((c) => c.status !== 'connected' && (
+    (c.type === 'telegram' && codeIsLive(c))
+    || (c.type === 'slack' && (codeIsLive(c) || Boolean(c.config?.pendingBind)))
+  ));
   useEffect(() => {
     if (hasPending && !pollRef.current) {
       pollRef.current = setInterval(load, 3000);
@@ -166,8 +182,10 @@ const V2ConnectorsPage: React.FC = () => {
     return () => { cancelled = true; };
   }, [api]);
 
-  const createTelegram = async () => {
-    if (!newPodId || creating) return;
+  const createConnector = async () => {
+    if (!newPodId || !addingType || creating) return;
+    const type = addingType;
+    const typeLabel = TYPE_LABELS[type] || type;
     setCreating(true);
     setError(null);
     const installInProgressMessage = (boundPodId?: string): string => (
@@ -179,12 +197,12 @@ const V2ConnectorsPage: React.FC = () => {
         : t('connectors.installInProgress', { defaultValue: 'Still setting up — try again in a moment.' })
     );
     try {
-      const result = await api.post<InstallResponse>('/api/installables/telegram/install', { podId: newPodId });
+      const result = await api.post<InstallResponse>(installableLifecyclePath(type), { podId: newPodId });
       if (result.status && result.status !== 'active') {
         setError(installInProgressMessage(result.boundPodId));
         return;
       }
-      setAdding(false);
+      setAddingType(null);
       await load();
     } catch (error) {
       const response = installErrorResponse(error);
@@ -192,7 +210,8 @@ const V2ConnectorsPage: React.FC = () => {
         setError(installInProgressMessage(response.data.boundPodId));
       } else if (response.status === 409 && response.data?.code === 'already_installed') {
         setError(t('connectors.alreadyBound', {
-          defaultValue: 'Your Telegram channel is bound to {{pod}}. Disconnect it to bind a different pod.',
+          defaultValue: 'Your {{connector}} channel is bound to {{pod}}. Disconnect it to bind a different pod.',
+          connector: typeLabel,
           pod: boundPodName(response.data.boundPodId, connectors, pods),
         }));
       } else {
@@ -226,6 +245,41 @@ const V2ConnectorsPage: React.FC = () => {
       await load();
     } catch {
       setError(t('connectors.codeError', { defaultValue: 'Could not create a new code.' }));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const authorizeSlack = async (c: Connector) => {
+    if (busyId) return;
+    setBusyId(c._id);
+    setError(null);
+    try {
+      const result = await api.post<SlackAuthorizeResponse>('/api/installables/slack/authorize-url', {});
+      if (!result.authorizeUrl) throw new Error('Slack authorization URL was missing');
+      // This leaves Commonly only after the server has stored the browser
+      // nonce cookie that binds Slack's callback to this authorization attempt.
+      window.location.assign(result.authorizeUrl);
+    } catch {
+      setError(t('connectors.slackAuthorizeError', {
+        defaultValue: 'Could not begin Slack authorization. Try again in a moment.',
+      }));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const resolveSlackBind = async (c: Connector, action: 'confirm' | 'reject') => {
+    if (busyId) return;
+    setBusyId(c._id);
+    setError(null);
+    try {
+      await api.post(`/api/installables/slack/${action}`, {});
+      await load();
+    } catch {
+      setError(t('connectors.slackBindError', {
+        defaultValue: 'Could not update the Slack connection. Try again in a moment.',
+      }));
     } finally {
       setBusyId(null);
     }
@@ -280,6 +334,8 @@ const V2ConnectorsPage: React.FC = () => {
   const renderCard = (c: Connector) => {
     const st = statusLine(c);
     const isTelegram = c.type === 'telegram';
+    const isSlack = c.type === 'slack';
+    const supportsRelayControls = isTelegram || isSlack;
     const connected = c.status === 'connected';
     const mirror = c.config?.relayAllAgentMessages === true;
     return (
@@ -298,7 +354,7 @@ const V2ConnectorsPage: React.FC = () => {
               {st.text}
             </div>
           </div>
-          {connected && isTelegram && (
+          {connected && supportsRelayControls && (
             <button
               type="button"
               className="v2-connector__manage"
@@ -309,7 +365,7 @@ const V2ConnectorsPage: React.FC = () => {
           )}
         </div>
 
-        {connected && isTelegram && (
+        {connected && supportsRelayControls && (
           <div className="v2-connector__controls">
             <label className="v2-connector__relay">
               <input
@@ -390,18 +446,66 @@ const V2ConnectorsPage: React.FC = () => {
             <code className="v2-connector__code">{groupCode(c.config?.connectCode || '')}</code>
           </div>
         )}
+
+        {!connected && isSlack && !c.config?.pendingBind && (
+          <div className="v2-connector__code-step">
+            <div className="v2-connector__code-hint">
+              {t('connectors.slackAuthorizeHint', {
+                defaultValue: 'Authorize Commonly in Slack to connect your private DM.',
+              })}
+            </div>
+            <button
+              type="button"
+              className="v2-connector__copy"
+              disabled={busyId === c._id}
+              onClick={() => authorizeSlack(c)}
+            >
+              {busyId === c._id
+                ? t('connectors.slackAuthorizing', { defaultValue: 'Opening Slack…' })
+                : t('connectors.slackAuthorize', { defaultValue: 'Authorize in Slack' })}
+            </button>
+          </div>
+        )}
+
+        {!connected && isSlack && c.config?.pendingBind && (
+          <div className="v2-connector__code-step">
+            <div className="v2-connector__code-hint">
+              {t('connectors.slackConfirmHint', {
+                defaultValue: '{{workspace}} wants to connect as {{user}}.',
+                workspace: c.config.pendingBind.teamName || 'This Slack workspace',
+                user: c.config.pendingBind.slackUserName ? `@${c.config.pendingBind.slackUserName}` : 'your Slack user',
+              })}
+            </div>
+            <button
+              type="button"
+              className="v2-connector__copy"
+              disabled={busyId === c._id}
+              onClick={() => resolveSlackBind(c, 'confirm')}
+            >
+              {t('connectors.slackConfirm', { defaultValue: 'Confirm connection' })}
+            </button>
+            <button
+              type="button"
+              className="v2-connector__danger"
+              disabled={busyId === c._id}
+              onClick={() => resolveSlackBind(c, 'reject')}
+            >
+              {t('connectors.slackReject', { defaultValue: 'This is not me' })}
+            </button>
+          </div>
+        )}
       </article>
     );
   };
 
-  const hasTelegramInstallation = connectors.some(
-    (connector) => connector.type === 'telegram' && Boolean(connector.installationId),
+  const hasInstallation = (type: string): boolean => connectors.some(
+    (connector) => connector.type === type && Boolean(connector.installationId),
   );
 
   const addTiles = (
     <div className="v2-connector-add__tiles">
-      {ADD_PLATFORMS.map((p) => (p.enabled && !(p.type === 'telegram' && hasTelegramInstallation) ? (
-        <button key={p.type} type="button" className="v2-connector-add__tile" onClick={() => setAdding(true)}>
+      {ADD_PLATFORMS.map((p) => (hasInstallation(p.type) ? null : p.enabled ? (
+        <button key={p.type} type="button" className="v2-connector-add__tile" onClick={() => setAddingType(p.type)}>
           <span className={`v2-connector__tile v2-connector__tile--${p.type}`}><PlatformGlyph type={p.type} /></span>
           <span>{TYPE_LABELS[p.type]}</span>
         </button>
@@ -454,14 +558,19 @@ const V2ConnectorsPage: React.FC = () => {
             >
               {pods.map((p) => <option key={p._id} value={p._id}>{p.name}</option>)}
             </select>
-            <button type="button" className="v2-connectors__create" disabled={!newPodId || creating} onClick={createTelegram}>
+            <button type="button" className="v2-connectors__create" disabled={!newPodId || creating} onClick={createConnector}>
               {creating
                 ? t('connectors.creating', { defaultValue: 'Creating…' })
-                : t('connectors.createTelegram', { defaultValue: 'New Telegram connector' })}
+                : t('connectors.createConnector', {
+                  defaultValue: 'New {{connector}} connector',
+                  connector: TYPE_LABELS[addingType || ''] || 'channel',
+                })}
             </button>
           </div>
           <p className="v2-connectors__foot">
-            {t('connectors.footnote', { defaultValue: 'You get a one-time code to send to the bot. More platforms are on the way.' })}
+            {addingType === 'slack'
+              ? t('connectors.slackFootnote', { defaultValue: 'Slack opens its secure authorization flow, then asks you to confirm the workspace and DM.' })
+              : t('connectors.footnote', { defaultValue: 'You get a one-time code to send to the bot. More platforms are on the way.' })}
           </p>
         </div>
       )}

--- a/frontend/src/v2/components/V2ConnectorsPage.tsx
+++ b/frontend/src/v2/components/V2ConnectorsPage.tsx
@@ -255,7 +255,11 @@ const V2ConnectorsPage: React.FC = () => {
     setBusyId(c._id);
     setError(null);
     try {
-      const result = await api.post<SlackAuthorizeResponse>('/api/installables/slack/authorize-url', {});
+      const result = await api.post<SlackAuthorizeResponse>(
+        '/api/installables/slack/authorize-url',
+        {},
+        { withCredentials: true },
+      );
       if (!result.authorizeUrl) throw new Error('Slack authorization URL was missing');
       // This leaves Commonly only after the server has stored the browser
       // nonce cookie that binds Slack's callback to this authorization attempt.

--- a/frontend/src/v2/components/V2ConnectorsPage.tsx
+++ b/frontend/src/v2/components/V2ConnectorsPage.tsx
@@ -130,6 +130,7 @@ const V2ConnectorsPage: React.FC = () => {
   const [confirmDisconnect, setConfirmDisconnect] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [slackCallbackError, setSlackCallbackError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const adding = addingType !== null;
 
@@ -146,6 +147,31 @@ const V2ConnectorsPage: React.FC = () => {
   }, [api, t]);
 
   useEffect(() => { load(); }, [load]);
+
+  // Slack returns through a separate browser tab. Its callback cannot render
+  // a useful Commonly page itself, so it redirects here with an intentionally
+  // opaque status. Consume the query once: URL error codes are never shown
+  // back to the user and therefore cannot become a UI data surface.
+  useEffect(() => {
+    const query = new URLSearchParams(window.location.search);
+    const slackState = query.get('slack');
+    if (slackState !== 'pending' && slackState !== 'error') return;
+    if (slackState === 'pending') {
+      void load();
+    } else {
+      setSlackCallbackError(t('connectors.slackCallbackError', {
+        defaultValue: 'Slack authorization didn’t complete — try again.',
+      }));
+    }
+    query.delete('slack');
+    query.delete('code');
+    const remaining = query.toString();
+    window.history.replaceState(
+      window.history.state,
+      '',
+      `${window.location.pathname}${remaining ? `?${remaining}` : ''}${window.location.hash}`,
+    );
+  }, [load, t]);
 
   // Poll while a provider can finish binding: Telegram has a copied code;
   // Slack either has an OAuth state or is awaiting the owner's confirmation.
@@ -355,6 +381,7 @@ const V2ConnectorsPage: React.FC = () => {
     const isSlack = c.type === 'slack';
     const supportsRelayControls = isTelegram || isSlack;
     const connected = c.status === 'connected';
+    const manageable = supportsRelayControls && (connected || c.status === 'error');
     const mirror = c.config?.relayAllAgentMessages === true;
     return (
       <article key={c._id} className={`v2-connector v2-connector--${c.type}`}>
@@ -372,7 +399,7 @@ const V2ConnectorsPage: React.FC = () => {
               {st.text}
             </div>
           </div>
-          {connected && supportsRelayControls && (
+          {manageable && (
             <button
               type="button"
               className="v2-connector__manage"
@@ -424,7 +451,7 @@ const V2ConnectorsPage: React.FC = () => {
           </div>
         )}
 
-        {manageId === c._id && connected && (
+        {manageId === c._id && manageable && (
           <div className="v2-connector__manage-panel">
             {confirmDisconnect === c._id ? (
               <button type="button" className="v2-connector__danger" disabled={busyId === c._id} onClick={() => disconnect(c)}>
@@ -593,7 +620,7 @@ const V2ConnectorsPage: React.FC = () => {
         </div>
       )}
 
-      {error && <div className="v2-connectors__error" role="alert">{error}</div>}
+      {(error || slackCallbackError) && <div className="v2-connectors__error" role="alert">{error || slackCallbackError}</div>}
     </div>
   );
 };

--- a/frontend/src/v2/components/V2ConnectorsPage.tsx
+++ b/frontend/src/v2/components/V2ConnectorsPage.tsx
@@ -252,6 +252,10 @@ const V2ConnectorsPage: React.FC = () => {
 
   const authorizeSlack = async (c: Connector) => {
     if (busyId) return;
+    // Open the tab during the user gesture, before awaiting the API call, so
+    // browsers do not block it as an async popup. The main Commonly page then
+    // remains open to poll the callback's pending owner-confirmation state.
+    const authorizationWindow = window.open('', '_blank');
     setBusyId(c._id);
     setError(null);
     try {
@@ -261,10 +265,20 @@ const V2ConnectorsPage: React.FC = () => {
         { withCredentials: true },
       );
       if (!result.authorizeUrl) throw new Error('Slack authorization URL was missing');
-      // This leaves Commonly only after the server has stored the browser
-      // nonce cookie that binds Slack's callback to this authorization attempt.
-      window.location.assign(result.authorizeUrl);
+      // The API has now stored the browser nonce cookie that binds Slack's
+      // callback to this authorization attempt. Drop the opener before this
+      // blank tab crosses to Slack, avoiding reverse-tabnabbing.
+      if (authorizationWindow) {
+        authorizationWindow.opener = null;
+        authorizationWindow.location.assign(result.authorizeUrl);
+      } else {
+        // A browser may still block a new tab. Continue rather than losing a
+        // user-initiated authorization attempt; the callback can be revisited
+        // through the browser's back button in that exceptional case.
+        window.location.assign(result.authorizeUrl);
+      }
     } catch {
+      authorizationWindow?.close();
       setError(t('connectors.slackAuthorizeError', {
         defaultValue: 'Could not begin Slack authorization. Try again in a moment.',
       }));


### PR DESCRIPTION
Summary:
- enable Slack in the Connectors installable flow
- add server-built OAuth, a separate authorization tab, and owner confirmation/rejection states
- reuse lifecycle install, pending, and uninstall handling across Telegram and Slack

Validation:
- V2ConnectorsPage Jest suite: 22 passing
- frontend typecheck passed
- scoped ESLint: 0 errors (existing TSX filename warnings)

Dependency: do not merge before #1537. After #1537 merges, this branch will be rebased onto main so only the page diff remains.