### PR TITLE
fix(silence): the detector re-opened an answered-late message every pass — one alert email per 5 minutes

### DIFF
--- a/backend/__tests__/unit/services/onboardingSilenceService.test.js
+++ b/backend/__tests__/unit/services/onboardingSilenceService.test.js
@@ -36,11 +36,13 @@ const mockEpisodeFindOne = jest.fn();
 const mockEpisodeFind = jest.fn();
 const mockEpisodeCreate = jest.fn();
 const mockEpisodeUpdateOne = jest.fn();
+const mockEpisodeExists = jest.fn();
 jest.mock('../../../models/OnboardingSilenceEpisode', () => ({
   findOne: (...a) => mockEpisodeFindOne(...a),
   find: (...a) => mockEpisodeFind(...a),
   create: (...a) => mockEpisodeCreate(...a),
   updateOne: (...a) => mockEpisodeUpdateOne(...a),
+  exists: (...a) => mockEpisodeExists(...a),
 }));
 
 const { scan } = require('../../../services/onboardingSilenceService');
@@ -69,12 +71,14 @@ const setup = ({
   bots = [{ _id: SCOUT }],
   openEpisodes = [],
   existingEpisode = null,
+  coveredByResolved = null,
   events = [],
   runsStarted = 0,
 } = {}) => {
   mockRunCount.mockResolvedValue(runsStarted);
   mockEpisodeFind.mockReturnValue(limitLean(openEpisodes));
   mockEpisodeFindOne.mockResolvedValue(existingEpisode);
+  mockEpisodeExists.mockResolvedValue(coveredByResolved);
   mockEpisodeCreate.mockImplementation((doc) => Promise.resolve({ _id: 'ep1', ...doc }));
   mockEpisodeUpdateOne.mockResolvedValue({ modifiedCount: 1 });
 
@@ -186,6 +190,38 @@ describe('onboardingSilenceService.scan', () => {
 
     const [filter] = mockInstallFind.mock.calls[0];
     expect(filter.status).toBe('active');
+  });
+
+  it('never re-opens a message a RESOLVED episode already covers', async () => {
+    // 2026-09-04: a message answered 46 minutes late fails the in-window
+    // "answered" test on every pass of the 24h lookback. Without this guard the
+    // pass after a resolution opened it again, and the alert recipient got one
+    // email every five minutes for the same message.
+    setup({ coveredByResolved: { _id: 'ep7' } });
+    const result = await scan({ now: NOW });
+
+    expect(result.opened).toHaveLength(0);
+    expect(result.updated).toBe(0);
+    expect(mockEpisodeCreate).not.toHaveBeenCalled();
+    expect(mockEpisodeUpdateOne).not.toHaveBeenCalled();
+    // Coverage is by time, not by message id: the resolved episode must have
+    // started at or before this message and been resolved at or after it. A
+    // message typed after the resolution is a genuinely new silence.
+    expect(mockEpisodeExists).toHaveBeenCalledWith({
+      userId: NEWCOMER,
+      podId: POD,
+      status: 'resolved',
+      firstTypedAt: { $lte: TYPED_AT },
+      resolvedAt: { $gte: TYPED_AT },
+    });
+  });
+
+  it('still opens when no resolved episode covers the message', async () => {
+    setup({ coveredByResolved: null });
+    const result = await scan({ now: NOW });
+
+    expect(result.opened).toHaveLength(1);
+    expect(mockEpisodeCreate).toHaveBeenCalledTimes(1);
   });
 
   it('absorbs a second silent message into the open episode instead of opening another', async () => {

--- a/backend/services/onboardingSilenceService.ts
+++ b/backend/services/onboardingSilenceService.ts
@@ -381,6 +381,23 @@ const openOrExtendEpisode = async ({
   const podId = String(message.pod_id);
   const userId = String(message.user_id);
 
+  // A message already judged by a RESOLVED episode is never re-opened. The
+  // scan's "answered" test only looks inside the threshold window, so a message
+  // answered late (silent for 46 minutes, then answered) fails that test on
+  // every pass for the whole 24h lookback. Before this guard the sequence was:
+  // open -> next pass resolves (answer found) -> next pass opens AGAIN -> ...,
+  // one alert email every five minutes for the same message (2026-09-04, the
+  // first day a recipient was configured). Resolution still re-arms the pair:
+  // a message typed AFTER the resolution is a genuinely new silence.
+  const covered = await OnboardingSilenceEpisode.exists({
+    userId,
+    podId,
+    status: 'resolved',
+    firstTypedAt: { $lte: typedAt },
+    resolvedAt: { $gte: typedAt },
+  });
+  if (covered) return;
+
   const existing = await OnboardingSilenceEpisode.findOne({ userId, podId, status: 'open' });
   if (existing) {
     // Absorb, idempotently. Passes overlap by design (a 24h lookback re-run


### PR DESCRIPTION
## What happened

#1536 gave the onboarding-silence detector a recipient for the first time (2026-09-04 10:45Z). Within the hour Sam had an alert email every five minutes, all for the same message: `stranger-smoke` in its Scout room, message 63002, typed 2026-09-03 23:12Z during the hosted-room outage and answered 46 minutes later once #1528 deployed.

Backend log, three consecutive passes:

```
[onboarding-silence] resolved episode=6a9aaf3d… outcome=answered lagSeconds=2779
[onboarding-silence] ALERT user=stranger-smoke … messageId=63002 … diagnosis=ran-but-silent
[onboarding-silence] resolved episode=6a9ab069… outcome=answered lagSeconds=2779
[onboarding-silence] ALERT user=stranger-smoke … messageId=63002 …
[onboarding-silence] resolved episode=6a9ab195… outcome=answered lagSeconds=2779
```

A new episode id each pass, the same message, the same lag.

## Why

`scan` judges a message "answered" only by a bot reply **inside the threshold window** (`t <= deadline`). That is the right test for opening an episode, and the wrong test for a message that was answered late: it fails every pass for the whole 24h lookback. `openOrExtendEpisode` only looked for an **open** episode to absorb into, and `resolveOpenEpisodes` deliberately re-arms the (user, pod) pair after a resolution. So the loop was: open → next pass resolves (answer found after the window) → next pass opens again → alert again.

## Fix

Before opening or absorbing, `openOrExtendEpisode` checks for a **resolved** episode that already covers the message by time: `firstTypedAt <= typedAt <= resolvedAt`. Covered messages are skipped. Re-arming is preserved: a message typed after the resolution is a genuinely new silence and still opens.

Coverage is by time, not by message id, so the guard also covers messages that were absorbed into the episode rather than the one that opened it.

## Tests

- `never re-opens a message a RESOLVED episode already covers` — pins the query shape (status resolved, `firstTypedAt $lte`, `resolvedAt $gte`) and that neither create nor absorb runs.
- `still opens when no resolved episode covers the message` — the default path is unchanged.
- Existing 17 cases unchanged; the model mock gains `exists`.

## Live state

The recipient env was removed from the running backend with `kubectl set env` at ~11:58Z to stop the emails; the next `Deploy Dev` restores it from the chart (#1536), so this PR must deploy before the recipient comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHfcrzjN6MpeuCCAap5Qnb
