### PR TITLE
feat(v2): rebuild workspace thread, decisions, and composer

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
         'src/v2/components/V2InviteRedeem.tsx',
         'src/components/RegistrationInviteRequired.tsx',
         'src/components/VerifyEmail.tsx',
-        'src/v2/components/V2PodChat.tsx',
+        'src/v2/components/V2Thread.tsx',
         'src/v2/components/V2FirstRunHero.tsx',
         'src/v2/components/V2InviteModal.tsx',
         // Phase 2 — the v2 shell (#719)

--- a/frontend/src/i18n/__tests__/translationKeys.test.ts
+++ b/frontend/src/i18n/__tests__/translationKeys.test.ts
@@ -75,7 +75,9 @@ describe('i18n migration manifest', () => {
     expect(missing).toEqual([]);
   });
 
-  it('keeps the deferred message bubble outside the migrated-file manifest', () => {
+  it('keeps the retired chat and bubble files out of the migrated-file manifest', () => {
+    expect(migratedFiles).not.toContain('src/v2/components/V2PodChat.tsx');
     expect(migratedFiles).not.toContain('src/v2/components/V2MessageBubble.tsx');
+    expect(migratedFiles).toContain('src/v2/components/V2Thread.tsx');
   });
 });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -110,6 +110,7 @@
       "otherPlaceholder": "Write your ruling…",
       "sendOther": "Send ruling",
       "ruled": "✓ {{by}} ruled: {{value}}",
+      "ruledShort": "ruled",
       "actionFailed": "That ruling could not be saved. Try again."
     },
     "mention": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -3,6 +3,7 @@
     "brandName": "Commonly",
     "brandWordmark": "commonly",
     "agent": "Agent",
+    "you": "you",
     "close": "Close",
     "copy": "Copy",
     "copied": "Copied!",
@@ -439,6 +440,10 @@
       "recent_other": "{{formattedCount}} recent heartbeats",
       "none": "No recent heartbeats"
     },
+    "header": {
+      "agentsWorking_one": "{{count}} agent working",
+      "agentsWorking_other": "{{count}} agents working"
+    },
     "team": {
       "view": "View pod team",
       "hide": "Hide pod team"
@@ -467,7 +472,9 @@
       "uploading": "Uploading…",
       "attachFile": "Attach file",
       "sending": "Sending…",
-      "send": "Send message",
+      "send": "Send",
+      "sendAria": "Send message",
+      "postsAs": "posts as {{name}}",
       "mentionAgent": "mention an agent",
       "toSend": "to send"
     },

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -3,6 +3,7 @@
     "brandName": "Commonly",
     "brandWordmark": "commonly",
     "agent": "智能体",
+    "you": "你",
     "close": "关闭",
     "copy": "复制",
     "copied": "已复制",
@@ -439,6 +440,9 @@
       "recent_one": "最近收到 {{formattedCount}} 次心跳",
       "recent_other": "最近收到 {{formattedCount}} 次心跳"
     },
+    "header": {
+      "agentsWorking_other": "{{count}} 个智能体正在工作"
+    },
     "team": {
       "view": "查看 Pod 团队",
       "hide": "隐藏 Pod 团队"
@@ -467,7 +471,9 @@
       "uploading": "正在上传…",
       "attachFile": "添加文件",
       "sending": "正在发送…",
-      "send": "发送消息",
+      "send": "发送",
+      "sendAria": "发送消息",
+      "postsAs": "发布身份：{{name}}",
       "mentionAgent": "提及智能体",
       "toSend": "发送"
     },

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -110,6 +110,7 @@
       "otherPlaceholder": "写下你的裁定…",
       "sendOther": "发送裁定",
       "ruled": "✓ {{by}} 已裁定：{{value}}",
+      "ruledShort": "已裁定",
       "actionFailed": "无法保存该裁定，请重试。"
     },
     "mention": {

--- a/frontend/src/v2/__tests__/V2Composer.test.tsx
+++ b/frontend/src/v2/__tests__/V2Composer.test.tsx
@@ -85,6 +85,7 @@ describe('V2Composer send button', () => {
     }));
 
     expect(view.container.querySelector('.v2-thread__working')).toHaveTextContent('0 agents working');
+    expect(view.container.querySelector('.v2-thread__working')).not.toHaveClass('v2-thread__working--active');
 
     view.rerender(
       <AuthContext.Provider value={authValue}>
@@ -101,6 +102,7 @@ describe('V2Composer send button', () => {
     );
 
     expect(view.container.querySelector('.v2-thread__working')).toHaveTextContent('1 agent working');
+    expect(view.container.querySelector('.v2-thread__working')).toHaveClass('v2-thread__working--active');
   });
 
   test('clicking the send button sends the drafted text', async () => {

--- a/frontend/src/v2/__tests__/V2Composer.test.tsx
+++ b/frontend/src/v2/__tests__/V2Composer.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import V2PodChat from '../components/V2PodChat';
+import V2Thread from '../components/V2Thread';
 import { AuthContext } from '../../context/AuthContext';
 
 jest.mock('../../context/SocketContext', () => ({
@@ -15,7 +15,11 @@ jest.mock('../../context/SocketContext', () => ({
 
 // Composer behavior does not depend on avatar rendering. Keep this test
 // isolated from the external DiceBear package graph used by V2Avatar.
-jest.mock('../components/V2Avatar', () => () => <span data-testid="avatar" />);
+jest.mock('../components/V2Avatar', () => {
+  const MockAvatar = () => <span data-testid="avatar" />;
+  MockAvatar.displayName = 'MockAvatar';
+  return MockAvatar;
+});
 jest.mock('../utils/avatars', () => ({ initialsFor: (name: string) => name.slice(0, 2) }));
 
 // jsdom has no scrollIntoView; the component auto-scrolls on mount.
@@ -69,32 +73,34 @@ const makeDetail = (overrides = {}) => ({
 const renderChat = (detail) => render(
   <AuthContext.Provider value={authValue}>
     <MemoryRouter>
-      <V2PodChat detail={detail} />
+      <V2Thread detail={detail} />
     </MemoryRouter>
   </AuthContext.Provider>,
 );
 
-describe('V2PodChat composer send button', () => {
-  test('only shows a no-heartbeat state when the pod has an installed agent', () => {
+describe('V2Composer send button', () => {
+  test('uses the artboard’s compact working count in the thread header', () => {
     const view = renderChat(makeDetail({
       pod: { _id: 'p1', name: 'My Workspace', type: 'chat', description: 'Team discussion' },
     }));
 
-    // A human-only pod is not waiting on anyone to heartbeat.
-    expect(view.container.querySelector('.v2-chat__goal-meta')).toBeNull();
+    expect(view.container.querySelector('.v2-thread__working')).toHaveTextContent('0 agents working');
 
     view.rerender(
       <AuthContext.Provider value={authValue}>
         <MemoryRouter>
-          <V2PodChat detail={makeDetail({
+          <V2Thread detail={makeDetail({
             pod: { _id: 'p1', name: 'My Workspace', type: 'chat', description: 'Team discussion' },
-            agents: [{ agentName: 'scout', instanceId: 'default', displayName: 'Scout' }],
+            agents: [{
+              agentName: 'scout', instanceId: 'default', displayName: 'Scout',
+              lastHeartbeatAt: new Date().toISOString(),
+            }],
           })} />
         </MemoryRouter>
       </AuthContext.Provider>,
     );
 
-    expect(view.container.querySelector('.v2-chat__goal-meta')).toHaveTextContent('No recent heartbeats');
+    expect(view.container.querySelector('.v2-thread__working')).toHaveTextContent('1 agent working');
   });
 
   test('clicking the send button sends the drafted text', async () => {
@@ -150,16 +156,16 @@ describe('V2PodChat composer send button', () => {
     rerender(
       <AuthContext.Provider value={authValue}>
         <MemoryRouter>
-          <V2PodChat detail={{ ...detail, sendError: 'Replies are temporarily unavailable. Please try again shortly.' }} />
+          <V2Thread detail={{ ...detail, sendError: 'Replies are temporarily unavailable. Please try again shortly.' }} />
         </MemoryRouter>
       </AuthContext.Provider>,
     );
 
     const sendError = screen.getByText('Replies are temporarily unavailable. Please try again shortly.');
-    expect(sendError.closest('.v2-chat__composer')).not.toBeNull();
+    expect(sendError.closest('.v2-composer')).not.toBeNull();
     expect(sendError.closest('.v2-chat__messages')).toBeNull();
     expect(screen.getByPlaceholderText(/message my workspace/i)).toHaveValue('I am checking it now.');
-    expect(screen.getByRole('button', { name: /cancel reply/i }).closest('.v2-chat__reply-chip')).not.toBeNull();
+    expect(screen.getByRole('button', { name: /cancel reply/i }).closest('.v2-composer__target')).not.toBeNull();
   });
 
   // W-T 4/4, constraint 4 (docs/design/threading-surface-ruling.md; ux-lead

--- a/frontend/src/v2/__tests__/V2ComposerMentionState.test.tsx
+++ b/frontend/src/v2/__tests__/V2ComposerMentionState.test.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import V2PodChat from '../components/V2PodChat';
+import V2Thread from '../components/V2Thread';
 import { AuthContext } from '../../context/AuthContext';
 
 jest.mock('../../context/SocketContext', () => ({
@@ -72,14 +72,14 @@ const mockStates = (agents) => {
 const renderChat = (detail) => render(
   <AuthContext.Provider value={authValue}>
     <MemoryRouter>
-      <V2PodChat detail={detail} />
+      <V2Thread detail={detail} />
     </MemoryRouter>
   </AuthContext.Provider>,
 );
 
 afterEach(() => jest.clearAllMocks());
 
-describe('V2PodChat mention-state honesty (#891 surface 1)', () => {
+describe('V2Composer mention-state honesty (#891 surface 1)', () => {
   test('mentioning a never-connected agent warns the OWNER with the fix command', async () => {
     mockStates([{
       agentName: 'sam-agent', instanceId: 'default', state: 'never-connected', isOwner: true, fixCommand: 'commonly agent run sam-agent',

--- a/frontend/src/v2/__tests__/V2ComposerSurface.test.tsx
+++ b/frontend/src/v2/__tests__/V2ComposerSurface.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import V2Composer from '../components/V2Composer';
+
+const renderComposer = (overrides: Partial<React.ComponentProps<typeof V2Composer>> = {}) => {
+  const props: React.ComponentProps<typeof V2Composer> = {
+    podName: 'Sharpen',
+    authorName: 'lily',
+    draft: '',
+    sending: false,
+    uploading: false,
+    sendError: null,
+    composerError: null,
+    replyTarget: null,
+    threadTarget: null,
+    mentionOpen: false,
+    mentionIndex: 0,
+    mentions: [],
+    warnings: [],
+    inputRef: { current: null },
+    fileInputRef: { current: null },
+    mentionDropdownRef: { current: null },
+    onDraftChange: jest.fn(),
+    onDraftPointer: jest.fn(),
+    onKeyDown: jest.fn(),
+    onMentionSelect: jest.fn(),
+    onSend: jest.fn(),
+    onAttach: jest.fn(),
+    onCancelReply: jest.fn(),
+    onCancelThread: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<V2Composer {...props} />) };
+};
+
+describe('V2Composer', () => {
+  test('keeps the workspace’s single bordered input and posts-as line independent of the thread controller', () => {
+    const { props, container } = renderComposer({ draft: 'Ready to ship' });
+
+    expect(container.querySelector('.v2-composer')).toBeInTheDocument();
+    expect(screen.getByText('posts as lily · ⌘↵')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send message' })).toHaveTextContent('Send');
+
+    fireEvent.change(screen.getByPlaceholderText('Message Sharpen…'), {
+      target: { value: 'Next draft', selectionStart: 10 },
+    });
+    expect(props.onDraftChange).toHaveBeenCalledWith('Next draft', 10);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+    expect(props.onSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/v2/__tests__/V2DecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2DecisionCard.test.tsx
@@ -14,8 +14,8 @@ const decision = {
   detail: 'Which implementation should ship?',
   actorName: 'Sprint impl',
   options: [
-    { label: 'Ship the rebuilt workspace', recommended: true, description: 'The full artboard cutover.' },
-    { label: 'Keep the legacy chat', description: 'Do not ship the new workspace.' },
+    { label: 'Ship the rebuilt workspace', description: 'The full artboard cutover.' },
+    { label: 'Keep the legacy chat', recommended: true, description: 'Do not ship the new workspace.' },
   ],
 };
 
@@ -31,7 +31,8 @@ describe('V2DecisionCard', () => {
     expect(screen.getByText('Choose the workspace cutover')).toBeInTheDocument();
     expect(screen.getByText('Which implementation should ship?')).toBeInTheDocument();
     expect(screen.getByText('Sprint impl')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Ship the rebuilt workspace' })).toHaveClass('v2-decision-card__choice--recommended');
+    expect(screen.getByRole('button', { name: 'Ship the rebuilt workspace' })).toHaveClass('v2-decision-card__choice--primary');
+    expect(screen.getByRole('button', { name: 'Keep the legacy chat' })).not.toHaveClass('v2-decision-card__choice--primary');
 
     fireEvent.click(screen.getByRole('button', { name: 'Ship the rebuilt workspace' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(

--- a/frontend/src/v2/__tests__/V2DecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2DecisionCard.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import V2DecisionCard from '../components/V2DecisionCard';
+
+const mockPost = jest.fn();
+
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => ({ post: mockPost }),
+}));
+
+const decision = {
+  id: 'decision-1',
+  title: 'Choose the workspace cutover',
+  detail: 'Which implementation should ship?',
+  actorName: 'Sprint impl',
+  options: [
+    { label: 'Ship the rebuilt workspace', recommended: true, description: 'The full artboard cutover.' },
+    { label: 'Keep the legacy chat', description: 'Do not ship the new workspace.' },
+  ],
+};
+
+describe('V2DecisionCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders a structured fork rather than its prose fallback and posts the chosen option', async () => {
+    mockPost.mockResolvedValue({ decision: { ruling: { value: 'Ship the rebuilt workspace', by: 'Sam' } } });
+    render(<V2DecisionCard decision={decision} />);
+
+    expect(screen.getByText('Choose the workspace cutover')).toBeInTheDocument();
+    expect(screen.getByText('Which implementation should ship?')).toBeInTheDocument();
+    expect(screen.getByText('Sprint impl')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ship the rebuilt workspace' })).toHaveClass('v2-decision-card__choice--recommended');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ship the rebuilt workspace' }));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
+      '/api/activity/decisions/decision-1/choose',
+      { value: 'Ship the rebuilt workspace' },
+    ));
+    expect(await screen.findByRole('status')).toHaveTextContent('Sam ruled: Ship the rebuilt workspace');
+  });
+
+  test('shows the standing ruling from a racing human instead of presenting a second choice', async () => {
+    mockPost.mockRejectedValue({
+      response: { status: 409, data: { decision: { ruling: { value: 'Keep the legacy chat', by: 'Lily' } } } },
+    });
+    render(<V2DecisionCard decision={decision} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep the legacy chat' }));
+    expect(await screen.findByRole('status')).toHaveTextContent('Lily ruled: Keep the legacy chat');
+    expect(screen.queryByRole('button', { name: 'Ship the rebuilt workspace' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
+++ b/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
@@ -212,7 +212,7 @@ describe('V2FirstRunHero', () => {
     await flush();
 
     expect(screen.queryByRole('heading', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
-    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockGet).not.toHaveBeenCalledWith('/api/users/me/agent-connection');
   });
 
   /*
@@ -308,7 +308,7 @@ describe('V2FirstRunHero', () => {
     await flush();
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockGet).not.toHaveBeenCalledWith('/api/users/me/agent-connection');
 
     act(() => {
       window.dispatchEvent(new Event('commonly:reopen-first-run'));
@@ -398,7 +398,7 @@ describe('V2Layout first-run placement', () => {
       expect(screen.getByText('Quiet pod empty state')).toBeInTheDocument();
     });
     expect(screen.queryByRole('dialog', { name: 'Bring your agent into the room' })).not.toBeInTheDocument();
-    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockGet).not.toHaveBeenCalledWith('/api/users/me/agent-connection');
   });
 
   test('reopens the dismissed guide from the rail and restores onboarding suppression', async () => {
@@ -414,7 +414,7 @@ describe('V2Layout first-run placement', () => {
     await waitFor(() => {
       expect(screen.getByText('Quiet pod empty state')).toBeInTheDocument();
     });
-    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockGet).not.toHaveBeenCalledWith('/api/users/me/agent-connection');
 
     fireEvent.click(screen.getByRole('button', { name: 'Guide' }));
 

--- a/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
+++ b/frontend/src/v2/__tests__/V2FirstRunHero.test.tsx
@@ -73,7 +73,7 @@ jest.mock('../components/V2NavRail', () => () => (
 jest.mock('../components/V2PodsSidebar', () => () => <aside>Pods</aside>);
 jest.mock('../components/V2Inspector', () => () => <aside>Inspector</aside>);
 jest.mock('../components/V2InviteModal', () => () => null);
-jest.mock('../components/V2PodChat', () => ({ firstRunVisible }: { firstRunVisible?: boolean }) => (
+jest.mock('../components/V2Thread', () => ({ firstRunVisible }: { firstRunVisible?: boolean }) => (
   <main data-testid="pod-chat">
     <span>Normal pod view</span>
     {!firstRunVisible && <span>Quiet pod empty state</span>}

--- a/frontend/src/v2/__tests__/V2Inspector.test.tsx
+++ b/frontend/src/v2/__tests__/V2Inspector.test.tsx
@@ -100,7 +100,7 @@ describe('V2Inspector', () => {
 
   test('uses the settled-workspace empty copy when no agent is working', async () => {
     mockGet.mockImplementation(() => Promise.resolve({ items: [], tasks: [] }));
-    renderInspector({ detail: { ...detail, agents: [] } as any });
+    renderInspector({ detail: { ...detail, agents: [] } as any, attentionItems: [] });
 
     expect(await screen.findByText('Nothing open.')).toBeInTheDocument();
   });

--- a/frontend/src/v2/__tests__/V2Inspector.test.tsx
+++ b/frontend/src/v2/__tests__/V2Inspector.test.tsx
@@ -72,6 +72,13 @@ describe('V2Inspector', () => {
     expect(screen.queryByRole('tab')).not.toBeInTheDocument();
   });
 
+  test('uses the short lowercase room name in the single-line agents label', () => {
+    renderInspector({ detail: { ...detail, pod: { ...detail.pod, name: 'Sharpen · decision loop' } } as any });
+
+    expect(screen.getByRole('heading', { name: 'agents in sharpen' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /decision loop/i })).not.toBeInTheDocument();
+  });
+
   test('links attention, board, profile, invite, and manage exits without legacy tabs', async () => {
     const onOpenInvite = jest.fn();
     renderInspector({ onOpenInvite });

--- a/frontend/src/v2/__tests__/V2Inspector.test.tsx
+++ b/frontend/src/v2/__tests__/V2Inspector.test.tsx
@@ -33,7 +33,14 @@ const detail = {
 
 const renderInspector = (props: Partial<React.ComponentProps<typeof V2Inspector>> = {}) => render(
   <MemoryRouter>
-    <V2Inspector detail={detail as any} onOpenInvite={jest.fn()} {...props} />
+    <V2Inspector
+      detail={detail as any}
+      attentionItems={[{
+        id: 'decision-1', kind: 'decision', title: 'Slack default mode', actorName: 'Wren', podId: 'pod-1', messageId: 'message-7',
+      }]}
+      onOpenInvite={jest.fn()}
+      {...props}
+    />
   </MemoryRouter>,
 );
 
@@ -41,11 +48,6 @@ describe('V2Inspector', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGet.mockImplementation((url: string) => {
-      if (url === '/api/activity/decision-queue') {
-        return Promise.resolve({ items: [{
-          id: 'decision-1', kind: 'decision', title: 'Slack default mode', actorName: 'Wren', podId: 'pod-1', messageId: 'message-7',
-        }] });
-      }
       if (url === '/api/v1/tasks/pod-1') {
         return Promise.resolve({ tasks: [
           { taskId: 'TASK-131', title: 'Build the card', status: 'in_progress', assignee: 'kai' },
@@ -90,11 +92,8 @@ describe('V2Inspector', () => {
   });
 
   test('does not render a stale attention item from another pod', async () => {
-    mockGet.mockImplementation((url: string) => {
-      if (url === '/api/activity/decision-queue') return Promise.resolve({ items: [{ id: 'other', kind: 'decision', title: 'Other pod', podId: 'pod-2' }] });
-      return Promise.resolve({ tasks: [] });
-    });
-    renderInspector();
+    mockGet.mockResolvedValue({ tasks: [] });
+    renderInspector({ attentionItems: [{ id: 'other', kind: 'decision', title: 'Other pod', podId: 'pod-2' }] });
     await waitFor(() => expect(screen.getByText('Nothing. Wren is working.')).toBeInTheDocument());
     expect(screen.queryByText('Other pod')).not.toBeInTheDocument();
   });

--- a/frontend/src/v2/__tests__/V2InviteDmGate.test.tsx
+++ b/frontend/src/v2/__tests__/V2InviteDmGate.test.tsx
@@ -42,7 +42,7 @@ jest.mock('../components/V2InviteModal', () => function MockV2InviteModal({ open
   return open ? <div data-testid="invite-modal-tab">{initialTab}</div> : null;
 });
 jest.mock('../components/V2FirstRunHero', () => () => null);
-jest.mock('../components/V2PodChat', () => function MockV2PodChat({ onOpenInvite }) {
+jest.mock('../components/V2Thread', () => function MockV2Thread({ onOpenInvite }) {
   return (
     <div>
       {onOpenInvite && (

--- a/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
+++ b/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
@@ -38,7 +38,7 @@ jest.mock('../../context/AuthContext', () => ({
 
 jest.mock('../components/V2NavRail', () => () => null);
 jest.mock('../components/V2PodsSidebar', () => () => null);
-jest.mock('../components/V2PodChat', () => () => null);
+jest.mock('../components/V2Thread', () => () => null);
 jest.mock('../components/V2Inspector', () => () => null);
 jest.mock('../components/V2InviteModal', () => () => null);
 jest.mock('../components/V2FirstRunHero', () => () => null);

--- a/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
+++ b/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import {
   MemoryRouter, Route, Routes, useLocation,
 } from 'react-router-dom';
@@ -38,8 +38,10 @@ jest.mock('../../context/AuthContext', () => ({
 
 jest.mock('../components/V2NavRail', () => () => null);
 jest.mock('../components/V2PodsSidebar', () => () => null);
-jest.mock('../components/V2Thread', () => () => null);
-jest.mock('../components/V2Inspector', () => () => null);
+jest.mock('../components/V2Thread', () => ({ onToggleInspector }: { onToggleInspector?: () => void }) => (
+  <button type="button" onClick={onToggleInspector}>toggle inspector</button>
+));
+jest.mock('../components/V2Inspector', () => () => <aside data-testid="workspace-inspector" />);
 jest.mock('../components/V2InviteModal', () => () => null);
 jest.mock('../components/V2FirstRunHero', () => () => null);
 
@@ -71,6 +73,8 @@ const newerWorkspacePod: V2Pod = {
   createdAt: '2026-07-22T00:00:00.000Z',
 };
 
+const originalMatchMedia = window.matchMedia;
+
 const renderAutoLayout = () => render(
   <MemoryRouter initialEntries={['/v2']}>
     <Routes>
@@ -89,6 +93,38 @@ describe('V2Layout default pod selection', () => {
 
   afterEach(() => {
     localStorage.clear();
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  test('a phone starts with its inspector sheet closed even when desktop left it open', () => {
+    const phoneViewport = {
+      matches: true,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(() => phoneViewport),
+    });
+    localStorage.setItem('v2.inspectorCollapsed', '0');
+
+    render(
+      <MemoryRouter initialEntries={['/v2/pods/workspace']}>
+        <Routes>
+          <Route path="/v2/pods/:podId" element={<V2Layout selectionMode="param" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('workspace-inspector')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'toggle inspector' }));
+    expect(screen.getByTestId('workspace-inspector')).toBeInTheDocument();
+    expect(phoneViewport.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
   });
 
   test('lands a new user in their oldest own workspace instead of auto-joined HQ', async () => {

--- a/frontend/src/v2/__tests__/V2MessageRow.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageRow.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import V2MessageBubble from '../components/V2MessageBubble';
+import V2MessageRow from '../components/V2MessageRow';
 
 jest.mock('../../context/AuthContext', () => ({
   useAuth: () => ({ currentUser: { username: 'viewer' } }),
 }));
 
-describe('V2MessageBubble', () => {
+describe('V2MessageRow', () => {
   const previousApiUrl = process.env.REACT_APP_API_URL;
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('V2MessageBubble', () => {
 
     render(
       <MemoryRouter>
-        <V2MessageBubble
+        <V2MessageRow
           message={{
             id: '1',
             pod_id: 'pod-1',
@@ -50,7 +50,7 @@ describe('V2MessageBubble', () => {
   it('renders no reactions row when a message has no reactions — the trigger lives in the cluster', () => {
     render(
       <MemoryRouter>
-        <V2MessageBubble
+        <V2MessageRow
           message={{
             id: '42',
             pod_id: 'pod-1',
@@ -73,7 +73,7 @@ describe('V2MessageBubble', () => {
   it('keeps the reactions row in flow when chips exist', () => {
     render(
       <MemoryRouter>
-        <V2MessageBubble
+        <V2MessageRow
           message={{
             id: '43',
             pod_id: 'pod-1',
@@ -96,7 +96,7 @@ describe('V2MessageBubble', () => {
   it('marks a system card with its action state', () => {
     render(
       <MemoryRouter>
-        <V2MessageBubble
+        <V2MessageRow
           message={{
             id: '44',
             pod_id: 'pod-1',

--- a/frontend/src/v2/__tests__/V2MessageRowQuote.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageRowQuote.test.tsx
@@ -13,9 +13,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import V2MessageBubble from '../components/V2MessageBubble';
+import V2MessageRow from '../components/V2MessageRow';
 
-jest.mock('../components/V2Avatar', () => () => <span data-testid="avatar" />);
+jest.mock('../components/V2Avatar', () => {
+  const MockAvatar = () => <span data-testid="avatar" />;
+  MockAvatar.displayName = 'MockAvatar';
+  return MockAvatar;
+});
 jest.mock('../../context/AuthContext', () => ({
   useAuth: () => ({ currentUser: { _id: 'u1', username: 'me' }, token: 't' }),
 }));
@@ -33,7 +37,7 @@ const msg = (replyToId, replyAuthor) => ({
 });
 
 const show = (props) => render(
-  <MemoryRouter><V2MessageBubble message={msg('root-1', 'rootauthor')} {...props} /></MemoryRouter>,
+  <MemoryRouter><V2MessageRow message={msg('root-1', 'rootauthor')} {...props} /></MemoryRouter>,
 );
 
 describe('the quote is hidden only when the rail already supplies its context', () => {
@@ -49,7 +53,7 @@ describe('the quote is hidden only when the rail already supplies its context', 
     // who is being answered, so suppressing it would lose the addressee.
     render(
       <MemoryRouter>
-        <V2MessageBubble message={msg('m-other', 'someoneelse')} insideThreadRoot="root-1" />
+        <V2MessageRow message={msg('m-other', 'someoneelse')} insideThreadRoot="root-1" />
       </MemoryRouter>,
     );
     expect(screen.getByText(/the quoted text/)).toBeInTheDocument();
@@ -64,7 +68,7 @@ describe('the quote is hidden only when the rail already supplies its context', 
   test('no quote at all is still no quote', () => {
     render(
       <MemoryRouter>
-        <V2MessageBubble message={{ ...msg('root-1', 'a'), replyTo: null }} insideThreadRoot="root-1" />
+        <V2MessageRow message={{ ...msg('root-1', 'a'), replyTo: null }} insideThreadRoot="root-1" />
       </MemoryRouter>,
     );
     expect(screen.queryByText(/the quoted text/)).not.toBeInTheDocument();
@@ -75,7 +79,7 @@ describe('the quote is hidden only when the rail already supplies its context', 
     // the view. An === on mixed types would silently never suppress.
     render(
       <MemoryRouter>
-        <V2MessageBubble message={msg(101, 'rootauthor')} insideThreadRoot="101" />
+        <V2MessageRow message={msg(101, 'rootauthor')} insideThreadRoot="101" />
       </MemoryRouter>,
     );
     expect(screen.queryByText(/the quoted text/)).not.toBeInTheDocument();

--- a/frontend/src/v2/__tests__/V2MobileTabs.test.tsx
+++ b/frontend/src/v2/__tests__/V2MobileTabs.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import V2MobileTabs from '../components/V2MobileTabs';
+
+const Location = () => <output data-testid="location">{useLocation().pathname}</output>;
+
+describe('V2MobileTabs', () => {
+  test('keeps chat, board, needs-you and settings reachable from the phone shell', () => {
+    const openInspector = jest.fn();
+    render(
+      <MemoryRouter initialEntries={['/v2/pods/pod-1']}>
+        <V2MobileTabs podId="pod-1" needsYouCount={2} onOpenInspector={openInspector} />
+        <Location />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Board' }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/v2/pods/pod-1/board');
+    fireEvent.click(screen.getByRole('button', { name: 'Needs you' }));
+    expect(openInspector).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/v2/settings');
+  });
+});

--- a/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
@@ -90,7 +90,7 @@ describe('V2PodsSidebar workspace groups', () => {
 
     const pods = screen.getByRole('heading', { name: 'pods' }).closest('section');
     const direct = screen.getByRole('heading', { name: 'direct' }).closest('section');
-    expect(within(pods).getByRole('button', { name: 'Sharpen' })).toBeInTheDocument();
+    expect(within(pods).getByRole('button', { name: /^Sharpen/ })).toBeInTheDocument();
     expect(within(pods).getByRole('button', { name: 'Agent Admin' })).toBeInTheDocument();
     expect(within(pods).getByRole('button', { name: 'Study Group' })).toBeInTheDocument();
     expect(within(pods).getByRole('button', { name: 'Project Chat' })).toBeInTheDocument();

--- a/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
@@ -47,6 +47,7 @@ const renderSidebar = (pods, selectedPodId = 'sharpen') => render(
   <MemoryRouter initialEntries={['/v2/pods/sharpen']}>
     <V2PodsSidebar
       selectedPodId={selectedPodId}
+      attentionItems={[{ id: 'decision-1', kind: 'decision', title: 'Choose workspace', podId: 'sharpen' }]}
       podsState={{
         pods,
         loading: false,
@@ -70,9 +71,6 @@ describe('V2PodsSidebar workspace groups', () => {
         return Promise.resolve([{
           _id: 'telegram', type: 'telegram', status: 'connected', podId: { _id: 'sharpen', name: 'Sharpen' },
         }]);
-      }
-      if (url === '/api/activity/decision-queue') {
-        return Promise.resolve({ items: [{ id: 'decision-1', podId: 'sharpen' }] });
       }
       return Promise.resolve([]);
     });

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -71,13 +71,16 @@ describe('V2Thread decision cards', () => {
       }
       return Promise.resolve({ data: {} });
     });
-    mockPost.mockResolvedValue({ data: { decision: { ruling: { value: 'Ship the rebuilt workspace', by: 'Lily' } } } });
+    mockPost.mockResolvedValue({ data: { decision: { ruling: {
+      value: 'Ship the rebuilt workspace', by: 'Lily', messageId: 'ruling-42', at: '2026-09-05T12:01:00.000Z',
+    } } } });
   });
 
   test('replaces the decision request prose at its durable message position with a live card', async () => {
+    const onDecisionSettled = jest.fn();
     render(
       <AuthContext.Provider value={auth}>
-        <MemoryRouter><V2Thread detail={detail} /></MemoryRouter>
+        <MemoryRouter><V2Thread detail={detail} onDecisionSettled={onDecisionSettled} /></MemoryRouter>
       </AuthContext.Provider>,
     );
 
@@ -91,6 +94,11 @@ describe('V2Thread decision cards', () => {
       { value: 'Ship the rebuilt workspace' },
       expect.anything(),
     ));
-    expect(await screen.findByRole('status')).toHaveTextContent('Lily ruled: Ship the rebuilt workspace');
+    const ruling = await screen.findByTestId('decision-ruling-row');
+    expect(ruling).toHaveTextContent('Lily');
+    expect(ruling).toHaveTextContent('ruled');
+    expect(ruling).toHaveTextContent('Ship the rebuilt workspace');
+    expect(screen.queryByTestId('decision-card')).not.toBeInTheDocument();
+    expect(onDecisionSettled).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -1,0 +1,96 @@
+// @ts-nocheck
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2Thread from '../components/V2Thread';
+import { AuthContext } from '../../context/AuthContext';
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: (...args) => mockGet(...args),
+    post: (...args) => mockPost(...args),
+    patch: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  },
+}));
+
+jest.mock('../../context/SocketContext', () => ({
+  useSocket: () => ({ socket: null, connected: false }),
+}));
+
+jest.mock('../components/V2Avatar', () => {
+  const MockAvatar = () => <span data-testid="avatar" />;
+  MockAvatar.displayName = 'MockAvatar';
+  return MockAvatar;
+});
+
+beforeAll(() => { Element.prototype.scrollIntoView = jest.fn(); });
+
+const auth = {
+  currentUser: { _id: 'human-1', username: 'lily' },
+  user: { _id: 'human-1', username: 'lily' },
+  token: 'token', loading: false, error: null, isAuthenticated: true,
+  register: jest.fn(), login: jest.fn(), logout: jest.fn(), updateProfile: jest.fn(),
+};
+
+const detail = {
+  pod: { _id: 'pod-1', name: 'Sharpen', description: 'Make the next cut', type: 'chat' },
+  members: [{ _id: 'human-1', username: 'lily', isBot: false }],
+  agents: [],
+  messages: [{
+    id: '42', pod_id: 'pod-1', user_id: 'agent-1',
+    user: { username: 'sprint-impl', isBot: true },
+    content: 'Choose one of the following approaches in prose.',
+    message_type: 'text', created_at: '2026-09-05T12:00:00.000Z',
+  }],
+  sendMessage: jest.fn(), loading: false, error: null, sendError: null,
+  hasMore: false, loadingOlder: false, loadOlder: jest.fn(), refresh: jest.fn(),
+};
+
+describe('V2Thread decision cards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockImplementation((url) => {
+      if (url === '/api/activity/decision-queue') {
+        return Promise.resolve({ data: { items: [{
+          id: 'decision-42', kind: 'decision', podId: 'pod-1', messageId: '42',
+          actorName: 'Sprint impl', title: 'Choose the workspace cutover',
+          detail: 'Which implementation should ship?',
+          options: [{ label: 'Ship the rebuilt workspace', recommended: true }],
+        }] } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    mockPost.mockResolvedValue({ data: { decision: { ruling: { value: 'Ship the rebuilt workspace', by: 'Lily' } } } });
+  });
+
+  test('replaces the decision request prose at its durable message position with a live card', async () => {
+    render(
+      <AuthContext.Provider value={auth}>
+        <MemoryRouter><V2Thread detail={detail} /></MemoryRouter>
+      </AuthContext.Provider>,
+    );
+
+    expect(await screen.findByTestId('decision-card')).toBeInTheDocument();
+    expect(screen.getByText('Choose the workspace cutover')).toBeInTheDocument();
+    expect(screen.queryByText('Choose one of the following approaches in prose.')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ship the rebuilt workspace' }));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
+      '/api/activity/decisions/decision-42/choose',
+      { value: 'Ship the rebuilt workspace' },
+      expect.anything(),
+    ));
+    expect(await screen.findByRole('status')).toHaveTextContent('Lily ruled: Ship the rebuilt workspace');
+  });
+});

--- a/frontend/src/v2/__tests__/V2ThreadDeliveryHint.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDeliveryHint.test.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import V2PodChat from '../components/V2PodChat';
+import V2Thread from '../components/V2Thread';
 import { AuthContext } from '../../context/AuthContext';
 
 let mockSocketValue = { socket: null, connected: false };
@@ -79,7 +79,7 @@ const DeliveryHarness = ({ response, sendSpy, agents = DEFAULT_AGENTS }) => {
     error: null,
     refresh: jest.fn(),
   };
-  return <V2PodChat detail={detail} />;
+  return <V2Thread detail={detail} />;
 };
 
 const renderHarness = (response, sendSpy = jest.fn()) => render(
@@ -97,7 +97,7 @@ const sendDraft = (content) => {
   fireEvent.click(screen.getByRole('button', { name: /send message/i }));
 };
 
-describe('V2PodChat agent delivery hint', () => {
+describe('V2Thread agent delivery hint', () => {
   test('shows a real-agent example after a zero-enqueued send', async () => {
     const response = makeMessage('hello room', {
       enqueued: 0, implicit: [], agentsInPod: 1,

--- a/frontend/src/v2/__tests__/V2ThreadStarter.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadStarter.test.tsx
@@ -5,7 +5,7 @@ import {
 } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
-import V2PodChat from '../components/V2PodChat';
+import V2Thread from '../components/V2Thread';
 import { AuthContext } from '../../context/AuthContext';
 
 // SocketContext exports only the provider + hook (no raw context object),
@@ -15,10 +15,10 @@ jest.mock('../../context/SocketContext', () => ({
   useSocket: () => ({ socket: null, connected: false }),
 }));
 
-jest.mock('../components/V2MessageBubble', () => {
-  const MockV2MessageBubble = () => <div>Rendered message</div>;
-  MockV2MessageBubble.displayName = 'MockV2MessageBubble';
-  return MockV2MessageBubble;
+jest.mock('../components/V2MessageRow', () => {
+  const MockV2MessageRow = () => <div>Rendered message</div>;
+  MockV2MessageRow.displayName = 'MockV2MessageRow';
+  return MockV2MessageRow;
 });
 
 // jsdom has no scrollIntoView; the component auto-scrolls on mount.
@@ -75,7 +75,7 @@ const makeDetail = (overrides = {}) => ({
 const renderChat = (detail, props = {}) => render(
   <AuthContext.Provider value={authValue}>
     <MemoryRouter>
-      <V2PodChat detail={detail} {...props} />
+      <V2Thread detail={detail} {...props} />
     </MemoryRouter>
   </AuthContext.Provider>,
 );
@@ -90,7 +90,7 @@ const makeAgentRoom = (overrides = {}) => makeDetail({
   ...overrides,
 });
 
-describe('V2PodChat teaching empty states', () => {
+describe('V2Thread teaching empty states', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     sessionStorage.clear();
@@ -130,7 +130,7 @@ describe('V2PodChat teaching empty states', () => {
   });
 });
 
-describe('V2PodChat starter prompts', () => {
+describe('V2Thread starter prompts', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     sessionStorage.clear();
@@ -179,7 +179,7 @@ describe('V2PodChat starter prompts', () => {
   });
 });
 
-describe('V2PodChat agent-room liveness', () => {
+describe('V2Thread agent-room liveness', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     axios.get.mockResolvedValue({ data: { agents: [] } });
@@ -239,7 +239,7 @@ describe('V2PodChat agent-room liveness', () => {
     view.rerender(
       <AuthContext.Provider value={authValue}>
         <MemoryRouter>
-          <V2PodChat detail={{ ...detail, messages: [sent, reply] }} />
+          <V2Thread detail={{ ...detail, messages: [sent, reply] }} />
         </MemoryRouter>
       </AuthContext.Provider>,
     );
@@ -280,7 +280,7 @@ describe('V2PodChat agent-room liveness', () => {
   });
 });
 
-describe('V2PodChat just-created Pod starter panel', () => {
+describe('V2Thread just-created Pod starter panel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     sessionStorage.clear();

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -145,6 +145,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(lastRuleBody(v2, '.v2-shell')).toContain('padding: 14px');
   });
 
+  test('the workspace keeps each artboard column width declared exactly once', () => {
+    // cssVariable() intentionally reads the first match, so it would miss a
+    // later media override. Only the chat track may contract before phone.
+    for (const name of ['--v2-rail-w', '--v2-pods-w', '--v2-inspector-w']) {
+      expect(v2.match(new RegExp(`${name}\\s*:`, 'g')) || []).toHaveLength(1);
+    }
+  });
+
   test('the compact rail uses the artboard’s 32px square marks inside the 56px column', () => {
     const rail = ruleBody(v2, '.v2-rail');
     const brand = ruleBody(v2, '.v2-rail__brand-icon');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -62,6 +62,19 @@ const cssVariable = (css: string, name: string): string | undefined => (
   new RegExp(`${name}\\s*:\\s*([^;]+);`).exec(css)?.[1].trim()
 );
 
+const activeAccentBackgroundSelectors = (css: string, classNames: Set<string>): string[] => (
+  [...new Set(Array.from(css.matchAll(/([^{}]+)\{([^{}]*)\}/g)).flatMap(([, rawSelector, body]) => {
+    if (!/background\s*:\s*var\(--v2-accent\)/.test(body)) return [];
+    return rawSelector
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split(',')
+      .map((selector) => selector.trim().replace(/:hover(?::[^\s.{]+)?/g, ''))
+      .filter((selector) => Array.from(classNames).some((className) => (
+        new RegExp(`\\.${className}(?![\\w-])`).test(selector)
+      )));
+  }))].sort()
+);
+
 // App.css is shared by legacy V1 and v2. A leading element selector in V1
 // styles crosses that boundary unless it is rooted beneath the legacy canvas.
 // Keep html/body as the two deliberate document-level exceptions.
@@ -92,6 +105,8 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   const messageRow = read('../components/V2MessageRow.tsx');
   const composer = read('../components/V2Composer.tsx');
   const decisionCard = read('../components/V2DecisionCard.tsx');
+  const navRail = read('../components/V2NavRail.tsx');
+  const threadCard = read('../components/V2ThreadCard.tsx');
   const v2Layout = read('../components/V2Layout.tsx');
   const mobileTabs = read('../components/V2MobileTabs.tsx');
   const podBoard = read('../components/V2PodBoard.tsx');
@@ -763,7 +778,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(podChat).toContain('podChat.header.agentsWorking');
     expect(podChat).toContain('v2-thread__inspector-toggle');
     expect(ruleBody(v2, '.v2-thread__header')).toContain('border-bottom: 1px solid var(--v2-border-soft)');
-    expect(ruleBody(v2, '.v2-thread__title h1')).toContain('font: 700 22px/28px var(--v2-font)');
+    expect(ruleBody(v2, '.v2-thread__title h1')).toContain('font: 700 22px/28px var(--v2-font-display)');
     expect(ruleBody(v2, '.v2-thread__working')).toContain('font: 500 11px/16px var(--v2-font-mono)');
   });
 
@@ -776,6 +791,46 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(mobileTabs).toContain('onOpenInspector');
     expect(mobileTabs).toContain("navigate('/v2/settings')");
     expect(v2Layout).toContain('<V2MobileTabs');
+  });
+
+  test('workspace thread rows retain the artboard grammar at desktop and phone widths', () => {
+    const title = ruleBody(v2, '.v2-thread__title h1');
+    const avatarRule = ruleBody(v2, '.v2-thread .v2-avatar');
+    const time = ruleBody(v2, '.v2-thread .v2-msg__time');
+    const actions = ruleBody(v2, '.v2-thread .v2-msg__actions');
+    expect(title).toContain('var(--v2-font-display)');
+    expect(avatarRule).toContain('width: 28px');
+    expect(avatarRule).toContain('border-radius: 4px');
+    expect(avatarRule).toContain('border: 0');
+    expect(avatarRule).toContain('box-shadow: none');
+    expect(time).toContain('font: 500 11px/16px var(--v2-font-mono)');
+    expect(actions).toContain('border-radius: 4px');
+    expect(actions).toContain('box-shadow: none');
+
+    const phoneStart = v2.lastIndexOf(
+      '@media (max-width: 760px)',
+      v2.lastIndexOf('/* The workspace is edge-to-edge on a phone'),
+    );
+    const phone = v2.slice(phoneStart);
+    expect(phone).toContain('.v2-decision-card__options { align-items: stretch; flex-direction: column; }');
+    expect(phone).toContain('.v2-root button.v2-decision-card__choice { width: 100%; min-height: 44px; font-size: 15px; }');
+    expect(phone).toContain('.v2-root button.v2-chat__mobile-nav-btn');
+    expect(phone).toContain('border: 1px solid var(--v2-border)');
+  });
+
+  test('phone drawer and inspector sheet are mutually exclusive overlays', () => {
+    // Both panels are fixed overlays at 390px. Leaving the sheet open while
+    // mounting the drawer puts the latter underneath an inert hit target.
+    const mobileNavOpener = v2Layout.slice(
+      v2Layout.indexOf('const openMobileNav = useCallback(() => {'),
+      v2Layout.indexOf('const closeMobileNav', v2Layout.indexOf('const openMobileNav = useCallback(() => {')),
+    );
+    const inspectorOpener = v2Layout.slice(
+      v2Layout.indexOf('const openInspector = useCallback(() => {'),
+      v2Layout.indexOf('// File pills', v2Layout.indexOf('const openInspector = useCallback(() => {')),
+    );
+    expect(mobileNavOpener).toContain('setInspectorCollapsed(true);');
+    expect(inspectorOpener).toContain('setMobileNavOpen(false);');
   });
 
   test('Activity cards have shrinkable desktop and mobile layout guards', () => {
@@ -997,6 +1052,37 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(other).toContain('color: var(--v2-accent-text)');
       expect(other).toContain('border: 0');
       expect(other).not.toContain('background: var(--v2-accent)');
+    });
+
+    test('workspace cobalt backgrounds are a reviewed role allowlist: two blocks and five marks', () => {
+      // A class used by the route that gains an accent background joins this
+      // set automatically, so a seventh/extra fill fails instead of hiding in
+      // stale stylesheet rules. Inspector state classes are generated from the
+      // state kind, hence the two explicit additions below.
+      const workspaceSource = [
+        navRail,
+        podsSidebar,
+        thread,
+        threadCard,
+        workspaceInspector,
+        decisionCard,
+        composer,
+        messageRow,
+      ].join('\n');
+      const activeClasses = new Set(Array.from(workspaceSource.matchAll(/\bv2-[\w-]+/g), ([className]) => className));
+      activeClasses.add('v2-workspace-inspector__state--needs-you');
+      activeClasses.add('v2-workspace-inspector__state--working');
+
+      const cobalt = activeAccentBackgroundSelectors(v2, activeClasses);
+      expect(cobalt).toEqual([
+        '.v2-pods__channel-dot--live',
+        '.v2-rail__brand-icon',
+        '.v2-root button.v2-decision-card__choice--primary',
+        '.v2-root button.v2-pods__row--selected',
+        '.v2-thread-card__dot',
+        '.v2-workspace-inspector__state--needs-you',
+        '.v2-workspace-inspector__state--working',
+      ]);
     });
 
     test('a ruled in-thread decision drops back to a muted transcript label, not a second card', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -806,6 +806,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(time).toContain('font: 500 11px/16px var(--v2-font-mono)');
     expect(actions).toContain('border-radius: 4px');
     expect(actions).toContain('box-shadow: none');
+    // These scoped rules only take effect when the chat mounts the thread
+    // surface class; without it the legacy 30px circular avatar rules win.
+    expect(thread).toContain('className="v2-chat v2-thread"');
 
     const phoneStart = v2.lastIndexOf(
       '@media (max-width: 760px)',

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -400,6 +400,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(workspaceInspector).toContain("'inspector.workspace.agentsIn'");
     expect(workspaceInspector).toContain("'inspector.workspace.needsYou'");
     expect(workspaceInspector).toContain("'inspector.workspace.boardToday'");
+    expect(workspaceInspector).toContain('shortRoomName(pod.name).toLowerCase()');
     expect(workspaceInspector).toContain('v2-workspace-inspector__state--${state.kind}');
     expect(workspaceInspector).not.toContain('v2-inspector__tabs');
     expect(workspaceInspector).not.toContain('v2-inspector__progress');
@@ -415,6 +416,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     const avatar = ruleBody(v2, '.v2-workspace-inspector__avatar.v2-avatar');
     expect(avatar).toContain('border: 0');
     expect(avatar).toContain('box-shadow: none');
+    const label = ruleBody(v2, '.v2-workspace-inspector__label');
+    expect(label).toContain('font: 500 11px/14px var(--v2-font-mono)');
+    expect(label).toContain('white-space: nowrap');
+    expect(label).toContain('text-overflow: clip');
     const foot = selectorRuleBody(v2, '.v2-root .v2-workspace-inspector__foot button');
     expect(foot).toContain('var(--v2-font-mono)');
     const close = selectorRuleBody(v2, '.v2-root button.v2-workspace-inspector__close');
@@ -788,6 +793,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-thread__header')).toContain('border-bottom: 1px solid var(--v2-border-soft)');
     expect(ruleBody(v2, '.v2-thread__title h1')).toContain('font: 700 22px/28px var(--v2-font-display)');
     expect(ruleBody(v2, '.v2-thread__working')).toContain('font: 500 11px/16px var(--v2-font-mono)');
+    expect(ruleBody(v2, '.v2-thread__working::before')).toContain('color: var(--v2-text-muted)');
+    expect(ruleBody(v2, '.v2-thread__working--active::before')).toContain('color: var(--v2-accent)');
+    expect(thread).toContain("onlineAgentCount > 0 ? ' v2-thread__working--active' : ''");
   });
 
   test('the phone workspace is an edge-to-edge thread with reachable drawers and a real tab bar', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -83,9 +83,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   const tokens = read('../../../design-system/tokens.css');
   const aprofile = read('../agents/v2-agent-profile.css');
   const landing = read('../landing/v2-landing.css');
-  const podChat = read('../components/V2PodChat.tsx');
+  const podChat = read('../components/V2Thread.tsx');
   const podsSidebar = read('../components/V2PodsSidebar.tsx');
   const workspaceInspector = read('../components/V2Inspector.tsx');
+  const thread = read('../components/V2Thread.tsx');
+  const threadMessages = read('../components/V2ThreadMessages.tsx');
+  const messageRow = read('../components/V2MessageRow.tsx');
+  const composer = read('../components/V2Composer.tsx');
+  const decisionCard = read('../components/V2DecisionCard.tsx');
   const v2Layout = read('../components/V2Layout.tsx');
   const podBoard = read('../components/V2PodBoard.tsx');
   const activityPage = read('../components/V2ActivityPage.tsx');
@@ -231,12 +236,23 @@ describe('v2 layout invariants (CSS rule presence)', () => {
 
   test('grouped messages keep the avatar column so text never shifts (craft audit rule 3)', () => {
     // Consecutive same-author messages within the grouping window drop the
-    // header row; the ghost cell must match the .v2-msg grid's 38px avatar
+    // header row; the ghost cell must match the artboard's 28px avatar
     // column or grouped text mis-aligns with headed text by exactly the
     // avatar width — a defect jsdom cannot see.
-    expect(ruleBody(v2, '.v2-msg')).toContain('grid-template-columns: 38px');
-    expect(ruleBody(v2, '.v2-msg__avatar-ghost')).toContain('width: 38px');
+    expect(ruleBody(v2, '.v2-thread .v2-msg')).toContain('grid-template-columns: 28px');
+    expect(ruleBody(v2, '.v2-thread .v2-msg__avatar-ghost')).toContain('width: 28px');
     expect(v2).toContain('.v2-msg--grouped');
+  });
+
+  test('the workspace route uses the small replacement components, never the retired chat or bubble files', () => {
+    expect(fs.existsSync(path.join(__dirname, '../components/V2PodChat.tsx'))).toBe(false);
+    expect(fs.existsSync(path.join(__dirname, '../components/V2MessageBubble.tsx'))).toBe(false);
+    expect(thread).toContain("import V2ThreadMessages from './V2ThreadMessages'");
+    expect(threadMessages).toContain("import V2MessageRow from './V2MessageRow'");
+    expect(thread).toContain("import V2Composer");
+    expect(messageRow).toContain("import V2DecisionCard");
+    expect(composer).toContain('const V2Composer');
+    expect(decisionCard).toContain('const V2DecisionCard');
   });
 
   test('direct-agent liveness stays above the composer as a stable, readable row', () => {
@@ -448,7 +464,8 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // of rows and recreates the v1 island.
     expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('width: 100%');
     expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('margin-inline: 0');
-    expect(ruleBody(v2, '.v2-chat__composer > *')).toContain('margin-inline: 0');
+    expect(ruleBody(v2, '.v2-composer')).toContain('border: 1px solid var(--v2-border)');
+    expect(ruleBody(v2, '.v2-composer__posts-as')).toContain('font: 500 11px/16px var(--v2-font-mono)');
     // Nothing in the column may escape the shared edge (Sam, 2026-08-23:
     // mentions and threads sat off-grid while messages aligned).
     // Mentions: the wash bleed must equal the padding (the old -12px against
@@ -735,12 +752,11 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(podBoard).not.toContain('+ {t(\'board.newTask\')}');
   });
 
-  test('the chat heartbeat subtitle is guarded by an installed agent', () => {
-    // A zero-agent pod has nobody expected to heartbeat; showing "No recent"
-    // there was a false failure state. Pin both the predicate and its render
-    // guard so a later copy-only edit cannot restore the dangling separator.
-    expect(podChat).toContain('const liveState = agents.length > 0');
-    expect(podChat).toContain('{liveState && <span className="v2-chat__goal-meta"> · {liveState}</span>}');
+  test('the thread header is the artboard’s name, muted description, and working count', () => {
+    expect(podChat).toContain('className="v2-thread__header"');
+    expect(podChat).toContain('podChat.header.agentsWorking');
+    expect(ruleBody(v2, '.v2-thread__header')).toContain('border-bottom: 1px solid var(--v2-border-soft)');
+    expect(ruleBody(v2, '.v2-thread__working')).toContain('font: 500 11px/16px var(--v2-font-mono)');
   });
 
   test('Activity cards have shrinkable desktop and mobile layout guards', () => {
@@ -947,6 +963,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
         expect(rule).toContain('var(--v2-ink)');
         expect(rule).not.toContain('var(--v2-accent)');
       }
+    });
+
+    test('the pending human decision is the one cobalt action surface', () => {
+      const card = ruleBody(v2, '.v2-decision-card');
+      const recommended = selectorRuleBody(v2, '.v2-root button.v2-decision-card__choice--recommended');
+      expect(card).toContain('box-shadow: 0 0 0 2px var(--v2-accent)');
+      expect(recommended).toContain('background: var(--v2-accent)');
+      expect(recommended).not.toContain('var(--v2-ink)');
     });
 
     test('chat and workspace-inspector surfaces do not paint with accent-soft', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -804,6 +804,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   test('workspace thread rows retain the artboard grammar at desktop and phone widths', () => {
     const title = ruleBody(v2, '.v2-thread__title h1');
     const avatarRule = ruleBody(v2, '.v2-thread .v2-avatar');
+    const author = selectorRuleBody(v2, '.v2-thread .v2-msg__author');
     const time = ruleBody(v2, '.v2-thread .v2-msg__time');
     const actions = ruleBody(v2, '.v2-thread .v2-msg__actions');
     expect(title).toContain('var(--v2-font-display)');
@@ -811,7 +812,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(avatarRule).toContain('border-radius: 4px');
     expect(avatarRule).toContain('border: 0');
     expect(avatarRule).toContain('box-shadow: none');
-    expect(time).toContain('font: 500 11px/16px var(--v2-font-mono)');
+    expect(author).toContain('font-size: 14px');
+    expect(author).toContain('font-weight: 600');
+    expect(time).toContain('font: 500 12px/16px var(--v2-font-mono)');
     expect(actions).toContain('border-radius: 4px');
     expect(actions).toContain('box-shadow: none');
     // These scoped rules only take effect when the chat mounts the thread

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -986,15 +986,16 @@ describe('v2 layout invariants (CSS rule presence)', () => {
 
     test('the pending human decision is the sole cobalt-filled action exception: one primary choice, bordered alternatives, and a text-only Other action', () => {
       const card = ruleBody(v2, '.v2-decision-card');
-      const recommended = selectorRuleBody(v2, '.v2-root button.v2-decision-card__choice--recommended');
+      const primary = selectorRuleBody(v2, '.v2-root button.v2-decision-card__choice--primary');
       const ordinaryChoice = selectorRuleBody(v2, '.v2-root button.v2-decision-card__choice,');
       const other = ruleBody(v2, '.v2-root button.v2-decision-card__other');
       expect(card).toContain('box-shadow: 0 0 0 2px var(--v2-accent)');
-      expect(recommended).toContain('background: var(--v2-accent)');
-      expect(recommended).not.toContain('var(--v2-ink)');
+      expect(primary).toContain('background: var(--v2-accent)');
+      expect(primary).not.toContain('var(--v2-ink)');
       expect(ordinaryChoice).toContain('border: 1px solid var(--v2-border)');
       expect(ordinaryChoice).not.toContain('background: var(--v2-accent)');
       expect(other).toContain('color: var(--v2-accent-text)');
+      expect(other).toContain('border: 0');
       expect(other).not.toContain('background: var(--v2-accent)');
     });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -85,6 +85,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   const landing = read('../landing/v2-landing.css');
   const podChat = read('../components/V2Thread.tsx');
   const podsSidebar = read('../components/V2PodsSidebar.tsx');
+  const podAttention = read('../hooks/useV2PodAttention.ts');
   const workspaceInspector = read('../components/V2Inspector.tsx');
   const thread = read('../components/V2Thread.tsx');
   const threadMessages = read('../components/V2ThreadMessages.tsx');
@@ -92,6 +93,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   const composer = read('../components/V2Composer.tsx');
   const decisionCard = read('../components/V2DecisionCard.tsx');
   const v2Layout = read('../components/V2Layout.tsx');
+  const mobileTabs = read('../components/V2MobileTabs.tsx');
   const podBoard = read('../components/V2PodBoard.tsx');
   const activityPage = read('../components/V2ActivityPage.tsx');
   const v2App = read('../V2App.tsx');
@@ -185,10 +187,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(podsSidebar).not.toContain('v2-pods__item-dot');
   });
 
-  test('the selected-room count is derived from the decision queue, not a second unread path', () => {
-    expect(podsSidebar).toContain("'/api/activity/decision-queue'");
+  test('the selected-room count, inspector rows, and phone badge derive from one attention collection', () => {
+    expect(podAttention).toContain("'/api/activity/decision-queue'");
+    expect(v2Layout).toContain('useV2PodAttention()');
+    expect(v2Layout).toContain('attentionItems={attention.items}');
+    expect(v2Layout).toContain('needsYouCount={selectedPodId ? (attention.countByPod[selectedPodId] || 0) : 0}');
     expect(podsSidebar).toContain('attentionCountByPod');
     expect(podsSidebar).toContain('selected && attentionCount > 0');
+    expect(workspaceInspector).toContain('attentionItems.filter');
     expect(podsSidebar).not.toContain('useV2Unread');
   });
 
@@ -755,8 +761,21 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   test('the thread header is the artboard’s name, muted description, and working count', () => {
     expect(podChat).toContain('className="v2-thread__header"');
     expect(podChat).toContain('podChat.header.agentsWorking');
+    expect(podChat).toContain('v2-thread__inspector-toggle');
     expect(ruleBody(v2, '.v2-thread__header')).toContain('border-bottom: 1px solid var(--v2-border-soft)');
+    expect(ruleBody(v2, '.v2-thread__title h1')).toContain('font: 700 22px/28px var(--v2-font)');
     expect(ruleBody(v2, '.v2-thread__working')).toContain('font: 500 11px/16px var(--v2-font-mono)');
+  });
+
+  test('the phone workspace is an edge-to-edge thread with reachable drawers and a real tab bar', () => {
+    expect(v2).toContain('.v2-pane--rail { display: none; }');
+    expect(v2).toContain('.v2-thread__working--mobile { display: block; color: var(--v2-accent-text); }');
+    expect(v2).toContain('.v2-mobile-tabs__badge');
+    expect(ruleBody(v2, '.v2-root button.v2-mobile-tabs__item')).toContain('width: 44px');
+    expect(ruleBody(v2, '.v2-root button.v2-mobile-tabs__item')).toContain('height: 32px');
+    expect(mobileTabs).toContain('onOpenInspector');
+    expect(mobileTabs).toContain("navigate('/v2/settings')");
+    expect(v2Layout).toContain('<V2MobileTabs');
   });
 
   test('Activity cards have shrinkable desktop and mobile layout guards', () => {
@@ -792,8 +811,8 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   });
 
   test('starter prompts wrap within the mobile chat pane', () => {
-    // At 390px the rail leaves a narrow main pane. Both the row and each chip
-    // need explicit shrink/wrap rules or the longest prompt creates horizontal
+    // On the edge-to-edge phone thread, both the row and each chip need
+    // explicit shrink/wrap rules or the longest prompt creates horizontal
     // overflow and pushes the composer action off-screen.
     const row = ruleBody(v2, '.v2-chat__starter-prompts');
     const chip = ruleBody(v2, '.v2-root button.v2-chat__starter-prompt');
@@ -977,6 +996,15 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(ordinaryChoice).not.toContain('background: var(--v2-accent)');
       expect(other).toContain('color: var(--v2-accent-text)');
       expect(other).not.toContain('background: var(--v2-accent)');
+    });
+
+    test('a ruled in-thread decision drops back to a muted transcript label, not a second card', () => {
+      expect(thread).toContain('settledDecisionByMessageId');
+      expect(threadMessages).toContain('isDecisionRuling={Boolean(settledRuling)}');
+      expect(messageRow).toContain("t('activity.decision.ruledShort')");
+      const ruled = ruleBody(v2, '.v2-msg__ruled');
+      expect(ruled).toContain('color: var(--v2-text-muted)');
+      expect(ruled).toContain('var(--v2-font-mono)');
     });
 
     test('chat and workspace-inspector surfaces do not paint with accent-soft', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -965,12 +965,18 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       }
     });
 
-    test('the pending human decision is the one cobalt action surface', () => {
+    test('the pending human decision is the sole cobalt-filled action exception: one primary choice, bordered alternatives, and a text-only Other action', () => {
       const card = ruleBody(v2, '.v2-decision-card');
       const recommended = selectorRuleBody(v2, '.v2-root button.v2-decision-card__choice--recommended');
+      const ordinaryChoice = selectorRuleBody(v2, '.v2-root button.v2-decision-card__choice,');
+      const other = ruleBody(v2, '.v2-root button.v2-decision-card__other');
       expect(card).toContain('box-shadow: 0 0 0 2px var(--v2-accent)');
       expect(recommended).toContain('background: var(--v2-accent)');
       expect(recommended).not.toContain('var(--v2-ink)');
+      expect(ordinaryChoice).toContain('border: 1px solid var(--v2-border)');
+      expect(ordinaryChoice).not.toContain('background: var(--v2-accent)');
+      expect(other).toContain('color: var(--v2-accent-text)');
+      expect(other).not.toContain('background: var(--v2-accent)');
     });
 
     test('chat and workspace-inspector surfaces do not paint with accent-soft', () => {

--- a/frontend/src/v2/components/V2Composer.tsx
+++ b/frontend/src/v2/components/V2Composer.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import V2Avatar from './V2Avatar';
+import type { V2Message } from '../hooks/useV2PodDetail';
+
+export interface V2ComposerMention {
+  id: string;
+  label: string;
+  subtitle: string;
+  avatar?: string | null;
+  value: string;
+}
+
+export interface V2ComposerWarning {
+  agentName: string;
+  state: 'gone-dark' | 'never-connected';
+  fixCommand?: string;
+}
+
+interface V2ComposerProps {
+  podName: string;
+  authorName: string;
+  draft: string;
+  sending: boolean;
+  uploading: boolean;
+  sendError?: string | null;
+  composerError?: string | null;
+  replyTarget: V2Message | null;
+  threadTarget: { id: string; preview: string } | null;
+  mentionOpen: boolean;
+  mentionIndex: number;
+  mentions: V2ComposerMention[];
+  warnings: V2ComposerWarning[];
+  inputRef: React.RefObject<HTMLTextAreaElement>;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  mentionDropdownRef: React.RefObject<HTMLDivElement>;
+  onDraftChange: (value: string, cursor: number | null) => void;
+  onDraftPointer: (value: string, cursor: number | null) => void;
+  onKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement>;
+  onMentionSelect: (item: V2ComposerMention) => void;
+  onSend: () => void;
+  onAttach: (file: File | null) => void;
+  onCancelReply: () => void;
+  onCancelThread: () => void;
+}
+
+/** The one bounded input surface for a workspace thread. */
+const V2Composer: React.FC<V2ComposerProps> = ({
+  podName,
+  authorName,
+  draft,
+  sending,
+  uploading,
+  sendError,
+  composerError,
+  replyTarget,
+  threadTarget,
+  mentionOpen,
+  mentionIndex,
+  mentions,
+  warnings,
+  inputRef,
+  fileInputRef,
+  mentionDropdownRef,
+  onDraftChange,
+  onDraftPointer,
+  onKeyDown,
+  onMentionSelect,
+  onSend,
+  onAttach,
+  onCancelReply,
+  onCancelThread,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <div className="v2-composer">
+      {threadTarget && (
+        <div className="v2-composer__target" role="status">
+          <span>{t('podChat.thread.replyingInThread')} {threadTarget.preview.replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 40)}</span>
+          <button type="button" aria-label={t('podChat.cancelReply')} onClick={onCancelThread}>×</button>
+        </div>
+      )}
+      {replyTarget && (
+        <div className="v2-composer__target" role="status">
+          <span>
+            <Trans
+              i18nKey="podChat.replyingTo"
+              values={{ author: replyTarget.user?.username || t('podChat.messageFallback') }}
+              components={{ author: <strong /> }}
+            />{' '}
+            {String(replyTarget.content || '').replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 80)}
+          </span>
+          <button type="button" aria-label={t('podChat.cancelReply')} onClick={onCancelReply}>×</button>
+        </div>
+      )}
+      <div className="v2-composer__field">
+        <textarea
+          ref={inputRef}
+          placeholder={t('podChat.composer.placeholder', { podName })}
+          value={draft}
+          rows={2}
+          onChange={(event) => onDraftChange(event.target.value, event.target.selectionStart)}
+          onClick={(event) => onDraftPointer(event.currentTarget.value, event.currentTarget.selectionStart)}
+          onKeyUp={(event) => onDraftPointer(event.currentTarget.value, event.currentTarget.selectionStart)}
+          onKeyDown={onKeyDown}
+        />
+        {mentionOpen && mentions.length > 0 && (
+          <div className="v2-mention-dropdown" ref={mentionDropdownRef} role="listbox">
+            {mentions.map((item, index) => (
+              <button
+                type="button"
+                key={item.id}
+                className={`v2-mention-item${index === mentionIndex ? ' v2-mention-item--active' : ''}`}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => onMentionSelect(item)}
+                role="option"
+                aria-selected={index === mentionIndex}
+              >
+                <V2Avatar name={item.label} src={item.avatar || undefined} size="sm" />
+                <span className="v2-mention-item__text">
+                  <span className="v2-mention-item__label">@{item.value || item.label}</span>
+                  <span className="v2-mention-item__sub">{item.subtitle}</span>
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*,.pdf,.md,.txt,.csv,.json,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.zip"
+          className="v2-composer__file"
+          onChange={(event) => onAttach(event.target.files?.[0] || null)}
+        />
+        <div className="v2-composer__actions">
+          <button
+            type="button"
+            className="v2-composer__attach"
+            title={uploading ? t('podChat.composer.uploading') : t('podChat.composer.attachFile')}
+            aria-label={t('podChat.composer.attachFile')}
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 11l-9 9a5 5 0 01-7-7l9-9a3 3 0 014 4l-9 9a1 1 0 01-2-2l8-8" /></svg>
+          </button>
+          <span className="v2-composer__posts-as">{t('podChat.composer.postsAs', { name: authorName })} · ⌘↵</span>
+          <button
+            type="button"
+            className="v2-composer__send"
+            onClick={onSend}
+            disabled={sending || !draft.trim()}
+            aria-label={sending ? t('podChat.composer.sending') : t('podChat.composer.sendAria')}
+          >
+            {sending ? t('podChat.composer.sending') : t('podChat.composer.send')}
+          </button>
+        </div>
+      </div>
+      {(composerError || sendError) && <p className="v2-composer__error">{composerError || sendError}</p>}
+      {warnings.length > 0 && (
+        <div className="v2-composer__warnings" data-testid="mention-state-warning">
+          {warnings.map((warning) => (
+            <span key={warning.agentName}>
+              {warning.state === 'never-connected'
+                ? (warning.fixCommand
+                  ? t('podChat.mentionState.neverOwner', { handle: warning.agentName, command: warning.fixCommand })
+                  : t('podChat.mentionState.neverPeer', { handle: warning.agentName }))
+                : (warning.fixCommand
+                  ? t('podChat.mentionState.darkOwner', { handle: warning.agentName, command: warning.fixCommand })
+                  : t('podChat.mentionState.darkPeer', { handle: warning.agentName }))}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default V2Composer;

--- a/frontend/src/v2/components/V2DecisionCard.tsx
+++ b/frontend/src/v2/components/V2DecisionCard.tsx
@@ -16,9 +16,16 @@ export interface V2DecisionCardData {
   options: V2DecisionOption[];
 }
 
+export interface V2DecisionRuling {
+  value: string;
+  by?: string;
+  at?: string;
+  messageId?: string;
+}
+
 interface V2DecisionCardProps {
   decision: V2DecisionCardData;
-  onRuled?: (decisionId: string, ruling: { value: string; by?: string }) => void;
+  onRuled?: (decisionId: string, ruling: V2DecisionRuling) => void;
 }
 
 /**
@@ -29,7 +36,7 @@ interface V2DecisionCardProps {
 const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) => {
   const { t } = useTranslation();
   const api = useV2Api();
-  const [ruling, setRuling] = useState<{ value: string; by?: string } | null>(null);
+  const [ruling, setRuling] = useState<V2DecisionRuling | null>(null);
   const [otherOpen, setOtherOpen] = useState(false);
   const [otherValue, setOtherValue] = useState('');
   const [saving, setSaving] = useState(false);
@@ -42,19 +49,29 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
     setError(null);
     try {
       const response = await api.post<{
-        decision?: { ruling?: { value?: string; by?: string } | null };
+        decision?: { ruling?: V2DecisionRuling | null };
       }>(`/api/activity/decisions/${encodeURIComponent(decision.id)}/choose`, { value: trimmed });
       const settled = response?.decision?.ruling;
-      const next = { value: settled?.value || trimmed, ...(settled?.by ? { by: settled.by } : {}) };
+      const next = {
+        value: settled?.value || trimmed,
+        ...(settled?.by ? { by: settled.by } : {}),
+        ...(settled?.at ? { at: settled.at } : {}),
+        ...(settled?.messageId ? { messageId: settled.messageId } : {}),
+      };
       setRuling(next);
       onRuled?.(decision.id, next);
     } catch (caught) {
       const response = (caught as {
-        response?: { status?: number; data?: { decision?: { ruling?: { value?: string; by?: string } } } };
+        response?: { status?: number; data?: { decision?: { ruling?: V2DecisionRuling } } };
       }).response;
       const standing = response?.data?.decision?.ruling;
       if (response?.status === 409 && standing?.value) {
-        const next = { value: standing.value, ...(standing.by ? { by: standing.by } : {}) };
+        const next = {
+          value: standing.value,
+          ...(standing.by ? { by: standing.by } : {}),
+          ...(standing.at ? { at: standing.at } : {}),
+          ...(standing.messageId ? { messageId: standing.messageId } : {}),
+        };
         setRuling(next);
         onRuled?.(decision.id, next);
       } else {
@@ -77,7 +94,7 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
       {decision.detail && <p className="v2-decision-card__question">{decision.detail}</p>}
       {ruling ? (
         <p className="v2-decision-card__settled" role="status">
-          {t('activity.decision.ruled', ruling)}
+          {t('activity.decision.ruled', { by: ruling.by, value: ruling.value })}
         </p>
       ) : (
         <div className="v2-decision-card__options">

--- a/frontend/src/v2/components/V2DecisionCard.tsx
+++ b/frontend/src/v2/components/V2DecisionCard.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useV2Api } from '../hooks/useV2Api';
+
+export interface V2DecisionOption {
+  label: string;
+  description?: string;
+  recommended?: boolean;
+}
+
+export interface V2DecisionCardData {
+  id: string;
+  title: string;
+  detail?: string;
+  actorName?: string;
+  options: V2DecisionOption[];
+}
+
+interface V2DecisionCardProps {
+  decision: V2DecisionCardData;
+  onRuled?: (decisionId: string, ruling: { value: string; by?: string }) => void;
+}
+
+/**
+ * The in-thread face of an agent DecisionRequest. The decision is durable
+ * server state: a successful choice settles from the response, and a 409
+ * shows the standing ruling rather than inviting a second choice.
+ */
+const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) => {
+  const { t } = useTranslation();
+  const api = useV2Api();
+  const [ruling, setRuling] = useState<{ value: string; by?: string } | null>(null);
+  const [otherOpen, setOtherOpen] = useState(false);
+  const [otherValue, setOtherValue] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const choose = async (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed || saving || ruling) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await api.post<{
+        decision?: { ruling?: { value?: string; by?: string } | null };
+      }>(`/api/activity/decisions/${encodeURIComponent(decision.id)}/choose`, { value: trimmed });
+      const settled = response?.decision?.ruling;
+      const next = { value: settled?.value || trimmed, ...(settled?.by ? { by: settled.by } : {}) };
+      setRuling(next);
+      onRuled?.(decision.id, next);
+    } catch (caught) {
+      const response = (caught as {
+        response?: { status?: number; data?: { decision?: { ruling?: { value?: string; by?: string } } } };
+      }).response;
+      const standing = response?.data?.decision?.ruling;
+      if (response?.status === 409 && standing?.value) {
+        const next = { value: standing.value, ...(standing.by ? { by: standing.by } : {}) };
+        setRuling(next);
+        onRuled?.(decision.id, next);
+      } else {
+        setError(t('activity.decision.actionFailed'));
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const options = [...decision.options]
+    .sort((left, right) => Number(Boolean(right.recommended)) - Number(Boolean(left.recommended)));
+
+  return (
+    <article className={`v2-decision-card${ruling ? ' v2-decision-card--ruled' : ''}`} data-testid="decision-card">
+      <div className="v2-decision-card__head">
+        {decision.actorName && <span className="v2-decision-card__agent">{decision.actorName}</span>}
+        <h3>{decision.title}</h3>
+      </div>
+      {decision.detail && <p className="v2-decision-card__question">{decision.detail}</p>}
+      {ruling ? (
+        <p className="v2-decision-card__settled" role="status">
+          {t('activity.decision.ruled', ruling)}
+        </p>
+      ) : (
+        <div className="v2-decision-card__options">
+          {options.map((option) => (
+            <div className="v2-decision-card__option" key={option.label}>
+              <button
+                type="button"
+                className={option.recommended ? 'v2-decision-card__choice v2-decision-card__choice--recommended' : 'v2-decision-card__choice'}
+                onClick={() => { void choose(option.label); }}
+                disabled={saving}
+              >
+                {saving ? t('activity.decision.working') : option.label}
+              </button>
+              {option.description && <span>{option.description}</span>}
+            </div>
+          ))}
+          <button
+            type="button"
+            className="v2-decision-card__other"
+            onClick={() => setOtherOpen((open) => !open)}
+            disabled={saving}
+          >
+            {t('activity.decision.other')}
+          </button>
+          {otherOpen && (
+            <div className="v2-decision-card__other-form">
+              <input
+                aria-label={t('activity.decision.otherPlaceholder')}
+                value={otherValue}
+                onChange={(event) => setOtherValue(event.target.value)}
+                disabled={saving}
+              />
+              <button type="button" onClick={() => { void choose(otherValue); }} disabled={saving || !otherValue.trim()}>
+                {saving ? t('activity.decision.working') : t('activity.decision.sendOther')}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      {error && <p className="v2-decision-card__error" role="alert">{error}</p>}
+    </article>
+  );
+};
+
+export default V2DecisionCard;

--- a/frontend/src/v2/components/V2DecisionCard.tsx
+++ b/frontend/src/v2/components/V2DecisionCard.tsx
@@ -82,8 +82,10 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
     }
   };
 
-  const options = [...decision.options]
-    .sort((left, right) => Number(Boolean(right.recommended)) - Number(Boolean(left.recommended)));
+  // Option order is part of the asking agent's fork. The artboard gives the
+  // first rendered option the one cobalt action treatment; do not silently
+  // reorder the alternatives around the legacy `recommended` hint.
+  const options = decision.options;
 
   return (
     <article className={`v2-decision-card${ruling ? ' v2-decision-card--ruled' : ''}`} data-testid="decision-card">
@@ -98,11 +100,11 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
         </p>
       ) : (
         <div className="v2-decision-card__options">
-          {options.map((option) => (
+          {options.map((option, index) => (
             <div className="v2-decision-card__option" key={option.label}>
               <button
                 type="button"
-                className={option.recommended ? 'v2-decision-card__choice v2-decision-card__choice--recommended' : 'v2-decision-card__choice'}
+                className={index === 0 ? 'v2-decision-card__choice v2-decision-card__choice--primary' : 'v2-decision-card__choice'}
                 onClick={() => { void choose(option.label); }}
                 disabled={saving}
               >

--- a/frontend/src/v2/components/V2GithubPrCard.tsx
+++ b/frontend/src/v2/components/V2GithubPrCard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 // Inline GitHub PR preview rendered when a message references
 // `https://github.com/<owner>/<repo>/pull/<number>`. Detection lives in
-// V2MessageBubble; this component owns the fetch + render once given the
+// V2MessageRow; this component owns the fetch + render once given the
 // (owner, repo, number) tuple.
 //
 // Fetches via the public GitHub REST API (no auth required for public

--- a/frontend/src/v2/components/V2Inspector.tsx
+++ b/frontend/src/v2/components/V2Inspector.tsx
@@ -5,22 +5,13 @@ import { useTranslation } from 'react-i18next';
 import V2Avatar from './V2Avatar';
 import { UseV2PodDetailResult, V2Agent } from '../hooks/useV2PodDetail';
 import { useV2Api } from '../hooks/useV2Api';
+import { V2AttentionItem } from '../hooks/useV2PodAttention';
 
 interface V2InspectorProps {
   detail: UseV2PodDetailResult;
+  attentionItems?: V2AttentionItem[];
   onClose?: () => void;
   onOpenInvite?: () => void;
-}
-
-interface AttentionItem {
-  id: string;
-  kind: 'mention' | 'approval' | 'decision';
-  title: string;
-  detail?: string;
-  actorName?: string;
-  podId: string;
-  messageId?: string;
-  threadRootId?: string;
 }
 
 interface TaskItem {
@@ -52,7 +43,7 @@ const matchesAgent = (agent: V2Agent, value?: string): boolean => {
 
 const agentState = (
   agent: V2Agent,
-  attention: AttentionItem[],
+  attention: V2AttentionItem[],
   tasks: TaskItem[],
 ): { kind: 'needs-you' | 'working' | 'idle'; title?: string } => {
   const request = attention.find((item) => matchesAgent(agent, item.actorName));
@@ -65,29 +56,16 @@ const agentState = (
   return { kind: 'idle' };
 };
 
-const V2Inspector: React.FC<V2InspectorProps> = ({ detail, onClose, onOpenInvite }) => {
+const V2Inspector: React.FC<V2InspectorProps> = ({ detail, attentionItems = [], onClose, onOpenInvite }) => {
   const { pod, agents } = detail;
   const api = useV2Api();
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const [attention, setAttention] = useState<AttentionItem[]>([]);
   const [tasks, setTasks] = useState<TaskItem[]>([]);
-
-  useEffect(() => {
-    if (!pod?._id) {
-      setAttention([]);
-      return undefined;
-    }
-    let active = true;
-    api.get<{ items?: AttentionItem[] }>('/api/activity/decision-queue')
-      .then((data) => {
-        if (!active) return;
-        const items = Array.isArray(data?.items) ? data.items : [];
-        setAttention(items.filter((item) => item.podId === pod._id));
-      })
-      .catch(() => { if (active) setAttention([]); });
-    return () => { active = false; };
-  }, [api, pod?._id]);
+  const attention = useMemo(
+    () => attentionItems.filter((item) => item.podId === pod?._id),
+    [attentionItems, pod?._id],
+  );
 
   useEffect(() => {
     if (!pod?._id) {
@@ -117,7 +95,7 @@ const V2Inspector: React.FC<V2InspectorProps> = ({ detail, onClose, onOpenInvite
 
   if (!pod) return null;
 
-  const openAttention = (item: AttentionItem) => {
+  const openAttention = (item: V2AttentionItem) => {
     const target = item.threadRootId || item.messageId;
     navigate(`/v2/pods/${item.podId}${target ? `#message-${target}` : ''}`);
   };

--- a/frontend/src/v2/components/V2Inspector.tsx
+++ b/frontend/src/v2/components/V2Inspector.tsx
@@ -34,6 +34,12 @@ const labelForAgent = (agent: V2Agent): string => (
   agent.profile?.displayName || agent.displayName || agent.agentName
 );
 
+// Pods often carry a longer descriptive title, while the compact inspector
+// heading uses the room's short leading name (for example, “Sharpen”).
+const shortRoomName = (name: string): string => (
+  name.trim().split(/\s*[·—–:|]\s*/)[0].trim() || name.trim()
+);
+
 const matchesAgent = (agent: V2Agent, value?: string): boolean => {
   const candidate = (value || '').toLowerCase();
   return candidate === (agent.agentName || '').toLowerCase()
@@ -125,7 +131,7 @@ const V2Inspector: React.FC<V2InspectorProps> = ({ detail, attentionItems = [], 
 
         <section className="v2-workspace-inspector__card" aria-labelledby="workspace-inspector-agents">
           <h2 id="workspace-inspector-agents" className="v2-workspace-inspector__label">
-            {t('inspector.workspace.agentsIn', { pod: pod.name.toLowerCase() })}
+            {t('inspector.workspace.agentsIn', { pod: shortRoomName(pod.name).toLowerCase() })}
           </h2>
           <div className="v2-workspace-inspector__rows">
             {agents.length === 0 && <p className="v2-workspace-inspector__empty">{t('inspector.workspace.noAgents')}</p>}

--- a/frontend/src/v2/components/V2InviteModal.tsx
+++ b/frontend/src/v2/components/V2InviteModal.tsx
@@ -1,5 +1,5 @@
 // V2InviteModal — shared invite UI mounted at V2Layout level so both the
-// chat header invite icon (V2PodChat) and the inspector "+ Invite" button
+// thread starter invite action (V2Thread) and the inspector "+ Invite" button
 // can open the same modal. Two tabs: shareable links (people) and an agent
 // install shortcut (browse → install).
 import React, { useState, useEffect, useCallback } from 'react';

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -7,8 +7,10 @@ import V2Thread from './V2Thread';
 import V2Inspector from './V2Inspector';
 import V2InviteModal, { type V2InviteTab } from './V2InviteModal';
 import V2FirstRunHero from './V2FirstRunHero';
+import V2MobileTabs from './V2MobileTabs';
 import { useV2Pods } from '../hooks/useV2Pods';
 import { useV2PodDetail } from '../hooks/useV2PodDetail';
+import { useV2PodAttention } from '../hooks/useV2PodAttention';
 import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
 import { useAuth } from '../../context/AuthContext';
 
@@ -69,6 +71,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const { currentUser } = useAuth();
   const podsState = useV2Pods();
   const { pods, loading } = podsState;
+  const attention = useV2PodAttention();
 
   const [inspectorCollapsed, setInspectorCollapsed] = useState<boolean>(readInspectorCollapsed());
   // Invite modal lives here (not in V2Inspector) so the chat header
@@ -182,6 +185,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
       <V2PodsSidebar
         selectedPodId={selectedPodId}
         podsState={podsState}
+        attentionItems={attention.items}
         mobileOpen={mobileNavOpen}
         onMobileClose={closeMobileNav}
       />
@@ -195,6 +199,12 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
         onOpenInvite={inviteEnabled ? openInvite : undefined}
         onOpenFile={openFile}
         onOpenMobileNav={openMobileNav}
+        onDecisionSettled={attention.refresh}
+      />
+      <V2MobileTabs
+        podId={selectedPodId}
+        needsYouCount={selectedPodId ? (attention.countByPod[selectedPodId] || 0) : 0}
+        onOpenInspector={openInspector}
       />
       {selectedPodId && !inspectorCollapsed && (
         <>
@@ -206,6 +216,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
           />
           <V2Inspector
             detail={detail}
+            attentionItems={attention.items}
             onClose={toggleInspector}
             onOpenInvite={inviteEnabled ? () => openInvite() : undefined}
           />

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -93,16 +93,24 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   // decides whether it should open; an established/dismissed user flips it off
   // as soon as the probe resolves.
   const [firstRunVisible, setFirstRunVisible] = useState(true);
-  const openMobileNav = useCallback(() => setMobileNavOpen(true), []);
+  const openMobileNav = useCallback(() => {
+    // The phone has two overlays: rooms drawer and inspector sheet. Opening
+    // one must close the other, otherwise the drawer is mounted behind an
+    // already-open sheet and has no usable hit target.
+    setInspectorCollapsed(true);
+    setMobileNavOpen(true);
+  }, []);
   const closeMobileNav = useCallback(() => setMobileNavOpen(false), []);
   const toggleInspector = useCallback(() => {
     setInspectorCollapsed((prev) => {
       const next = !prev;
       writeInspectorCollapsed(next);
+      if (!next) setMobileNavOpen(false);
       return next;
     });
   }, []);
   const openInspector = useCallback(() => {
+    setMobileNavOpen(false);
     setInspectorCollapsed(false);
     writeInspectorCollapsed(false);
   }, []);

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -21,6 +21,11 @@ interface V2LayoutProps {
 const INSPECTOR_PREF_KEY = 'v2.inspectorCollapsed';
 const LAST_POD_KEY = 'v2:lastPodId';
 const INVITE_BLOCKED_POD_TYPES = new Set(['agent-room', 'agent-dm']);
+const PHONE_MEDIA_QUERY = '(max-width: 760px)';
+
+const isPhoneViewport = (): boolean => (
+  typeof window !== 'undefined' && !!window.matchMedia?.(PHONE_MEDIA_QUERY).matches
+);
 
 const readInspectorCollapsed = (): boolean => {
   try {
@@ -73,7 +78,11 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const { pods, loading } = podsState;
   const attention = useV2PodAttention();
 
-  const [inspectorCollapsed, setInspectorCollapsed] = useState<boolean>(readInspectorCollapsed());
+  // A desktop preference must not leak into the phone sheet. On phones the
+  // sheet starts closed and opens only through the header or bottom control.
+  const [inspectorCollapsed, setInspectorCollapsed] = useState<boolean>(() => (
+    isPhoneViewport() ? true : readInspectorCollapsed()
+  ));
   // Invite modal lives here (not in V2Inspector) so the chat header
   // invite icon and the inspector "+ Invite" button can both open it. The
   // modal itself is V2InviteModal — this component just owns open/close.
@@ -88,6 +97,16 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   // instead of a grid column; this owns its open/closed state. Desktop ignores
   // it entirely (the sidebar is always a visible column there).
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  useEffect(() => {
+    if (!window.matchMedia) return undefined;
+    const phoneViewport = window.matchMedia(PHONE_MEDIA_QUERY);
+    const closeInspectorOnPhone = () => {
+      if (phoneViewport.matches) setInspectorCollapsed(true);
+    };
+    closeInspectorOnPhone();
+    phoneViewport.addEventListener('change', closeInspectorOnPhone);
+    return () => phoneViewport.removeEventListener('change', closeInspectorOnPhone);
+  }, []);
   // Assume visible until the ownership-status probe resolves. This prevents
   // the empty-state stack from flashing while the shell-level first-run modal
   // decides whether it should open; an established/dismissed user flips it off

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import V2NavRail from './V2NavRail';
 import V2PodsSidebar from './V2PodsSidebar';
-import V2PodChat from './V2PodChat';
+import V2Thread from './V2Thread';
 import V2Inspector from './V2Inspector';
 import V2InviteModal, { type V2InviteTab } from './V2InviteModal';
 import V2FirstRunHero from './V2FirstRunHero';
@@ -164,7 +164,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
 
   // The inspector is a separate column only when expanded. When collapsed,
   // it's not rendered at all and the chat extends to the right edge — the
-  // entry point is the avatar group in the chat header (see V2PodChat).
+  // entry point is the working-count control in the thread header (see V2Thread).
   const showInspector = Boolean(selectedPodId && !inspectorCollapsed);
   const shellClass = ['v2-shell', !showInspector ? 'v2-shell--no-inspector' : ''].filter(Boolean).join(' ');
 
@@ -185,7 +185,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
         mobileOpen={mobileNavOpen}
         onMobileClose={closeMobileNav}
       />
-      <V2PodChat
+      <V2Thread
         detail={detail}
         podsState={podsState}
         firstRunVisible={firstRunVisible}

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -78,8 +78,10 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
   const { pods, loading } = podsState;
   const attention = useV2PodAttention();
 
-  // A desktop preference must not leak into the phone sheet. On phones the
-  // sheet starts closed and opens only through the header or bottom control.
+  // A desktop preference must not leak into the phone sheet. This initializer
+  // prevents its first rendered frame from flashing open; the media listener
+  // below handles later viewport changes. On phones the sheet opens only
+  // through the header or bottom control.
   const [inspectorCollapsed, setInspectorCollapsed] = useState<boolean>(() => (
     isPhoneViewport() ? true : readInspectorCollapsed()
   ));

--- a/frontend/src/v2/components/V2MessageActions.tsx
+++ b/frontend/src/v2/components/V2MessageActions.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { V2Message } from '../hooks/useV2PodDetail';
+
+export interface V2RenderedReaction {
+  emoji: string;
+  count: number;
+  mine: boolean;
+  users?: Array<{ id: string; username: string; displayName?: string }>;
+}
+
+interface V2MessageActionsProps {
+  message: V2Message;
+  author: string;
+  onReply?: (message: V2Message) => void;
+  onThread?: (message: V2Message) => void;
+  canInteract: boolean;
+  pickerOpen: boolean;
+  reactions: V2RenderedReaction[];
+  onTogglePicker: () => void;
+  onToggleReaction: (emoji: string, mine: boolean) => void;
+}
+
+const REACTION_PALETTE = ['👍', '❤️', '🔥', '🤔', '👀', '🚀'];
+
+/** The row-level action affordances, kept out of the message content flow. */
+const V2MessageActions: React.FC<V2MessageActionsProps> = ({
+  message,
+  author,
+  onReply,
+  onThread,
+  canInteract,
+  pickerOpen,
+  reactions,
+  onTogglePicker,
+  onToggleReaction,
+}) => {
+  const { t } = useTranslation();
+  if (!onReply && !onThread && !canInteract) return null;
+
+  return (
+    <div
+      className="v2-msg__actions"
+      role="toolbar"
+      aria-label="Message actions"
+      onClick={(event) => event.stopPropagation()}
+    >
+      {onReply && (
+        <button
+          type="button"
+          className="v2-msg__action"
+          aria-label={`Reply to ${author}`}
+          title={`Reply to ${author}`}
+          onClick={() => onReply(message)}
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <polyline points="9 17 4 12 9 7" />
+            <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
+          </svg>
+        </button>
+      )}
+      {onThread && (
+        <button
+          type="button"
+          className="v2-msg__action"
+          aria-label={`${t('podChat.thread.startThread')} from ${author}`}
+          title={t('podChat.thread.startThread')}
+          onClick={() => onThread(message)}
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
+        </button>
+      )}
+      {canInteract && (
+        <span className="v2-msg__action-wrap">
+          <button
+            type="button"
+            className="v2-msg__action"
+            aria-label="Add reaction"
+            title="Add reaction"
+            onClick={onTogglePicker}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="10" />
+              <path d="M8 14s1.5 2 4 2 4-2 4-2" />
+              <line x1="9" y1="9" x2="9.01" y2="9" />
+              <line x1="15" y1="9" x2="15.01" y2="9" />
+            </svg>
+          </button>
+          {pickerOpen && (
+            <span className="v2-msg__reaction-picker" role="menu">
+              {REACTION_PALETTE.map((emoji) => {
+                const existing = reactions.find((reaction) => reaction.emoji === emoji);
+                const mine = Boolean(existing?.mine);
+                return (
+                  <button
+                    key={emoji}
+                    type="button"
+                    role="menuitem"
+                    className={`v2-msg__reaction-picker-item${mine ? ' v2-msg__reaction-picker-item--mine' : ''}`}
+                    onClick={() => onToggleReaction(emoji, mine)}
+                  >
+                    {emoji}
+                  </button>
+                );
+              })}
+            </span>
+          )}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default V2MessageActions;

--- a/frontend/src/v2/components/V2MessageRow.tsx
+++ b/frontend/src/v2/components/V2MessageRow.tsx
@@ -5,6 +5,8 @@ import ReactMarkdown from 'react-markdown';
 import V2Avatar from './V2Avatar';
 import V2GithubPrCard, { parseGithubPrUrls } from './V2GithubPrCard';
 import V2ApprovalCard from './V2ApprovalCard';
+import V2DecisionCard, { type V2DecisionCardData } from './V2DecisionCard';
+import V2MessageActions, { type V2RenderedReaction } from './V2MessageActions';
 import { V2Message } from '../hooks/useV2PodDetail';
 import { formatRelativeTime } from '../utils/grouping';
 import { useAuth } from '../../context/AuthContext';
@@ -70,8 +72,13 @@ const messageMarkdownComponents = {
   // and `.v2-msg__content pre`. Mentions inside code are NOT transformed.
 };
 
-interface V2MessageBubbleProps {
+interface V2MessageRowProps {
   message: V2Message;
+  // DecisionRequest data is deliberately joined by the thread container,
+  // not parsed from the agent's prose. The message is the durable timeline
+  // anchor; the queue owns the choices and resolution state.
+  decision?: V2DecisionCardData;
+  onDecisionRuled?: (decisionId: string, ruling: { value: string; by?: string }) => void;
   isLead?: boolean;
   // Map of agent-user username → per-installation displayName, so messages
   // authored by an installed agent render as "Engineer (Nova)" instead of the
@@ -83,7 +90,7 @@ interface V2MessageBubbleProps {
   // `message.user.username`, so we gate click behavior on a known set.
   agentAuthorKeys?: Set<string>;
   // Clicking the author avatar / name opens the inspector to that member's
-  // detail sub-page. Passed in by V2PodChat; only fires for agent authors.
+  // detail sub-page. Passed in by V2Thread; only fires for agent authors.
   onAuthorClick?: (author: string) => void;
   /**
    * The root this bubble is being rendered UNDER, when it sits inside an
@@ -303,13 +310,7 @@ const parseAgentDmEvent = (content: string | undefined): { headline: string; tar
   return { headline: match[1], targetPodId: match[2] };
 };
 
-// Sprint B5: shared picker palette. 6 emojis chosen to span the common
-// reaction intents: agree / love / fire / brain / eyes / launch. Keep
-// small so the popover stays compact and doesn't overflow narrow chat
-// columns in mobile shells.
-const REACTION_PALETTE = ['👍', '❤️', '🔥', '🤔', '👀', '🚀'];
-
-const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, grouped, insideThreadRoot }) => {
+const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisionRuled, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, grouped, insideThreadRoot }) => {
   const { currentUser } = useAuth();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -347,6 +348,17 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
   const isClickable = !!onAuthorClick && !!agentAuthorKeys?.has(rawUsername.toLowerCase());
   const handleAuthorClick = isClickable ? () => onAuthorClick?.(rawUsername) : undefined;
   const time = formatRelativeTime(message.created_at);
+
+  if (decision) {
+    return (
+      <div className="v2-message-row v2-message-row--decision">
+        <V2DecisionCard
+          decision={{ ...decision, actorName: decision.actorName || author }}
+          onRuled={onDecisionRuled}
+        />
+      </div>
+    );
+  }
 
   // ADR-020 D3: payload-driven components render from structure, not
   // content regex — the first message class where `payload` is the truth
@@ -437,7 +449,7 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
   const hasLive = Array.isArray(liveReactions);
   const reactMessageId = String(message.id || '');
   const canInteract = !!(hasLive && reactMessageId && /^\d+$/.test(reactMessageId));
-  const renderList = hasLive
+  const renderList: V2RenderedReaction[] = hasLive
     ? liveReactions!
     : reactions.map((r) => ({ emoji: r.emoji, count: r.count, mine: false }));
   const toggleReaction = async (emoji: string, mine: boolean) => {
@@ -470,7 +482,7 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
 
   return (
     <div
-      className={`v2-msg${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}${actionsRevealed ? ' v2-msg--reveal' : ''}`}
+      className={`v2-msg v2-message-row${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}${actionsRevealed ? ' v2-msg--reveal' : ''}`}
       onClick={onBubbleTap}
     >
       {grouped ? (
@@ -499,90 +511,17 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
           seed={message.user_id || undefined}
         />
       )}
-      {/* One hover cluster for every row variant (Sam's taste rulings
-          2026-08-23): Reply, Thread, and the reaction trigger live together
-          in a floating pill at the message's top-right — visible on hover
-          or keyboard focus, never in the head's text flow (the inline text
-          buttons crowded the head and shifted layout), and identical for
-          headed and grouped rows. The reaction picker anchors here too, so
-          the trigger sits with its siblings instead of orphaned at the far
-          edge of an empty reactions band. */}
-      {(onReply || onThread || canInteract) && (
-        /* stopPropagation: on touch, the bubble's own tap toggles reveal —
-           without this, tapping any action would immediately re-hide the
-           cluster (and close the picker it just opened). */
-        <div
-          className="v2-msg__actions"
-          role="toolbar"
-          aria-label="Message actions"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {onReply && (
-            <button
-              type="button"
-              className="v2-msg__action"
-              aria-label={`Reply to ${author}`}
-              title={`Reply to ${author}`}
-              onClick={() => onReply(message)}
-            >
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <polyline points="9 17 4 12 9 7" />
-                <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
-              </svg>
-            </button>
-          )}
-          {onThread && (
-            <button
-              type="button"
-              className="v2-msg__action"
-              aria-label={`${t('podChat.thread.startThread')} from ${author}`}
-              title={t('podChat.thread.startThread')}
-              onClick={() => onThread(message)}
-            >
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-              </svg>
-            </button>
-          )}
-          {canInteract && (
-            <span className="v2-msg__action-wrap">
-              <button
-                type="button"
-                className="v2-msg__action"
-                aria-label="Add reaction"
-                title="Add reaction"
-                onClick={() => setPickerOpen((v) => !v)}
-              >
-                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <circle cx="12" cy="12" r="10" />
-                  <path d="M8 14s1.5 2 4 2 4-2 4-2" />
-                  <line x1="9" y1="9" x2="9.01" y2="9" />
-                  <line x1="15" y1="9" x2="15.01" y2="9" />
-                </svg>
-              </button>
-              {pickerOpen && (
-                <span className="v2-msg__reaction-picker" role="menu">
-                  {REACTION_PALETTE.map((e) => {
-                    const existing = renderList.find((x) => x.emoji === e);
-                    const mine = !!existing?.mine;
-                    return (
-                      <button
-                        key={e}
-                        type="button"
-                        role="menuitem"
-                        className={`v2-msg__reaction-picker-item${mine ? ' v2-msg__reaction-picker-item--mine' : ''}`}
-                        onClick={() => toggleReaction(e, mine)}
-                      >
-                        {e}
-                      </button>
-                    );
-                  })}
-                </span>
-              )}
-            </span>
-          )}
-        </div>
-      )}
+      <V2MessageActions
+        message={message}
+        author={author}
+        onReply={onReply}
+        onThread={onThread}
+        canInteract={canInteract}
+        pickerOpen={pickerOpen}
+        reactions={renderList}
+        onTogglePicker={() => setPickerOpen((open) => !open)}
+        onToggleReaction={toggleReaction}
+      />
       <div className="v2-msg__body">
         {!grouped && (
         <div className="v2-msg__head">
@@ -713,4 +652,4 @@ const V2MessageBubble: React.FC<V2MessageBubbleProps> = ({ message, isLead, agen
   );
 };
 
-export default V2MessageBubble;
+export default V2MessageRow;

--- a/frontend/src/v2/components/V2MessageRow.tsx
+++ b/frontend/src/v2/components/V2MessageRow.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import V2Avatar from './V2Avatar';
 import V2GithubPrCard, { parseGithubPrUrls } from './V2GithubPrCard';
 import V2ApprovalCard from './V2ApprovalCard';
-import V2DecisionCard, { type V2DecisionCardData } from './V2DecisionCard';
+import V2DecisionCard, { type V2DecisionCardData, type V2DecisionRuling } from './V2DecisionCard';
 import V2MessageActions, { type V2RenderedReaction } from './V2MessageActions';
 import { V2Message } from '../hooks/useV2PodDetail';
 import { formatRelativeTime } from '../utils/grouping';
@@ -78,7 +78,11 @@ interface V2MessageRowProps {
   // not parsed from the agent's prose. The message is the durable timeline
   // anchor; the queue owns the choices and resolution state.
   decision?: V2DecisionCardData;
-  onDecisionRuled?: (decisionId: string, ruling: { value: string; by?: string }) => void;
+  onDecisionRuled?: (decisionId: string, ruling: V2DecisionRuling) => void;
+  // A decision's durable ruling is an ordinary human reply. This marker only
+  // supplies the small transcript label; it never turns arbitrary prose into
+  // a decision result.
+  isDecisionRuling?: boolean;
   isLead?: boolean;
   // Map of agent-user username → per-installation displayName, so messages
   // authored by an installed agent render as "Engineer (Nova)" instead of the
@@ -310,7 +314,7 @@ const parseAgentDmEvent = (content: string | undefined): { headline: string; tar
   return { headline: match[1], targetPodId: match[2] };
 };
 
-const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisionRuled, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, grouped, insideThreadRoot }) => {
+const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisionRuled, isDecisionRuling = false, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, grouped, insideThreadRoot }) => {
   const { currentUser } = useAuth();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -482,6 +486,7 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
 
   return (
     <div
+      data-testid={isDecisionRuling ? 'decision-ruling-row' : undefined}
       className={`v2-msg v2-message-row${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}${actionsRevealed ? ' v2-msg--reveal' : ''}`}
       onClick={onBubbleTap}
     >
@@ -534,6 +539,7 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
           )}
           {isLead && <span className="v2-msg__lead-badge">{t('podChat.leadBadge')}</span>}
           {time && <span className="v2-msg__time">{time}</span>}
+          {isDecisionRuling && <span className="v2-msg__ruled">· {t('activity.decision.ruledShort')}</span>}
         </div>
         )}
         {(() => {

--- a/frontend/src/v2/components/V2MobileTabs.tsx
+++ b/frontend/src/v2/components/V2MobileTabs.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import ViewKanbanOutlinedIcon from '@mui/icons-material/ViewKanbanOutlined';
+import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
+
+interface V2MobileTabsProps {
+  podId: string | null;
+  needsYouCount: number;
+  onOpenInspector: () => void;
+}
+
+/** Phone-only workspace navigation. Desktop keeps the persistent rail. */
+const V2MobileTabs: React.FC<V2MobileTabsProps> = ({ podId, needsYouCount, onOpenInspector }) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const goToPod = (suffix = '') => {
+    if (podId) navigate(`/v2/pods/${podId}${suffix}`);
+  };
+
+  return (
+    <nav className="v2-mobile-tabs" aria-label={t('common.nav.pods')}>
+      <button type="button" className="v2-mobile-tabs__item v2-mobile-tabs__item--active" onClick={() => goToPod()} aria-label={t('common.nav.pods')}>
+        <ChatBubbleOutlineIcon fontSize="small" aria-hidden="true" />
+      </button>
+      <button type="button" className="v2-mobile-tabs__item" onClick={() => goToPod('/board')} aria-label="Board" disabled={!podId}>
+        <ViewKanbanOutlinedIcon fontSize="small" aria-hidden="true" />
+      </button>
+      <button type="button" className="v2-mobile-tabs__item" onClick={onOpenInspector} aria-label="Needs you" disabled={!podId}>
+        <NotificationsNoneOutlinedIcon fontSize="small" aria-hidden="true" />
+        {needsYouCount > 0 && <span className="v2-mobile-tabs__badge">{needsYouCount}</span>}
+      </button>
+      <button type="button" className="v2-mobile-tabs__item" onClick={() => navigate('/v2/settings')} aria-label={t('common.nav.settings')}>
+        <PersonOutlineIcon fontSize="small" aria-hidden="true" />
+      </button>
+    </nav>
+  );
+};
+
+export default V2MobileTabs;

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -5,6 +5,7 @@ import V2Avatar from './V2Avatar';
 import { UseV2PodsResult, V2Pod, V2PodMember, useV2Pods } from '../hooks/useV2Pods';
 import { useV2Api } from '../hooks/useV2Api';
 import { useV2Pinned } from '../hooks/useV2Pinned';
+import { V2AttentionItem } from '../hooks/useV2PodAttention';
 import { useAuth } from '../../context/AuthContext';
 
 interface Connector {
@@ -14,14 +15,10 @@ interface Connector {
   podId?: { _id: string; name?: string } | string | null;
 }
 
-interface AttentionItem {
-  id: string;
-  podId: string | null;
-}
-
 interface V2PodsSidebarProps {
   selectedPodId: string | null;
   podsState?: UseV2PodsResult;
+  attentionItems?: V2AttentionItem[];
   // The drawer only exists below 760px. Desktop always shows this column.
   mobileOpen?: boolean;
   onMobileClose?: () => void;
@@ -125,7 +122,7 @@ const directMemberFor = (pod: V2Pod, currentUserId?: string): V2PodMember | unde
 );
 
 const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
-  selectedPodId, podsState, mobileOpen = false, onMobileClose,
+  selectedPodId, podsState, attentionItems = [], mobileOpen = false, onMobileClose,
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -137,7 +134,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
     pods, loading, error, createPod,
   } = podsState || ownPodsState;
   const [connectors, setConnectors] = useState<Connector[]>([]);
-  const [attentionItems, setAttentionItems] = useState<AttentionItem[]>([]);
   const [creating, setCreating] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [newPodName, setNewPodName] = useState('');
@@ -153,20 +149,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
       })
       .catch(() => {
         if (active) setConnectors([]);
-      });
-    return () => { active = false; };
-  }, [api]);
-
-  // TASK-129 deliberately has one attention source. PR 2 receives this same
-  // collection for the inspector's rows; the sidebar only derives its count.
-  useEffect(() => {
-    let active = true;
-    api.get<{ items?: AttentionItem[] }>('/api/activity/decision-queue')
-      .then((data) => {
-        if (active) setAttentionItems(Array.isArray(data?.items) ? data.items : []);
-      })
-      .catch(() => {
-        if (active) setAttentionItems([]);
       });
     return () => { active = false; };
   }, [api]);

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -1,10 +1,12 @@
 import React, {
   useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState,
 } from 'react';
+import MenuIcon from '@mui/icons-material/Menu';
+import ViewSidebarOutlinedIcon from '@mui/icons-material/ViewSidebarOutlined';
 import V2Avatar from './V2Avatar';
 import V2CatchUpStrip from './V2CatchUpStrip';
 import V2Composer from './V2Composer';
-import { type V2DecisionCardData } from './V2DecisionCard';
+import { type V2DecisionCardData, type V2DecisionRuling } from './V2DecisionCard';
 import V2ThreadMessages from './V2ThreadMessages';
 import V2ThreadStarter from './V2ThreadStarter';
 import {
@@ -141,9 +143,12 @@ interface V2ThreadProps {
   // is the primary way back to the pod list on phones, where the sidebar is
   // an overlay rather than a visible column. Hidden via CSS on desktop.
   onOpenMobileNav?: () => void;
+  // A ruling changes the one workspace attention collection owned by
+  // V2Layout, so its sidebar, inspector, and phone badge refresh together.
+  onDecisionSettled?: () => void;
 }
 
-const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav }) => {
+const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav, onDecisionSettled }) => {
   const { t } = useTranslation();
   const {
     pod, members, messages, agents, sendMessage, loading, error, sendError,
@@ -230,6 +235,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // and 60s refresh keeps the states honest without hammering the endpoint.
   const [agentStates, setAgentStates] = useState<AgentStateRow[]>([]);
   const [decisions, setDecisions] = useState<ThreadDecision[]>([]);
+  const [settledDecisionByMessageId, setSettledDecisionByMessageId] = useState<Map<string, V2DecisionRuling>>(new Map());
 
   // A DecisionRequest posts an ordinary message for its timeline position and
   // materializes its typed choices in the attention queue. Join those two
@@ -267,6 +273,21 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   const decisionByMessageId = useMemo(() => new Map(
     decisions.map((decision) => [String(decision.messageId), decision]),
   ), [decisions]);
+
+  useEffect(() => {
+    setSettledDecisionByMessageId(new Map());
+  }, [pod?._id]);
+
+  const handleDecisionRuled = useCallback((decisionId: string, ruling: V2DecisionRuling) => {
+    const source = decisions.find((decision) => decision.id === decisionId);
+    if (!source) return;
+    setSettledDecisionByMessageId((current) => {
+      const next = new Map(current);
+      next.set(String(source.messageId), ruling);
+      return next;
+    });
+    onDecisionSettled?.();
+  }, [decisions, onDecisionSettled]);
 
   useEffect(() => {
     const podId = pod?._id;
@@ -669,9 +690,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
       title={t('podChat.mobile.showPods')}
       aria-label={t('podChat.mobile.showPodsList')}
     >
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-        <path d="M3 6h18M3 12h18M3 18h18" />
-      </svg>
+      <MenuIcon fontSize="small" aria-hidden="true" />
     </button>
   ) : null;
 
@@ -909,22 +928,28 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           <div className="v2-thread__header-row">
             {mobileNavButton}
             <div className="v2-thread__title">
-              <h1>{pod.name}</h1>
-              {pod.description && <p>{pod.description}</p>}
+              <div className="v2-thread__title-line">
+                <h1>{pod.name}</h1>
+                {pod.description && <p>{pod.description}</p>}
+              </div>
+              <span className="v2-thread__working v2-thread__working--mobile">
+                {t('podChat.header.agentsWorking', { count: onlineAgentCount })}
+              </span>
             </div>
-            {onToggleInspector ? (
+            <span className="v2-thread__working v2-thread__working--desktop">
+              {t('podChat.header.agentsWorking', { count: onlineAgentCount })}
+            </span>
+            {onToggleInspector && (
               <button
                 type="button"
-                className={`v2-thread__working${inspectorCollapsed ? '' : ' v2-thread__working--active'}`}
+                className={`v2-thread__inspector-toggle${inspectorCollapsed ? '' : ' v2-thread__inspector-toggle--active'}`}
                 onClick={onToggleInspector}
                 title={inspectorCollapsed ? t('podChat.team.view') : t('podChat.team.hide')}
                 aria-label={inspectorCollapsed ? t('podChat.team.view') : t('podChat.team.hide')}
                 aria-pressed={!inspectorCollapsed}
               >
-                {t('podChat.header.agentsWorking', { count: onlineAgentCount })}
+                <ViewSidebarOutlinedIcon fontSize="small" aria-hidden="true" />
               </button>
-            ) : (
-              <span className="v2-thread__working">{t('podChat.header.agentsWorking', { count: onlineAgentCount })}</span>
             )}
           </div>
         </header>
@@ -936,12 +961,14 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           threadView={threadView}
           threadState={threadState}
           decisionByMessageId={decisionByMessageId}
+          settledDecisionByMessageId={settledDecisionByMessageId}
           agentDisplayNames={agentDisplayNames}
           agentAuthorKeys={agentAuthorKeys}
           onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
           onOpenFile={onOpenFile}
           onReply={isReadOnly ? undefined : aimAtMessage}
           onThread={isReadOnly ? undefined : aimAtMessageThread}
+          onDecisionRuled={handleDecisionRuled}
           onAimAtThread={aimAtThread}
           hasMore={hasMore}
           loadingOlder={loadingOlder}

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -3,24 +3,30 @@ import React, {
 } from 'react';
 import V2Avatar from './V2Avatar';
 import V2CatchUpStrip from './V2CatchUpStrip';
-import V2Composer, { type V2ComposerWarning } from './V2Composer';
+import V2Composer from './V2Composer';
 import { type V2DecisionCardData } from './V2DecisionCard';
 import V2ThreadMessages from './V2ThreadMessages';
 import V2ThreadStarter from './V2ThreadStarter';
 import {
   UseV2PodDetailResult,
-  V2Agent,
 } from '../hooks/useV2PodDetail';
 import { useV2Api } from '../hooks/useV2Api';
-import { UseV2PodsResult, V2PodMember } from '../hooks/useV2Pods';
+import { UseV2PodsResult } from '../hooks/useV2Pods';
 import { useSocket } from '../../context/SocketContext';
 import { useAuth } from '../../context/AuthContext';
 import { useTranslation } from 'react-i18next';
 import type { V2InviteTab } from './V2InviteModal';
 
 import { useV2ThreadState } from '../hooks/useV2ThreadState';
+import { useV2ThreadMentions } from '../hooks/useV2ThreadMentions';
 import { buildThreadView } from '../utils/threadView';
 import { agentKeyFor } from '../utils/agentKey';
+import {
+  buildAgentUsername,
+  isOpaqueInstanceToken,
+  normalizeAgentSegment,
+  slugifyAgentHandle,
+} from '../utils/threadAgentIdentity';
 
 const AGENT_DELIVERY_HINT_KEY = 'v2.agentDeliveryHint';
 const JUST_CREATED_POD_KEY = 'v2.justCreated';
@@ -36,70 +42,6 @@ const STARTER_PROMPT_KEYS = [
   'podChat.starters.help',
   'podChat.starters.firstQuestion',
 ] as const;
-
-const normalizeAgentSegment = (value: string | undefined): string =>
-  (value || '').toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 40);
-
-// Per-user agents carry OPAQUE instance tokens (the u+sha10 convention, plus
-// the legacy long form) — machine keys, never identities. A moltbot's
-// instanceId ("aria") is the opposite: the human-chosen name, with agentName
-// as the runtime label we must never surface. So handle preference is:
-// human-meaningful instanceId wins; opaque token falls back to the
-// displayName slug (the backend mention map indexes displaySlug for every
-// installation), then agentName. That's how Scout gets @scout while
-// agentName stays 'guide' — and both handles land.
-const isOpaqueInstanceToken = (value: string | undefined): boolean =>
-  /^u[a-f0-9]{10}([a-f0-9]{14})?$/.test((value || '').toLowerCase());
-
-// Mirrors the backend mention map's slugify (agentMentionService) — keep the
-// two identical or a typed handle can render but not resolve.
-const slugifyHandle = (value: string | undefined): string => (value || '')
-  .toString()
-  .trim()
-  .toLowerCase()
-  .replace(/[^a-z0-9-]/g, '-')
-  .replace(/-+/g, '-')
-  .replace(/^-+|-+$/g, '');
-
-// Mirrors backend AgentIdentityService.buildAgentUsername — instance suffix
-// elides when default/empty/equal to base name. Used to wire a mention back
-// to the agent's User row username.
-const buildAgentUsername = (agentName: string | undefined, instanceId: string | undefined): string => {
-  const base = normalizeAgentSegment(agentName);
-  const inst = normalizeAgentSegment(instanceId);
-  if (!inst || inst === 'default' || inst === base) return base || 'agent';
-  return `${base}-${inst}`;
-};
-
-// Find an "active" @-mention context in the textarea: the closest @ to the
-// left of the cursor that's at start-of-string or preceded by whitespace/
-// quotation, with no whitespace between it and the cursor. Mirrors v1
-// ChatRoom.getMentionContext so behavior matches.
-const getMentionContext = (text: string, cursor: number | null): { start: number; query: string } | null => {
-  if (!text || cursor == null) return null;
-  const atIndex = text.lastIndexOf('@', cursor - 1);
-  if (atIndex < 0) return null;
-  const beforeChar = text[atIndex - 1];
-  if (beforeChar && !/\s|[([{"'`]/.test(beforeChar)) return null;
-  const between = text.slice(atIndex + 1, cursor);
-  if (/\s/.test(between)) return null;
-  return { start: atIndex, query: between };
-};
-
-interface MentionItem {
-  id: string;
-  label: string;
-  labelLower: string;
-  subtitle: string;
-  avatar?: string | null;
-  isAgent: boolean;
-  // Value inserted after `@`. For agents, prefer instanceId so mentions land
-  // on the right instance ("@nova" not "@openclaw").
-  value: string;
-  // #891 surface 1: reachability shown at compose time, so nobody offers a
-  // mention that can't land without saying so.
-  reach?: AgentReachState;
-}
 
 // #891 surface 1 — per-agent reachability from /api/pods/:podId/agent-states.
 // Only the states the kernel can derive HONESTLY for the agent's runtime
@@ -283,13 +225,6 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     [messages, threadState.byRoot],
   );
 
-  // @-mention dropdown state. mentionStart is the index of the `@` in the
-  // textarea so we know the slice to replace on select.
-  const [mentionOpen, setMentionOpen] = useState(false);
-  const [mentionQuery, setMentionQuery] = useState('');
-  const [mentionStart, setMentionStart] = useState(-1);
-  const [mentionIndex, setMentionIndex] = useState(0);
-
   // #891 surface 1: agent reachability at the moment of composing a mention.
   // Best-effort — a failed read renders nothing rather than something wrong,
   // and 60s refresh keeps the states honest without hammering the endpoint.
@@ -369,6 +304,24 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     });
     return map;
   }, [agentStates]);
+
+  const {
+    mentionOpen,
+    setMentionOpen,
+    mentionIndex,
+    setMentionIndex,
+    filteredMentions,
+    warnings: mentionWarnings,
+    updateMentionState,
+    selectMention,
+  } = useV2ThreadMentions({
+    members,
+    agents,
+    agentStateByHandle,
+    draft,
+    setDraft,
+    inputRef: composerInputRef,
+  });
 
   // Agent rooms are exactly one human and one agent. Resolve that one agent
   // through the same installation data that powers mentions, then attach the
@@ -617,160 +570,6 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     [agentKeyByAuthorString],
   );
 
-  // Build the @-mention list. members[] is User rows (humans + agent users);
-  // agents[] is AgentInstallation rows that carry the instanceId. We want
-  // @nova in the dropdown, not @openclaw-nova — so for any member that has
-  // a matching installation, promote it to the agent shape (instance handle,
-  // role subtitle). Agents that aren't (yet) members are appended at the end.
-  const mentionableItems: MentionItem[] = useMemo(() => {
-    const items: MentionItem[] = [];
-    const seen = new Set<string>();
-
-    const agentByUsername = new Map<string, V2Agent>();
-    (agents || []).forEach((a) => {
-      const rawName = (a as { name?: string; agentName?: string }).name || a.agentName || '';
-      if (!rawName) return;
-      agentByUsername.set(buildAgentUsername(rawName, a.instanceId), a);
-    });
-
-    const itemFromAgent = (a: V2Agent, fallbackAvatar: string | null = null): MentionItem | null => {
-      const rawName = (a as { name?: string; agentName?: string }).name || a.agentName || '';
-      if (!rawName) return null;
-      const username = buildAgentUsername(rawName, a.instanceId);
-      const display = a.displayName || a.profile?.displayName || rawName;
-      const instance = (a.instanceId || 'default').toLowerCase();
-      // Handle preference: a human-chosen instanceId ("aria") IS the
-      // identity and stays the handle — agentName there is the runtime label
-      // we never surface. An OPAQUE per-user token (guide/u3f9c2a1b7d) is a
-      // machine key and must never be the handle; fall back to the persona's
-      // displayName slug (@scout — the mention map indexes displaySlug),
-      // then the bare agentName (single-install rule).
-      const mentionValue = instance && instance !== 'default' && instance !== rawName.toLowerCase()
-        && !isOpaqueInstanceToken(instance)
-        ? instance
-        : (slugifyHandle(display) || rawName.toLowerCase());
-      const avatar = a.profile?.avatarUrl || a.profile?.iconUrl || a.iconUrl || fallbackAvatar;
-      // Compose-time honesty (#891 surface 1): a mention that can't land says
-      // so in the picker itself — certainty-matched copy (never-connected is
-      // structural and flat; gone-dark is inferred and hedged).
-      const reach = agentStateByHandle.get(mentionValue)?.state
-        || agentStateByHandle.get(rawName.toLowerCase())?.state;
-      const subtitle = reach === 'never-connected'
-        ? t('podChat.mentionState.typeaheadNever', { handle: mentionValue })
-        : reach === 'gone-dark'
-          ? t('podChat.mentionState.typeaheadDark', { handle: mentionValue })
-          : t('podChat.mentions.agentSubtitle', { handle: mentionValue });
-      return {
-        id: username,
-        label: display,
-        labelLower: `${display} ${rawName} ${username} ${mentionValue}`.toLowerCase(),
-        subtitle,
-        avatar,
-        isAgent: true,
-        value: mentionValue,
-        reach,
-      };
-    };
-
-    (members || []).forEach((m: V2PodMember) => {
-      const username = m.username || '';
-      if (!username) return;
-      const key = username.toLowerCase();
-      if (seen.has(key)) return;
-      seen.add(key);
-      const agentMatch = agentByUsername.get(key);
-      if (agentMatch) {
-        const item = itemFromAgent(agentMatch, m.profilePicture || null);
-        if (item) items.push(item);
-        return;
-      }
-      items.push({
-        id: m._id || username,
-        label: username,
-        labelLower: username.toLowerCase(),
-        subtitle: t('podChat.mentions.member'),
-        avatar: m.profilePicture || null,
-        isAgent: false,
-        value: username,
-      });
-    });
-
-    (agents || []).forEach((a: V2Agent) => {
-      const rawName = (a as { name?: string; agentName?: string }).name || a.agentName || '';
-      if (!rawName) return;
-      const username = buildAgentUsername(rawName, a.instanceId);
-      const key = username.toLowerCase();
-      if (seen.has(key)) return;
-      seen.add(key);
-      const item = itemFromAgent(a);
-      if (item) items.push(item);
-    });
-
-    return items;
-  }, [members, agents, t, agentStateByHandle]);
-
-  // #891 surface 1, send-time half: which mentioned agents in the current
-  // draft cannot hear it? Dependency-keyed explanation for everyone; the fix
-  // command only ever arrives for owners (the endpoint enforces the split).
-  const unreachableMentioned = useMemo<V2ComposerWarning[]>(() => {
-    if (!draft.includes('@')) return [];
-    const tokens: string[] = draft.match(/@([a-z0-9][\w-]*)/gi) || [];
-    const seen = new Set<string>();
-    const rows: V2ComposerWarning[] = [];
-    tokens.forEach((token) => {
-      const handle = token.slice(1).toLowerCase();
-      const state = agentStateByHandle.get(handle);
-      const warningState = state?.state;
-      if (
-        !state
-        || (warningState !== 'gone-dark' && warningState !== 'never-connected')
-        || seen.has(handle)
-      ) return;
-      seen.add(handle);
-      rows.push({ agentName: handle, state: warningState, fixCommand: state.fixCommand });
-    });
-    return rows;
-  }, [draft, agentStateByHandle]);
-
-  const filteredMentions: MentionItem[] = useMemo(() => {
-    if (!mentionOpen) return [];
-    const q = mentionQuery.trim().toLowerCase();
-    return mentionableItems.filter((item) => item.labelLower.includes(q)).slice(0, 8);
-  }, [mentionOpen, mentionQuery, mentionableItems]);
-
-  const updateMentionState = useCallback((nextValue: string, cursorPosition: number | null) => {
-    const ctx = getMentionContext(nextValue, cursorPosition);
-    if (!ctx) {
-      setMentionOpen(false);
-      setMentionQuery('');
-      setMentionStart(-1);
-      return;
-    }
-    setMentionOpen(true);
-    setMentionQuery(ctx.query);
-    setMentionStart(ctx.start);
-    setMentionIndex(0);
-  }, []);
-
-  const handleMentionSelect = useCallback((item: MentionItem) => {
-    const input = composerInputRef.current;
-    if (!input) return;
-    const cursor = input.selectionStart ?? draft.length;
-    const start = mentionStart >= 0 ? mentionStart : draft.lastIndexOf('@', cursor);
-    if (start < 0) return;
-    const insert = `@${item.value || item.label}`;
-    const next = `${draft.slice(0, start)}${insert} ${draft.slice(cursor)}`;
-    setDraft(next);
-    setMentionOpen(false);
-    setMentionQuery('');
-    setMentionStart(-1);
-    requestAnimationFrame(() => {
-      const nextCursor = start + insert.length + 1;
-      input.focus();
-      input.setSelectionRange(nextCursor, nextCursor);
-    });
-  }, [draft, mentionStart]);
-
   // Clear typing indicators on pod change so we never carry indicators from
   // another room into the current view.
   useEffect(() => {
@@ -981,7 +780,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           && exampleAgent.instanceId.toLowerCase() !== 'default'
           && !isOpaqueInstanceToken(exampleAgent.instanceId)
           ? exampleAgent.instanceId
-          : (slugifyHandle(exampleAgent?.displayName || exampleAgent?.profile?.displayName)
+          : (slugifyAgentHandle(exampleAgent?.displayName || exampleAgent?.profile?.displayName)
             || exampleAgent?.agentName);
         const mentionHandle = normalizeAgentSegment(rawMentionHandle);
         if (
@@ -1275,7 +1074,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
                 mentionOpen={mentionOpen}
                 mentionIndex={mentionIndex}
                 mentions={filteredMentions}
-                warnings={unreachableMentioned}
+                warnings={mentionWarnings}
                 inputRef={composerInputRef}
                 fileInputRef={fileInputRef}
                 mentionDropdownRef={mentionDropdownRef}
@@ -1304,7 +1103,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
                     if (event.key === 'Enter' && !event.shiftKey) {
                       event.preventDefault();
                       const selection = filteredMentions[mentionIndex];
-                      if (selection) handleMentionSelect(selection);
+                      if (selection) selectMention(selection);
                       return;
                     }
                   }
@@ -1313,7 +1112,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
                     void handleSend();
                   }
                 }}
-                onMentionSelect={handleMentionSelect}
+                onMentionSelect={selectMention}
                 onSend={() => { void handleSend(); }}
                 onAttach={(file) => { void handleAttachFile(file); }}
                 onCancelReply={() => setReplyTarget(null)}

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -3,7 +3,10 @@ import React, {
 } from 'react';
 import V2Avatar from './V2Avatar';
 import V2CatchUpStrip from './V2CatchUpStrip';
-import V2MessageBubble from './V2MessageBubble';
+import V2Composer, { type V2ComposerWarning } from './V2Composer';
+import { type V2DecisionCardData } from './V2DecisionCard';
+import V2ThreadMessages from './V2ThreadMessages';
+import V2ThreadStarter from './V2ThreadStarter';
 import {
   UseV2PodDetailResult,
   V2Agent,
@@ -12,20 +15,16 @@ import { useV2Api } from '../hooks/useV2Api';
 import { UseV2PodsResult, V2PodMember } from '../hooks/useV2Pods';
 import { useSocket } from '../../context/SocketContext';
 import { useAuth } from '../../context/AuthContext';
-import { initialsFor } from '../utils/avatars';
-import { isGroupedWithPrevious } from '../utils/messageGrouping';
-import { Trans, useTranslation } from 'react-i18next';
-import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import type { V2InviteTab } from './V2InviteModal';
 
-import V2ThreadCard from './V2ThreadCard';
 import { useV2ThreadState } from '../hooks/useV2ThreadState';
 import { buildThreadView } from '../utils/threadView';
 import { agentKeyFor } from '../utils/agentKey';
 
-const PLAN_MODE_KEY = 'v2.podMode';
 const AGENT_DELIVERY_HINT_KEY = 'v2.agentDeliveryHint';
 const JUST_CREATED_POD_KEY = 'v2.justCreated';
+const AGENT_INVITE_TAB: V2InviteTab = 'agent';
 // A sent direct message is durable in the room, but it is not a reply. Give
 // the person a clear, bounded wait state instead of leaving the composer to
 // imply that the agent is working. Two minutes is long enough for a normal
@@ -37,15 +36,6 @@ const STARTER_PROMPT_KEYS = [
   'podChat.starters.help',
   'podChat.starters.firstQuestion',
 ] as const;
-const CLOSE_MARK = '×';
-const COMMAND_KEY = '⌘';
-const ENTER_KEY = '↵';
-
-type PodMode = 'plan' | 'execute';
-
-const podMarkFor = (name: string, type: string | undefined, dmLabel: string): string => (
-  type === 'agent-room' ? dmLabel : initialsFor(name).slice(0, 2)
-);
 
 const normalizeAgentSegment = (value: string | undefined): string =>
   (value || '').toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 40);
@@ -124,7 +114,6 @@ interface AgentStateRow {
   isOwner: boolean;
   fixCommand?: string;
 }
-const REACH_NEEDS_WARNING = new Set<AgentReachState>(['gone-dark', 'never-connected']);
 const REACH_IS_ACTIVE = new Set<AgentReachState>(['listening', 'reachable']);
 
 interface DirectAgentIdentity {
@@ -147,6 +136,12 @@ interface TypingAgentEntry {
   instanceId?: string;
   displayName: string;
   avatar?: string;
+}
+
+interface ThreadDecision extends V2DecisionCardData {
+  kind: 'decision';
+  podId: string;
+  messageId: string;
 }
 
 const TypingIndicator: React.FC<{ agents: TypingAgentEntry[] }> = ({ agents }) => {
@@ -179,30 +174,7 @@ const TypingIndicator: React.FC<{ agents: TypingAgentEntry[] }> = ({ agents }) =
   );
 };
 
-const modeCopy = (mode: PodMode, t: TFunction) => (
-  mode === 'plan'
-    ? t('podChat.mode.planDescription')
-    : t('podChat.mode.executeDescription')
-);
-
-const readMode = (podId: string): PodMode => {
-  try {
-    const raw = localStorage.getItem(`${PLAN_MODE_KEY}.${podId}`);
-    return raw === 'execute' ? 'execute' : 'plan';
-  } catch {
-    return 'plan';
-  }
-};
-
-const writeMode = (podId: string, mode: PodMode) => {
-  try {
-    localStorage.setItem(`${PLAN_MODE_KEY}.${podId}`, mode);
-  } catch {
-    // localStorage unavailable; revert to default on next render.
-  }
-};
-
-interface V2PodChatProps {
+interface V2ThreadProps {
   detail: UseV2PodDetailResult;
   podsState?: UseV2PodsResult;
   // V2Layout owns the shell-level first-run modal. This flag reserves the
@@ -220,7 +192,7 @@ interface V2PodChatProps {
   // path and a single modal instance handles both surfaces.
   onOpenInvite?: (initialTab?: V2InviteTab) => void;
   // Click on an in-message file pill routes here. Passed straight through
-  // to V2MessageBubble → FilePill so the click opens the inspector
+  // to V2MessageRow → FilePill so the click opens the inspector
   // artifact preview instead of window.open()'ing a raw file in a new tab.
   onOpenFile?: (fileName: string) => void;
   // Opens the mobile pods drawer (<=760px). The hamburger in the chat header
@@ -229,15 +201,8 @@ interface V2PodChatProps {
   onOpenMobileNav?: () => void;
 }
 
-const Icon = ({ d }: { d: string }) => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d={d} />
-  </svg>
-);
-
-const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav }) => {
-  const { t, i18n } = useTranslation();
-  const numberFormatter = new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language || 'en');
+const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, inspectorCollapsed, onToggleInspector, onOpenMember, onOpenInvite, onOpenFile, onOpenMobileNav }) => {
+  const { t } = useTranslation();
   const {
     pod, members, messages, agents, sendMessage, loading, error, sendError,
     hasMore, loadingOlder, loadOlder,
@@ -260,7 +225,6 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   } | null>(null);
   const [awaitingAgentReply, setAwaitingAgentReply] = useState<AwaitingAgentReply | null>(null);
   const deliveryHintShownPodsRef = useRef<Set<string>>(new Set());
-  const [mode, setMode] = useState<PodMode>(pod ? readMode(pod._id) : 'plan');
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const messagesContainerRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -330,6 +294,45 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   // Best-effort — a failed read renders nothing rather than something wrong,
   // and 60s refresh keeps the states honest without hammering the endpoint.
   const [agentStates, setAgentStates] = useState<AgentStateRow[]>([]);
+  const [decisions, setDecisions] = useState<ThreadDecision[]>([]);
+
+  // A DecisionRequest posts an ordinary message for its timeline position and
+  // materializes its typed choices in the attention queue. Join those two
+  // durable records by messageId; never infer a card from agent prose.
+  useEffect(() => {
+    const podId = pod?._id;
+    if (!podId) {
+      setDecisions([]);
+      return undefined;
+    }
+    let active = true;
+    const load = async () => {
+      try {
+        const data = await api.get<{ items?: ThreadDecision[] }>('/api/activity/decision-queue');
+        if (!active) return;
+        setDecisions((data?.items || []).filter((item) => (
+          item.kind === 'decision'
+          && item.podId === podId
+          && typeof item.messageId === 'string'
+          && item.messageId.length > 0
+          && Array.isArray(item.options)
+          && item.options.length > 0
+        )));
+      } catch {
+        // A queue read is additive decoration: preserve a working thread when
+        // attention is temporarily unavailable rather than inventing cards.
+        if (active) setDecisions([]);
+      }
+    };
+    void load();
+    const timer = window.setInterval(load, 15_000);
+    return () => { active = false; window.clearInterval(timer); };
+  }, [api, pod?._id]);
+
+  const decisionByMessageId = useMemo(() => new Map(
+    decisions.map((decision) => [String(decision.messageId), decision]),
+  ), [decisions]);
+
   useEffect(() => {
     const podId = pod?._id;
     if (!podId) return undefined;
@@ -432,10 +435,6 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     }, remaining);
     return () => clearTimeout(timeout);
   }, [awaitingAgentReply, pod?._id, messages, directAgent?.username]);
-
-  useEffect(() => {
-    if (pod) setMode(readMode(pod._id));
-  }, [pod?._id]);
 
   useEffect(() => {
     setAgentDeliveryHint(null);
@@ -556,7 +555,7 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   // Map of agent-user username → per-installation displayName. Mirrors
   // backend AgentIdentityService.buildAgentUsername: '<agentName>' when
   // instanceId is 'default' or matches the agentName, else
-  // '<agentName>-<instanceId>'. Lets V2MessageBubble render "Engineer (Nova)"
+  // '<agentName>-<instanceId>'. Lets V2MessageRow render "Engineer (Nova)"
   // instead of the raw User row username "openclaw-nova".
   //
   // Note: the backend payload key is `name` (per buildAgentInstallationPayload
@@ -713,17 +712,22 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   // #891 surface 1, send-time half: which mentioned agents in the current
   // draft cannot hear it? Dependency-keyed explanation for everyone; the fix
   // command only ever arrives for owners (the endpoint enforces the split).
-  const unreachableMentioned = useMemo(() => {
-    if (!draft.includes('@')) return [] as AgentStateRow[];
+  const unreachableMentioned = useMemo<V2ComposerWarning[]>(() => {
+    if (!draft.includes('@')) return [];
     const tokens: string[] = draft.match(/@([a-z0-9][\w-]*)/gi) || [];
     const seen = new Set<string>();
-    const rows: AgentStateRow[] = [];
+    const rows: V2ComposerWarning[] = [];
     tokens.forEach((token) => {
       const handle = token.slice(1).toLowerCase();
       const state = agentStateByHandle.get(handle);
-      if (!state || !REACH_NEEDS_WARNING.has(state.state) || seen.has(handle)) return;
+      const warningState = state?.state;
+      if (
+        !state
+        || (warningState !== 'gone-dark' && warningState !== 'never-connected')
+        || seen.has(handle)
+      ) return;
       seen.add(handle);
-      rows.push({ ...state, agentName: handle });
+      rows.push({ agentName: handle, state: warningState, fixCommand: state.fixCommand });
     });
     return rows;
   }, [draft, agentStateByHandle]);
@@ -854,38 +858,6 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     document.addEventListener('mousedown', onMouseDown);
     return () => document.removeEventListener('mousedown', onMouseDown);
   }, [mentionOpen]);
-
-  // Avatar row shows active members only — humans (member.isBot=false)
-  // plus currently-installed agents. pod.members[] retains stale bot
-  // User rows for identity continuity (ADR-001 §3), so reading it raw
-  // surfaces uninstalled agents in the avatar count. Mirrors the
-  // V2Inspector filter so the chat-header "+N" agrees with the
-  // Members tab count. MUST live above the `if (!pod)` early return —
-  // hooks run on every render or React fires #310 on pod-state changes.
-  const activeMemberAgentUsernames = React.useMemo(() => {
-    const set = new Set<string>();
-    (agents || []).forEach((a) => {
-      const rawName = ((a as { name?: string; agentName?: string }).name || a.agentName || '').toLowerCase();
-      const inst = (a.instanceId || '').toLowerCase();
-      const username = !inst || inst === 'default' || inst === rawName ? rawName : `${rawName}-${inst}`;
-      if (username) set.add(username);
-    });
-    return set;
-  }, [agents]);
-  const effectiveMembers = React.useMemo(() => {
-    // `isBot` is documented as unreliable on the wire (V2Inspector
-    // 804-807). A member whose `isBot` is falsy but whose username
-    // matches an active agent would be counted twice without this
-    // secondary guard.
-    const humans = (members || []).filter((m) => {
-      if (m.isBot) return false;
-      return !activeMemberAgentUsernames.has((m.username || '').toLowerCase());
-    });
-    const activeAgentMembers = (members || []).filter((m) => (
-      activeMemberAgentUsernames.has((m.username || '').toLowerCase())
-    ));
-    return [...humans, ...activeAgentMembers];
-  }, [members, activeMemberAgentUsernames]);
 
   // Mobile-only hamburger: opens the pods slide-over drawer. CSS hides it on
   // desktop (>=761px) where the sidebar is a permanent column. Without it a
@@ -1126,224 +1098,71 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
     }
   };
 
-  const handleSetMode = (next: PodMode) => {
-    setMode(next);
-    writeMode(pod._id, next);
-  };
-
-  // visibleMembers / memberCountExtra are plain consts derived from the
-  // effectiveMembers useMemo that lives above the `if (!pod)` early
-  // return — hooks must run on every render to satisfy the rules of
-  // hooks (otherwise React #310 fires on pod-state transitions). Plain
-  // consts can live here.
-  const visibleMembers = effectiveMembers.slice(0, 3);
-  const memberCountExtra = Math.max(0, effectiveMembers.length - visibleMembers.length);
   const onlineAgentCount = agents.filter((agent) => (
     !!agent.lastHeartbeatAt && Date.now() - new Date(agent.lastHeartbeatAt).getTime() < 10 * 60 * 1000
   )).length;
-  // A no-heartbeat state has meaning only when this pod has an installed
-  // agent. Human-only pods otherwise read as broken despite having nobody
-  // expected to check in.
-  const liveState = agents.length > 0
-    ? onlineAgentCount > 0
-      ? t('podChat.heartbeat.recent', {
-        count: onlineAgentCount,
-        formattedCount: numberFormatter.format(onlineAgentCount),
-      })
-      : t('podChat.heartbeat.none')
-    : null;
   const starterPrompts = STARTER_PROMPT_KEYS.map((key) => t(key));
 
   return (
     <main className="v2-pane v2-pane--main">
       <div className="v2-chat">
-        <header className="v2-chat__header">
-          <div className="v2-chat__header-row">
+        <header className="v2-thread__header">
+          <div className="v2-thread__header-row">
             {mobileNavButton}
-            <div className="v2-chat__title">
-              <span className="v2-chat__title-mark">{podMarkFor(pod.name, pod.type, t('podChat.dmMark'))}</span>
-              <span className="v2-chat__title-text">{pod.name}</span>
+            <div className="v2-thread__title">
+              <h1>{pod.name}</h1>
+              {pod.description && <p>{pod.description}</p>}
             </div>
-
             {onToggleInspector ? (
               <button
                 type="button"
-                className={`v2-chat__avatars v2-chat__avatars--button${inspectorCollapsed ? '' : ' v2-chat__avatars--active'}`}
+                className={`v2-thread__working${inspectorCollapsed ? '' : ' v2-thread__working--active'}`}
                 onClick={onToggleInspector}
                 title={inspectorCollapsed ? t('podChat.team.view') : t('podChat.team.hide')}
                 aria-label={inspectorCollapsed ? t('podChat.team.view') : t('podChat.team.hide')}
                 aria-pressed={!inspectorCollapsed}
               >
-                {visibleMembers.map((m) => (
-                  <V2Avatar key={m._id || m.username} name={m.username} src={m.profilePicture || undefined} size="md" />
-                ))}
-                {memberCountExtra > 0 && (
-                  <span className="v2-chat__avatars-more">+{memberCountExtra}</span>
-                )}
+                {t('podChat.header.agentsWorking', { count: onlineAgentCount })}
               </button>
             ) : (
-              <div className="v2-chat__avatars">
-                {visibleMembers.map((m) => (
-                  <V2Avatar key={m._id || m.username} name={m.username} src={m.profilePicture || undefined} size="md" />
-                ))}
-                {memberCountExtra > 0 && (
-                  <span className="v2-chat__avatars-more">+{memberCountExtra}</span>
-                )}
-              </div>
+              <span className="v2-thread__working">{t('podChat.header.agentsWorking', { count: onlineAgentCount })}</span>
             )}
-
-            {/* Plan / Execute mode toggle — hidden until the pod-mode workflow
-                ships end-to-end. Currently the toggle persists `mode` to the
-                pod but no downstream surface uses it for behavior, so the
-                control reads as broken — clicks land but nothing changes for
-                the user. Re-enable when the mode actually drives behavior
-                (agent autonomy gating, suggestion ranking, etc.). */}
-            {false && (
-              <div className={`v2-chat__mode-toggle v2-chat__mode-toggle--header v2-chat__mode-toggle--${mode}`} role="group" aria-label={t('podChat.mode.preference')}>
-                <button
-                  type="button"
-                  className={`v2-chat__mode-option${mode === 'plan' ? ' v2-chat__mode-option--active' : ''}`}
-                  onClick={() => handleSetMode('plan')}
-                  aria-pressed={mode === 'plan'}
-                  title={modeCopy('plan', t)}
-                >
-                  <Icon d="M9 11l3 3L22 4M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11" />
-                  {t('podChat.mode.plan')}
-                </button>
-                <button
-                  type="button"
-                  className={`v2-chat__mode-option${mode === 'execute' ? ' v2-chat__mode-option--active' : ''}`}
-                  onClick={() => handleSetMode('execute')}
-                  aria-pressed={mode === 'execute'}
-                  title={modeCopy('execute', t)}
-                >
-                  <Icon d="M5 3l14 9-14 9V3z" />
-                  {t('podChat.mode.execute')}
-                </button>
-              </div>
-            )}
-
-            {onOpenInvite && (
-              <button
-                type="button"
-                className="v2-chat__icon-btn"
-                onClick={() => onOpenInvite()}
-                title={t('podChat.invite')}
-                aria-label={t('podChat.invite')}
-              >
-                <Icon d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zM20 8v6M17 11h6" />
-              </button>
-            )}
-
           </div>
-
-          {pod.description && (
-            <div className="v2-chat__goal">
-              {pod.description}
-              {liveState && <span className="v2-chat__goal-meta"> · {liveState}</span>}
-            </div>
-          )}
         </header>
 
         <V2CatchUpStrip podId={pod._id} />
 
-        <div className="v2-chat__messages" ref={messagesContainerRef}>
-          {hasMore && (
-            <div className="v2-chat__older">
-              <button
-                type="button"
-                className="v2-chat__older-btn"
-                onClick={handleLoadOlder}
-                disabled={loadingOlder}
-              >
-                {loadingOlder ? t('podChat.loadingOlder') : t('podChat.loadOlder')}
-              </button>
-            </div>
-          )}
-              {error && (
-                <div className="v2-chat__error">
-                  {error}
-                </div>
-              )}
-              {loading && messages.length === 0 && (
-                <div className="v2-empty"><span className="v2-spinner" /></div>
-              )}
-              {starterPanelVisible && pod && (
-                <section className="v2-chat__new-pod" aria-label={t('podChat.newPod.label')}>
-                  <div className="v2-chat__new-pod-head">
-                    <div>
-                      <div className="v2-chat__new-pod-title">{t('podChat.newPod.title')}</div>
-                      <div className="v2-chat__new-pod-text">{t('podChat.newPod.text')}</div>
-                    </div>
-                    <button
-                      type="button"
-                      className="v2-chat__new-pod-dismiss"
-                      aria-label={t('podChat.newPod.dismiss')}
-                      onClick={() => clearJustCreatedPod(pod._id)}
-                    >
-                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                        <path d="M18 6L6 18M6 6l12 12" />
-                      </svg>
-                    </button>
-                  </div>
-                  <div className="v2-chat__new-pod-actions">
-                    <div className="v2-chat__new-pod-action v2-chat__new-pod-action--invite">
-                      <div className="v2-chat__new-pod-action-title">{t('podChat.newPod.inviteTitle')}</div>
-                      <div className="v2-chat__new-pod-action-text">{t('podChat.newPod.inviteText')}</div>
-                      {starterInviteLoading && (
-                        <div className="v2-chat__new-pod-status">{t('podChat.newPod.preparingInvite')}</div>
-                      )}
-                      {starterInviteUrl && (
-                        <div className="v2-invite-link-row">
-                          <input
-                            type="text"
-                            className="v2-invite-link"
-                            aria-label={t('podChat.newPod.inviteLinkLabel')}
-                            readOnly
-                            value={starterInviteUrl}
-                            onFocus={(event) => event.currentTarget.select()}
-                          />
-                          <button
-                            type="button"
-                            className="v2-chat__new-pod-copy"
-                            onClick={() => { void handleStarterInviteCopy(); }}
-                          >
-                            {starterInviteCopied ? t('common.copied') : t('common.copy')}
-                          </button>
-                        </div>
-                      )}
-                      {starterInviteError && (
-                        <div className="v2-chat__new-pod-error">
-                          <span>{starterInviteError}</span>
-                          <button
-                            type="button"
-                            onClick={() => { void generateStarterInvite(pod._id); }}
-                          >
-                            {t('podChat.newPod.tryAgain')}
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                    <button
-                      type="button"
-                      className="v2-chat__new-pod-action"
-                      onClick={() => onOpenInvite?.('agent')}
-                    >
-                      <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.addAgentTitle')}</span>
-                      <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.addAgentText')}</span>
-                    </button>
-                    <button
-                      type="button"
-                      className="v2-chat__new-pod-action"
-                      onClick={() => composerInputRef.current?.focus()}
-                    >
-                      <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.messageTitle')}</span>
-                      <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.messageText')}</span>
-                    </button>
-                  </div>
-                </section>
-              )}
-              {!starterPanelVisible && !firstRunVisible && !loading && messages.length === 0 && (
+        <V2ThreadMessages
+          messages={messages}
+          threadView={threadView}
+          threadState={threadState}
+          decisionByMessageId={decisionByMessageId}
+          agentDisplayNames={agentDisplayNames}
+          agentAuthorKeys={agentAuthorKeys}
+          onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
+          onOpenFile={onOpenFile}
+          onReply={isReadOnly ? undefined : aimAtMessage}
+          onThread={isReadOnly ? undefined : aimAtMessageThread}
+          onAimAtThread={aimAtThread}
+          hasMore={hasMore}
+          loadingOlder={loadingOlder}
+          onLoadOlder={() => { void handleLoadOlder(); }}
+          loading={loading}
+          error={error}
+          starterPanel={starterPanelVisible ? (
+            <V2ThreadStarter
+              inviteUrl={starterInviteUrl}
+              inviteLoading={starterInviteLoading}
+              inviteError={starterInviteError}
+              inviteCopied={starterInviteCopied}
+              onDismiss={() => clearJustCreatedPod(pod._id)}
+              onCopyInvite={() => { void handleStarterInviteCopy(); }}
+              onRetryInvite={() => { void generateStarterInvite(pod._id); }}
+              onOpenInvite={() => onOpenInvite?.(AGENT_INVITE_TAB)}
+              onFocusComposer={() => composerInputRef.current?.focus()}
+            />
+          ) : undefined}
+          emptyState={!starterPanelVisible && !firstRunVisible && !loading && messages.length === 0 ? (
                 <div className="v2-empty">
                   {isBotToBot && botPair ? (
                     <>
@@ -1379,101 +1198,11 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                     </>
                   )}
                 </div>
-              )}
-              {threadView.map((item, i, view) => {
-                if (item.kind === 'message') {
-                  const m = item.message;
-                  const prev = view[i - 1];
-                  return (
-                    <React.Fragment key={m.id}>
-                      <V2MessageBubble
-                        message={m}
-                        agentDisplayNames={agentDisplayNames}
-                        agentAuthorKeys={agentAuthorKeys}
-                        onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
-                        onOpenFile={onOpenFile}
-                        onReply={isReadOnly ? undefined : aimAtMessage}
-                        onThread={isReadOnly ? undefined : aimAtMessageThread}
-                        grouped={isGroupedWithPrevious(
-                          m,
-                          prev && prev.kind === 'message' ? prev.message : undefined,
-                        )}
-                      />
-                      {agentDeliveryHint?.messageId === m.id && (
-                        <div className="v2-chat__delivery-hint" role="status">
-                          <Trans
-                            i18nKey="podChat.deliveryHint"
-                            values={{ handle: agentDeliveryHint.mentionHandle }}
-                            components={{ handle: <strong /> }}
-                          />
-                        </div>
-                      )}
-                    </React.Fragment>
-                  );
-                }
-
-                const st = threadState.byRoot.get(item.rootId);
-                // No state row means the server does not consider this a
-                // thread. Render the replies flat rather than inventing a
-                // collapsed card around them — absence is not "collapsed".
-                const collapsed = st ? st.collapsed : false;
-                return (
-                  // One block, not loose siblings: the conversation column
-                  // centers direct children, and a bare card + rail escaped
-                  // it (measured left-anchored at 24px vs the column's 186px).
-                  <div className="v2-thread-block" key={`thread-${item.rootId}`}>
-                    <V2ThreadCard
-                      replyCount={item.replyCount}
-                      participants={item.participants}
-                      lastActivityAt={item.lastActivityAt}
-                      collapsed={collapsed}
-                      following={st ? st.following : null}
-                      onToggleCollapsed={() => threadState.toggleCollapsed(item.rootId)}
-                      onToggleFollowing={() => threadState.toggleFollowing(item.rootId)}
-                      onReplyInThread={isReadOnly ? undefined : () => aimAtThread(
-                        item.rootId,
-                        String(messages.find((x) => String(x.id) === item.rootId)?.content || ''),
-                      )}
-                    />
-                    {!collapsed && (
-                      <div className="v2-thread-replies">
-                        {item.replies.map((r, ri) => (
-                          <V2MessageBubble
-                            key={r.id}
-                            message={r}
-                            agentDisplayNames={agentDisplayNames}
-                            agentAuthorKeys={agentAuthorKeys}
-                            onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
-                            onOpenFile={onOpenFile}
-                            onReply={isReadOnly ? undefined : aimAtMessage}
-                            onThread={isReadOnly ? undefined : aimAtMessageThread}
-                            grouped={isGroupedWithPrevious(r, item.replies[ri - 1])}
-                            // Only the rail passes this. The same message
-                            // rendered flat keeps its quote, which is the
-                            // half of constraint 5 that is easy to lose.
-                            insideThreadRoot={item.rootId}
-                          />
-                        ))}
-                        {!isReadOnly && (
-                          <button
-                            type="button"
-                            className="v2-thread-replies__aim"
-                            aria-label={t('podChat.thread.replyFromExpandedThread')}
-                            onClick={() => aimAtThread(
-                              item.rootId,
-                              String(messages.find((x) => String(x.id) === item.rootId)?.content || ''),
-                            )}
-                          >
-                            {t('podChat.thread.replyInThread')}
-                          </button>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-              <div ref={messagesEndRef} />
-            </div>
+          ) : undefined}
+          agentDeliveryHint={agentDeliveryHint}
+          messagesContainerRef={messagesContainerRef}
+          messagesEndRef={messagesEndRef}
+        />
 
             <TypingIndicator agents={typingAgents} />
 
@@ -1533,171 +1262,63 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
                     : t('podChat.agentRoomLiveness.waiting', { agentName: awaitingAgentReply.agentName })}
                 </div>
               )}
-            <div className="v2-chat__composer">
-              {threadTarget && (
-                <div className="v2-chat__reply-chip v2-chat__reply-chip--thread" role="status">
-                  <span className="v2-chat__reply-chip-label">
-                    {t('podChat.thread.replyingInThread')}{' '}
-                    {threadTarget.preview.replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 40)}
-                  </span>
-                  <button
-                    type="button"
-                    className="v2-chat__reply-chip-cancel"
-                    aria-label={t('podChat.cancelReply')}
-                    onClick={() => setThreadTarget(null)}
-                  >
-                    {CLOSE_MARK}
-                  </button>
-                </div>
-              )}
-              {replyTarget && (
-                <div className="v2-chat__reply-chip" role="status">
-                  <span className="v2-chat__reply-chip-label">
-                    <Trans
-                      i18nKey="podChat.replyingTo"
-                      values={{ author: replyTarget.user?.username || t('podChat.messageFallback') }}
-                      components={{ author: <strong /> }}
-                    />{' '}
-                    {String(replyTarget.content || '').replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 80)}
-                  </span>
-                  <button
-                    type="button"
-                    className="v2-chat__reply-chip-cancel"
-                    aria-label={t('podChat.cancelReply')}
-                    onClick={() => setReplyTarget(null)}
-                  >
-                    {CLOSE_MARK}
-                  </button>
-                </div>
-              )}
-              <div className="v2-chat__composer-input-wrap">
-                <textarea
-                  ref={composerInputRef}
-                  className="v2-chat__composer-input"
-                  placeholder={t('podChat.composer.placeholder', { podName: pod.name })}
-                  value={draft}
-                  onChange={(e) => {
-                    const next = e.target.value;
-                    setDraft(next);
-                    updateMentionState(next, e.target.selectionStart);
-                  }}
-                  onClick={(e) => updateMentionState(
-                    (e.target as HTMLTextAreaElement).value,
-                    (e.target as HTMLTextAreaElement).selectionStart,
-                  )}
-                  onKeyUp={(e) => updateMentionState(
-                    (e.target as HTMLTextAreaElement).value,
-                    (e.target as HTMLTextAreaElement).selectionStart,
-                  )}
-                  onKeyDown={(e) => {
-                    if (mentionOpen && filteredMentions.length > 0) {
-                      if (e.key === 'ArrowDown') {
-                        e.preventDefault();
-                        setMentionIndex((p) => (p + 1) % filteredMentions.length);
-                        return;
-                      }
-                      if (e.key === 'ArrowUp') {
-                        e.preventDefault();
-                        setMentionIndex((p) => (p - 1 + filteredMentions.length) % filteredMentions.length);
-                        return;
-                      }
-                      if (e.key === 'Escape') {
-                        e.preventDefault();
-                        setMentionOpen(false);
-                        return;
-                      }
-                      if (e.key === 'Enter' && !e.shiftKey) {
-                        e.preventDefault();
-                        const sel = filteredMentions[mentionIndex];
-                        if (sel) handleMentionSelect(sel);
-                        return;
-                      }
+              <V2Composer
+                podName={pod.name}
+                authorName={currentUser?.username || t('common.you')}
+                draft={draft}
+                sending={sending}
+                uploading={uploading}
+                composerError={composerError}
+                sendError={sendError}
+                replyTarget={replyTarget}
+                threadTarget={threadTarget}
+                mentionOpen={mentionOpen}
+                mentionIndex={mentionIndex}
+                mentions={filteredMentions}
+                warnings={unreachableMentioned}
+                inputRef={composerInputRef}
+                fileInputRef={fileInputRef}
+                mentionDropdownRef={mentionDropdownRef}
+                onDraftChange={(next, cursor) => {
+                  setDraft(next);
+                  updateMentionState(next, cursor);
+                }}
+                onDraftPointer={updateMentionState}
+                onKeyDown={(event) => {
+                  if (mentionOpen && filteredMentions.length > 0) {
+                    if (event.key === 'ArrowDown') {
+                      event.preventDefault();
+                      setMentionIndex((index) => (index + 1) % filteredMentions.length);
+                      return;
                     }
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault();
-                      handleSend();
+                    if (event.key === 'ArrowUp') {
+                      event.preventDefault();
+                      setMentionIndex((index) => (index - 1 + filteredMentions.length) % filteredMentions.length);
+                      return;
                     }
-                  }}
-                  rows={2}
-                />
-                {mentionOpen && filteredMentions.length > 0 && (
-                  <div className="v2-mention-dropdown" ref={mentionDropdownRef} role="listbox">
-                    {filteredMentions.map((item, idx) => (
-                      <button
-                        type="button"
-                        key={item.id}
-                        className={`v2-mention-item${idx === mentionIndex ? ' v2-mention-item--active' : ''}`}
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={() => handleMentionSelect(item)}
-                        role="option"
-                        aria-selected={idx === mentionIndex}
-                      >
-                        <V2Avatar name={item.label} src={item.avatar || undefined} size="sm" />
-                        <span className="v2-mention-item__text">
-                          <span className="v2-mention-item__label">@{item.value || item.label}</span>
-                          <span className="v2-mention-item__sub">{item.subtitle}</span>
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-                <div className="v2-chat__composer-actions">
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    accept="image/*,.pdf,.md,.txt,.csv,.json,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.zip"
-                    style={{ display: 'none' }}
-                    onChange={(e) => handleAttachFile(e.target.files?.[0] || null)}
-                  />
-                  <button
-                    type="button"
-                    className="v2-chat__composer-icon-btn"
-                    title={uploading ? t('podChat.composer.uploading') : t('podChat.composer.attachFile')}
-                    aria-label={t('podChat.composer.attachFile')}
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={uploading}
-                  >
-                    <Icon d="M21 11l-9 9a5 5 0 01-7-7l9-9a3 3 0 014 4l-9 9a1 1 0 01-2-2l8-8" />
-                  </button>
-                </div>
-                <button
-                  type="button"
-                  className={`v2-chat__send v2-chat__send--${mode}`}
-                  onClick={() => handleSend()}
-                  disabled={sending || !draft.trim()}
-                  title={sending ? t('podChat.composer.sending') : t('podChat.composer.send')}
-                  aria-label={sending ? t('podChat.composer.sending') : t('podChat.composer.send')}
-                >
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                    <path d="M2.5 11.4 21.2 3.1c.6-.3 1.2.3.9.9L13.8 22.7c-.3.6-1.2.6-1.4-.1l-2.7-7.4-7.4-2.7c-.7-.2-.7-1.1.2-1.1z" />
-                  </svg>
-                </button>
-              </div>
-              {(composerError || sendError) && (
-                <div className="v2-chat__composer-footer">
-                  <span className="v2-chat__composer-error">{composerError || sendError}</span>
-                </div>
-              )}
-              {unreachableMentioned.length > 0 && (
-                <div className="v2-chat__composer-footer" data-testid="mention-state-warning">
-                  {unreachableMentioned.map((row) => (
-                    <span key={row.agentName} className="v2-chat__composer-hint">
-                      {row.state === 'never-connected'
-                        ? (row.fixCommand
-                          ? t('podChat.mentionState.neverOwner', { handle: row.agentName, command: row.fixCommand })
-                          : t('podChat.mentionState.neverPeer', { handle: row.agentName }))
-                        : (row.fixCommand
-                          ? t('podChat.mentionState.darkOwner', { handle: row.agentName, command: row.fixCommand })
-                          : t('podChat.mentionState.darkPeer', { handle: row.agentName }))}
-                    </span>
-                  ))}
-                </div>
-              )}
-              <div className="v2-chat__composer-hint">
-                <span><kbd>@</kbd> {t('podChat.composer.mentionAgent')}</span>
-                <span><kbd>{COMMAND_KEY}</kbd><kbd>{ENTER_KEY}</kbd> {t('podChat.composer.toSend')}</span>
-              </div>
-            </div>
+                    if (event.key === 'Escape') {
+                      event.preventDefault();
+                      setMentionOpen(false);
+                      return;
+                    }
+                    if (event.key === 'Enter' && !event.shiftKey) {
+                      event.preventDefault();
+                      const selection = filteredMentions[mentionIndex];
+                      if (selection) handleMentionSelect(selection);
+                      return;
+                    }
+                  }
+                  if (event.key === 'Enter' && !event.shiftKey) {
+                    event.preventDefault();
+                    void handleSend();
+                  }
+                }}
+                onMentionSelect={handleMentionSelect}
+                onSend={() => { void handleSend(); }}
+                onAttach={(file) => { void handleAttachFile(file); }}
+                onCancelReply={() => setReplyTarget(null)}
+                onCancelThread={() => setThreadTarget(null)}
+              />
             </>
             )}
       </div>
@@ -1705,4 +1326,4 @@ const V2PodChat: React.FC<V2PodChatProps> = ({ detail, firstRunVisible = false, 
   );
 };
 
-export default V2PodChat;
+export default V2Thread;

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -919,6 +919,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   const onlineAgentCount = agents.filter((agent) => (
     !!agent.lastHeartbeatAt && Date.now() - new Date(agent.lastHeartbeatAt).getTime() < 10 * 60 * 1000
   )).length;
+  const workingClass = onlineAgentCount > 0 ? ' v2-thread__working--active' : '';
   const starterPrompts = STARTER_PROMPT_KEYS.map((key) => t(key));
 
   return (
@@ -932,11 +933,11 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
                 <h1>{pod.name}</h1>
                 {pod.description && <p>{pod.description}</p>}
               </div>
-              <span className="v2-thread__working v2-thread__working--mobile">
+              <span className={`v2-thread__working v2-thread__working--mobile${workingClass}`}>
                 {t('podChat.header.agentsWorking', { count: onlineAgentCount })}
               </span>
             </div>
-            <span className="v2-thread__working v2-thread__working--desktop">
+            <span className={`v2-thread__working v2-thread__working--desktop${workingClass}`}>
               {t('podChat.header.agentsWorking', { count: onlineAgentCount })}
             </span>
             {onToggleInspector && (

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -923,7 +923,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
 
   return (
     <main className="v2-pane v2-pane--main">
-      <div className="v2-chat">
+      <div className="v2-chat v2-thread">
         <header className="v2-thread__header">
           <div className="v2-thread__header-row">
             {mobileNavButton}

--- a/frontend/src/v2/components/V2ThreadMessages.tsx
+++ b/frontend/src/v2/components/V2ThreadMessages.tsx
@@ -6,19 +6,21 @@ import { ThreadViewItem } from '../utils/threadView';
 import { isGroupedWithPrevious } from '../utils/messageGrouping';
 import V2MessageRow from './V2MessageRow';
 import V2ThreadCard from './V2ThreadCard';
-import { V2DecisionCardData } from './V2DecisionCard';
+import { V2DecisionCardData, V2DecisionRuling } from './V2DecisionCard';
 
 interface V2ThreadMessagesProps {
   messages: V2Message[];
   threadView: ThreadViewItem[];
   threadState: Pick<UseV2ThreadState, 'byRoot' | 'toggleCollapsed' | 'toggleFollowing'>;
   decisionByMessageId: Map<string, V2DecisionCardData>;
+  settledDecisionByMessageId: Map<string, V2DecisionRuling>;
   agentDisplayNames: Map<string, string>;
   agentAuthorKeys: Set<string>;
   onAuthorClick?: (author: string) => void;
   onOpenFile?: (fileName: string) => void;
   onReply?: (message: V2Message) => void;
   onThread?: (message: V2Message) => void;
+  onDecisionRuled?: (decisionId: string, ruling: V2DecisionRuling) => void;
   onAimAtThread: (rootId: string, preview: string) => void;
   hasMore: boolean;
   loadingOlder: boolean;
@@ -42,12 +44,14 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
   threadView,
   threadState,
   decisionByMessageId,
+  settledDecisionByMessageId,
   agentDisplayNames,
   agentAuthorKeys,
   onAuthorClick,
   onOpenFile,
   onReply,
   onThread,
+  onDecisionRuled,
   onAimAtThread,
   hasMore,
   loadingOlder,
@@ -65,6 +69,30 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
   const rootPreview = (rootId: string): string => String(
     messages.find((message) => String(message.id) === rootId)?.content || '',
   );
+
+  const rulingMessage = (source: V2Message, ruling: V2DecisionRuling): V2Message => {
+    // `chooseDecision` creates an ordinary PG reply before acknowledging the
+    // choice, so a socket-connected view normally already has this durable
+    // row. Reuse it for valid reactions, timestamps, and identity; the small
+    // fallback only covers the short response-before-socket race.
+    const durable = ruling.messageId
+      ? messages.find((message) => String(message.id) === String(ruling.messageId))
+      : undefined;
+    if (durable) return durable;
+    return {
+      ...source,
+      id: `decision-ruling-${source.id}`,
+      user_id: 'decision-ruling',
+      content: ruling.value,
+      created_at: ruling.at || source.created_at,
+      createdAt: ruling.at || source.createdAt,
+      user: { username: ruling.by || t('common.you'), isBot: false },
+      replyTo: null,
+      reply_msg_id: null,
+      reply_content: null,
+      reply_username: null,
+    };
+  };
 
   return (
     <div className="v2-chat__messages" ref={messagesContainerRef}>
@@ -88,11 +116,14 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
         if (item.kind === 'message') {
           const message = item.message;
           const previous = view[index - 1];
+          const settledRuling = settledDecisionByMessageId.get(String(message.id));
           return (
             <React.Fragment key={message.id}>
               <V2MessageRow
-                message={message}
-                decision={decisionByMessageId.get(String(message.id))}
+                message={settledRuling ? rulingMessage(message, settledRuling) : message}
+                decision={settledRuling ? undefined : decisionByMessageId.get(String(message.id))}
+                isDecisionRuling={Boolean(settledRuling)}
+                onDecisionRuled={onDecisionRuled}
                 agentDisplayNames={agentDisplayNames}
                 agentAuthorKeys={agentAuthorKeys}
                 onAuthorClick={onAuthorClick}
@@ -118,6 +149,10 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
         }
 
         const state = threadState.byRoot.get(item.rootId);
+        // The request source has already transformed into the human's ruling
+        // in the flat transcript above. Its durable reply remains in the
+        // server list, but rendering both would show the same pick twice.
+        if (settledDecisionByMessageId.has(item.rootId)) return null;
         // A missing state row is not permission to invent a collapsed thread.
         const collapsed = state ? state.collapsed : false;
         return (
@@ -139,6 +174,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
                     key={reply.id}
                     message={reply}
                     decision={decisionByMessageId.get(String(reply.id))}
+                    onDecisionRuled={onDecisionRuled}
                     agentDisplayNames={agentDisplayNames}
                     agentAuthorKeys={agentAuthorKeys}
                     onAuthorClick={onAuthorClick}

--- a/frontend/src/v2/components/V2ThreadMessages.tsx
+++ b/frontend/src/v2/components/V2ThreadMessages.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { V2Message } from '../hooks/useV2PodDetail';
+import { UseV2ThreadState } from '../hooks/useV2ThreadState';
+import { ThreadViewItem } from '../utils/threadView';
+import { isGroupedWithPrevious } from '../utils/messageGrouping';
+import V2MessageRow from './V2MessageRow';
+import V2ThreadCard from './V2ThreadCard';
+import { V2DecisionCardData } from './V2DecisionCard';
+
+interface V2ThreadMessagesProps {
+  messages: V2Message[];
+  threadView: ThreadViewItem[];
+  threadState: Pick<UseV2ThreadState, 'byRoot' | 'toggleCollapsed' | 'toggleFollowing'>;
+  decisionByMessageId: Map<string, V2DecisionCardData>;
+  agentDisplayNames: Map<string, string>;
+  agentAuthorKeys: Set<string>;
+  onAuthorClick?: (author: string) => void;
+  onOpenFile?: (fileName: string) => void;
+  onReply?: (message: V2Message) => void;
+  onThread?: (message: V2Message) => void;
+  onAimAtThread: (rootId: string, preview: string) => void;
+  hasMore: boolean;
+  loadingOlder: boolean;
+  onLoadOlder: () => void;
+  loading: boolean;
+  error: string | null;
+  starterPanel?: React.ReactNode;
+  emptyState?: React.ReactNode;
+  agentDeliveryHint?: { messageId: string; mentionHandle: string } | null;
+  messagesContainerRef: React.RefObject<HTMLDivElement | null>;
+  messagesEndRef: React.RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * The transcript is intentionally separate from V2Thread's transport and
+ * composer state. It owns only read order: flat rows, reply rails, and the
+ * one durable decision card that can replace a request message in either.
+ */
+const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
+  messages,
+  threadView,
+  threadState,
+  decisionByMessageId,
+  agentDisplayNames,
+  agentAuthorKeys,
+  onAuthorClick,
+  onOpenFile,
+  onReply,
+  onThread,
+  onAimAtThread,
+  hasMore,
+  loadingOlder,
+  onLoadOlder,
+  loading,
+  error,
+  starterPanel,
+  emptyState,
+  agentDeliveryHint,
+  messagesContainerRef,
+  messagesEndRef,
+}) => {
+  const { t } = useTranslation();
+
+  const rootPreview = (rootId: string): string => String(
+    messages.find((message) => String(message.id) === rootId)?.content || '',
+  );
+
+  return (
+    <div className="v2-chat__messages" ref={messagesContainerRef}>
+      {hasMore && (
+        <div className="v2-chat__older">
+          <button
+            type="button"
+            className="v2-chat__older-btn"
+            onClick={onLoadOlder}
+            disabled={loadingOlder}
+          >
+            {loadingOlder ? t('podChat.loadingOlder') : t('podChat.loadOlder')}
+          </button>
+        </div>
+      )}
+      {error && <div className="v2-chat__error">{error}</div>}
+      {loading && messages.length === 0 && <div className="v2-empty"><span className="v2-spinner" /></div>}
+      {starterPanel}
+      {emptyState}
+      {threadView.map((item, index, view) => {
+        if (item.kind === 'message') {
+          const message = item.message;
+          const previous = view[index - 1];
+          return (
+            <React.Fragment key={message.id}>
+              <V2MessageRow
+                message={message}
+                decision={decisionByMessageId.get(String(message.id))}
+                agentDisplayNames={agentDisplayNames}
+                agentAuthorKeys={agentAuthorKeys}
+                onAuthorClick={onAuthorClick}
+                onOpenFile={onOpenFile}
+                onReply={onReply}
+                onThread={onThread}
+                grouped={isGroupedWithPrevious(
+                  message,
+                  previous && previous.kind === 'message' ? previous.message : undefined,
+                )}
+              />
+              {agentDeliveryHint?.messageId === message.id && (
+                <div className="v2-chat__delivery-hint" role="status">
+                  <Trans
+                    i18nKey="podChat.deliveryHint"
+                    values={{ handle: agentDeliveryHint.mentionHandle }}
+                    components={{ handle: <strong /> }}
+                  />
+                </div>
+              )}
+            </React.Fragment>
+          );
+        }
+
+        const state = threadState.byRoot.get(item.rootId);
+        // A missing state row is not permission to invent a collapsed thread.
+        const collapsed = state ? state.collapsed : false;
+        return (
+          <div className="v2-thread-block" key={`thread-${item.rootId}`}>
+            <V2ThreadCard
+              replyCount={item.replyCount}
+              participants={item.participants}
+              lastActivityAt={item.lastActivityAt}
+              collapsed={collapsed}
+              following={state ? state.following : null}
+              onToggleCollapsed={() => threadState.toggleCollapsed(item.rootId)}
+              onToggleFollowing={() => threadState.toggleFollowing(item.rootId)}
+              onReplyInThread={onReply ? () => onAimAtThread(item.rootId, rootPreview(item.rootId)) : undefined}
+            />
+            {!collapsed && (
+              <div className="v2-thread-replies">
+                {item.replies.map((reply, replyIndex) => (
+                  <V2MessageRow
+                    key={reply.id}
+                    message={reply}
+                    decision={decisionByMessageId.get(String(reply.id))}
+                    agentDisplayNames={agentDisplayNames}
+                    agentAuthorKeys={agentAuthorKeys}
+                    onAuthorClick={onAuthorClick}
+                    onOpenFile={onOpenFile}
+                    onReply={onReply}
+                    onThread={onThread}
+                    grouped={isGroupedWithPrevious(reply, item.replies[replyIndex - 1])}
+                    insideThreadRoot={item.rootId}
+                  />
+                ))}
+                {onReply && (
+                  <button
+                    type="button"
+                    className="v2-thread-replies__aim"
+                    aria-label={t('podChat.thread.replyFromExpandedThread')}
+                    onClick={() => onAimAtThread(item.rootId, rootPreview(item.rootId))}
+                  >
+                    {t('podChat.thread.replyInThread')}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+      <div ref={messagesEndRef} />
+    </div>
+  );
+};
+
+export default V2ThreadMessages;

--- a/frontend/src/v2/components/V2ThreadStarter.tsx
+++ b/frontend/src/v2/components/V2ThreadStarter.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface V2ThreadStarterProps {
+  inviteUrl: string;
+  inviteLoading: boolean;
+  inviteError: string | null;
+  inviteCopied: boolean;
+  onDismiss: () => void;
+  onCopyInvite: () => void;
+  onRetryInvite: () => void;
+  onOpenInvite: () => void;
+  onFocusComposer: () => void;
+}
+
+/**
+ * The empty-room onboarding surface is separate from the transcript so the
+ * message list does not own pod creation, invite issuance, or focus control.
+ */
+const V2ThreadStarter: React.FC<V2ThreadStarterProps> = ({
+  inviteUrl,
+  inviteLoading,
+  inviteError,
+  inviteCopied,
+  onDismiss,
+  onCopyInvite,
+  onRetryInvite,
+  onOpenInvite,
+  onFocusComposer,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <section className="v2-chat__new-pod" aria-label={t('podChat.newPod.label')}>
+      <div className="v2-chat__new-pod-head">
+        <div>
+          <div className="v2-chat__new-pod-title">{t('podChat.newPod.title')}</div>
+          <div className="v2-chat__new-pod-text">{t('podChat.newPod.text')}</div>
+        </div>
+        <button
+          type="button"
+          className="v2-chat__new-pod-dismiss"
+          aria-label={t('podChat.newPod.dismiss')}
+          onClick={onDismiss}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      <div className="v2-chat__new-pod-actions">
+        <div className="v2-chat__new-pod-action v2-chat__new-pod-action--invite">
+          <div className="v2-chat__new-pod-action-title">{t('podChat.newPod.inviteTitle')}</div>
+          <div className="v2-chat__new-pod-action-text">{t('podChat.newPod.inviteText')}</div>
+          {inviteLoading && <div className="v2-chat__new-pod-status">{t('podChat.newPod.preparingInvite')}</div>}
+          {inviteUrl && (
+            <div className="v2-invite-link-row">
+              <input
+                type="text"
+                className="v2-invite-link"
+                aria-label={t('podChat.newPod.inviteLinkLabel')}
+                readOnly
+                value={inviteUrl}
+                onFocus={(event) => event.currentTarget.select()}
+              />
+              <button type="button" className="v2-chat__new-pod-copy" onClick={onCopyInvite}>
+                {inviteCopied ? t('common.copied') : t('common.copy')}
+              </button>
+            </div>
+          )}
+          {inviteError && (
+            <div className="v2-chat__new-pod-error">
+              <span>{inviteError}</span>
+              <button type="button" onClick={onRetryInvite}>{t('podChat.newPod.tryAgain')}</button>
+            </div>
+          )}
+        </div>
+        <button type="button" className="v2-chat__new-pod-action" onClick={onOpenInvite}>
+          <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.addAgentTitle')}</span>
+          <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.addAgentText')}</span>
+        </button>
+        <button type="button" className="v2-chat__new-pod-action" onClick={onFocusComposer}>
+          <span className="v2-chat__new-pod-action-title">{t('podChat.newPod.messageTitle')}</span>
+          <span className="v2-chat__new-pod-action-text">{t('podChat.newPod.messageText')}</span>
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default V2ThreadStarter;

--- a/frontend/src/v2/hooks/useV2PodAttention.ts
+++ b/frontend/src/v2/hooks/useV2PodAttention.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useV2Api } from './useV2Api';
+
+export interface V2AttentionItem {
+  id: string;
+  kind: 'mention' | 'approval' | 'decision';
+  title: string;
+  detail?: string;
+  actorName?: string;
+  podId: string | null;
+  messageId?: string;
+  threadRootId?: string;
+}
+
+/**
+ * The workspace has one open-attention collection. Sidebar badges, the
+ * inspector list, and the phone tab badge are views of this result, not
+ * independently refreshed counters that can disagree.
+ */
+export const useV2PodAttention = () => {
+  const api = useV2Api();
+  const apiRef = useRef(api);
+  apiRef.current = api;
+  const [items, setItems] = useState<V2AttentionItem[]>([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await apiRef.current.get<{ items?: V2AttentionItem[] }>('/api/activity/decision-queue');
+      setItems(Array.isArray(data?.items) ? data.items : []);
+    } catch {
+      // Attention is additive UI. A transient read failure must not invent a
+      // stale count or block the pod surface; the next refresh retries it.
+      setItems([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const countByPod = useMemo(() => items.reduce<Record<string, number>>((counts, item) => {
+    if (!item.podId) return counts;
+    counts[item.podId] = (counts[item.podId] || 0) + 1;
+    return counts;
+  }, {}), [items]);
+
+  return { items, countByPod, refresh };
+};

--- a/frontend/src/v2/hooks/useV2ThreadMentions.ts
+++ b/frontend/src/v2/hooks/useV2ThreadMentions.ts
@@ -1,0 +1,199 @@
+import { useCallback, useMemo, useState, type RefObject } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { V2Agent } from './useV2PodDetail';
+import type { V2PodMember } from './useV2Pods';
+import type { V2ComposerMention, V2ComposerWarning } from '../components/V2Composer';
+import {
+  buildAgentUsername,
+  isOpaqueInstanceToken,
+  rawAgentName,
+  slugifyAgentHandle,
+} from '../utils/threadAgentIdentity';
+
+type MentionReachState = 'listening' | 'gone-dark' | 'never-connected' | 'reachable' | 'unknown';
+
+interface MentionAgentState {
+  state: MentionReachState;
+  fixCommand?: string;
+}
+
+interface MentionItem extends V2ComposerMention {
+  labelLower: string;
+  isAgent: boolean;
+  reach?: MentionReachState;
+}
+
+interface UseV2ThreadMentionsArgs {
+  members: V2PodMember[];
+  agents: V2Agent[];
+  agentStateByHandle: Map<string, MentionAgentState>;
+  draft: string;
+  setDraft: (value: string | ((current: string) => string)) => void;
+  inputRef: RefObject<HTMLTextAreaElement>;
+}
+
+const getMentionContext = (text: string, cursor: number | null): { start: number; query: string } | null => {
+  if (!text || cursor == null) return null;
+  const atIndex = text.lastIndexOf('@', cursor - 1);
+  if (atIndex < 0) return null;
+  const beforeChar = text[atIndex - 1];
+  if (beforeChar && !/\s|[([{"'`]/.test(beforeChar)) return null;
+  const between = text.slice(atIndex + 1, cursor);
+  if (/\s/.test(between)) return null;
+  return { start: atIndex, query: between };
+};
+
+/** Composer-only mention state: candidates, reachability warnings, and insertion. */
+export const useV2ThreadMentions = ({
+  members,
+  agents,
+  agentStateByHandle,
+  draft,
+  setDraft,
+  inputRef,
+}: UseV2ThreadMentionsArgs) => {
+  const { t } = useTranslation();
+  const [mentionOpen, setMentionOpen] = useState(false);
+  const [mentionQuery, setMentionQuery] = useState('');
+  const [mentionStart, setMentionStart] = useState(-1);
+  const [mentionIndex, setMentionIndex] = useState(0);
+
+  const mentionableItems = useMemo<MentionItem[]>(() => {
+    const items: MentionItem[] = [];
+    const seen = new Set<string>();
+    const agentByUsername = new Map<string, V2Agent>();
+    agents.forEach((agent) => {
+      const name = rawAgentName(agent);
+      if (name) agentByUsername.set(buildAgentUsername(name, agent.instanceId), agent);
+    });
+
+    const itemFromAgent = (agent: V2Agent, fallbackAvatar: string | null = null): MentionItem | null => {
+      const name = rawAgentName(agent);
+      if (!name) return null;
+      const username = buildAgentUsername(name, agent.instanceId);
+      const label = agent.displayName || agent.profile?.displayName || name;
+      const instance = (agent.instanceId || 'default').toLowerCase();
+      const value = instance && instance !== 'default' && instance !== name.toLowerCase()
+        && !isOpaqueInstanceToken(instance)
+        ? instance
+        : (slugifyAgentHandle(label) || name.toLowerCase());
+      const reach = agentStateByHandle.get(value)?.state || agentStateByHandle.get(name.toLowerCase())?.state;
+      const subtitle = reach === 'never-connected'
+        ? t('podChat.mentionState.typeaheadNever', { handle: value })
+        : reach === 'gone-dark'
+          ? t('podChat.mentionState.typeaheadDark', { handle: value })
+          : t('podChat.mentions.agentSubtitle', { handle: value });
+      return {
+        id: username,
+        label,
+        labelLower: `${label} ${name} ${username} ${value}`.toLowerCase(),
+        subtitle,
+        avatar: agent.profile?.avatarUrl || agent.profile?.iconUrl || agent.iconUrl || fallbackAvatar,
+        isAgent: true,
+        value,
+        reach,
+      };
+    };
+
+    members.forEach((member) => {
+      const username = member.username || '';
+      if (!username) return;
+      const key = username.toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      const agent = agentByUsername.get(key);
+      if (agent) {
+        const item = itemFromAgent(agent, member.profilePicture || null);
+        if (item) items.push(item);
+        return;
+      }
+      items.push({
+        id: member._id || username,
+        label: username,
+        labelLower: username.toLowerCase(),
+        subtitle: t('podChat.mentions.member'),
+        avatar: member.profilePicture || null,
+        isAgent: false,
+        value: username,
+      });
+    });
+
+    agents.forEach((agent) => {
+      const name = rawAgentName(agent);
+      if (!name) return;
+      const username = buildAgentUsername(name, agent.instanceId);
+      if (seen.has(username)) return;
+      seen.add(username);
+      const item = itemFromAgent(agent);
+      if (item) items.push(item);
+    });
+    return items;
+  }, [agentStateByHandle, agents, members, t]);
+
+  const warnings = useMemo<V2ComposerWarning[]>(() => {
+    if (!draft.includes('@')) return [];
+    const tokens: string[] = draft.match(/@([a-z0-9][\w-]*)/gi) || [];
+    const seen = new Set<string>();
+    return tokens.reduce<V2ComposerWarning[]>((rows, token) => {
+      const agentName = token.slice(1).toLowerCase();
+      const state = agentStateByHandle.get(agentName);
+      if (!state || (state.state !== 'gone-dark' && state.state !== 'never-connected') || seen.has(agentName)) {
+        return rows;
+      }
+      seen.add(agentName);
+      rows.push({ agentName, state: state.state, fixCommand: state.fixCommand });
+      return rows;
+    }, []);
+  }, [agentStateByHandle, draft]);
+
+  const filteredMentions = useMemo(() => {
+    if (!mentionOpen) return [];
+    const query = mentionQuery.trim().toLowerCase();
+    return mentionableItems.filter((item) => item.labelLower.includes(query)).slice(0, 8);
+  }, [mentionOpen, mentionQuery, mentionableItems]);
+
+  const updateMentionState = useCallback((nextValue: string, cursorPosition: number | null) => {
+    const context = getMentionContext(nextValue, cursorPosition);
+    if (!context) {
+      setMentionOpen(false);
+      setMentionQuery('');
+      setMentionStart(-1);
+      return;
+    }
+    setMentionOpen(true);
+    setMentionQuery(context.query);
+    setMentionStart(context.start);
+    setMentionIndex(0);
+  }, []);
+
+  const selectMention = useCallback((item: V2ComposerMention) => {
+    const input = inputRef.current;
+    if (!input) return;
+    const cursor = input.selectionStart ?? draft.length;
+    const start = mentionStart >= 0 ? mentionStart : draft.lastIndexOf('@', cursor);
+    if (start < 0) return;
+    const insert = `@${item.value || item.label}`;
+    setDraft(`${draft.slice(0, start)}${insert} ${draft.slice(cursor)}`);
+    setMentionOpen(false);
+    setMentionQuery('');
+    setMentionStart(-1);
+    requestAnimationFrame(() => {
+      const nextCursor = start + insert.length + 1;
+      input.focus();
+      input.setSelectionRange(nextCursor, nextCursor);
+    });
+  }, [draft, inputRef, mentionStart, setDraft]);
+
+  return {
+    mentionOpen,
+    setMentionOpen,
+    mentionIndex,
+    setMentionIndex,
+    filteredMentions,
+    warnings,
+    updateMentionState,
+    selectMention,
+  };
+};
+
+export default useV2ThreadMentions;

--- a/frontend/src/v2/utils/agentKey.ts
+++ b/frontend/src/v2/utils/agentKey.ts
@@ -8,7 +8,7 @@
  * won, and clicking ANY agent's byline or member row rendered the same seat's
  * profile (Sam, 2026-08-26: "clicking any agent's profile goes to fable").
  *
- * Producers (V2PodChat author map) and consumers (V2Inspector agent view)
+ * Producers (V2Thread author map) and consumers (V2Inspector agent view)
  * MUST both import this — the collision existed precisely because each side
  * derived its own key.
  */

--- a/frontend/src/v2/utils/threadAgentIdentity.ts
+++ b/frontend/src/v2/utils/threadAgentIdentity.ts
@@ -1,0 +1,33 @@
+import type { V2Agent } from '../hooks/useV2PodDetail';
+
+export const normalizeAgentSegment = (value: string | undefined): string => (
+  value || ''
+).toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 40);
+
+// Per-user agent instance tokens are machine keys, while a human-chosen
+// instanceId is an identity. Never make an opaque token part of a mention.
+export const isOpaqueInstanceToken = (value: string | undefined): boolean => (
+  /^u[a-f0-9]{10}([a-f0-9]{14})?$/.test((value || '').toLowerCase())
+);
+
+// Mirrors agentMentionService's backend slugification. Handles must resolve
+// exactly the same way in the composer and in delivery.
+export const slugifyAgentHandle = (value: string | undefined): string => (value || '')
+  .toString()
+  .trim()
+  .toLowerCase()
+  .replace(/[^a-z0-9-]/g, '-')
+  .replace(/-+/g, '-')
+  .replace(/^-+|-+$/g, '');
+
+/** Mirrors AgentIdentityService.buildAgentUsername on the backend. */
+export const buildAgentUsername = (agentName: string | undefined, instanceId: string | undefined): string => {
+  const base = normalizeAgentSegment(agentName);
+  const instance = normalizeAgentSegment(instanceId);
+  if (!instance || instance === 'default' || instance === base) return base || 'agent';
+  return `${base}-${instance}`;
+};
+
+export const rawAgentName = (agent: V2Agent): string => (
+  (agent as { name?: string; agentName?: string }).name || agent.agentName || ''
+);

--- a/frontend/src/v2/utils/threadView.ts
+++ b/frontend/src/v2/utils/threadView.ts
@@ -5,7 +5,7 @@ import { V2ThreadParticipant } from '../components/V2ThreadCard';
 /**
  * Fold a flat message list into the threaded render order (W-T 4/4).
  *
- * Pure, and separate from V2PodChat, because this is the part with the edge
+ * Pure, and separate from V2Thread, because this is the part with the edge
  * cases and the component is 1,300 lines of surface. Everything here is
  * decided from data the server sent: `thread_root_id` on each message and the
  * per-root state from #1145. Nothing is derived from timestamps.

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5618,19 +5618,8 @@ body.modern-ui.v2-canvas {
   color: var(--v2-text-primary);
 }
 
-@media (max-width: 1279px) {
-  .v2-root {
-    --v2-rail-w: 72px;
-    --v2-pods-w: 248px;
-    --v2-inspector-w: 300px;
-    min-width: 0;
-  }
-}
-
 @media (max-width: 1023px) {
   .v2-root {
-    --v2-rail-w: 64px;
-    --v2-pods-w: 236px;
     min-width: 0;
   }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -10362,10 +10362,17 @@ body.modern-ui.v2-canvas {
 .v2-decision-card__settled { color: var(--v2-text-secondary); }
 .v2-decision-card__error { color: #b91c1c; }
 
+.v2-msg__ruled {
+  color: var(--v2-text-muted);
+  font: 500 11px/16px var(--v2-font-mono);
+}
+
 /* ---------- Workspace thread and composer (TASK-129 PR 3) ---------- */
 
 .v2-thread__header {
   flex: 0 0 auto;
+  box-sizing: border-box;
+  min-height: 64px;
   padding: 12px 14px;
   border-bottom: 1px solid var(--v2-border-soft);
   background: var(--v2-surface);
@@ -10383,21 +10390,29 @@ body.modern-ui.v2-canvas {
   flex: 1;
 }
 
+.v2-thread__title-line {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  gap: 8px;
+}
+
 .v2-thread__title h1 {
   margin: 0;
   overflow: hidden;
   color: var(--v2-text-primary);
-  font: 600 16px/20px var(--v2-font);
+  font: 700 22px/28px var(--v2-font);
   letter-spacing: -0.01em;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .v2-thread__title p {
-  margin: 2px 0 0;
+  min-width: 0;
+  margin: 0;
   overflow: hidden;
   color: var(--v2-text-muted);
-  font: 400 12px/16px var(--v2-font);
+  font: 400 14px/20px var(--v2-font);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -10411,16 +10426,23 @@ body.modern-ui.v2-canvas {
 
 .v2-thread__working::before { content: '●'; color: var(--v2-accent); }
 
-.v2-root button.v2-thread__working {
-  min-height: 28px;
-  padding: 4px 6px;
-  border: 0;
+.v2-thread__working--mobile { display: none; }
+
+.v2-root button.v2-thread__inspector-toggle {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid var(--v2-border);
   border-radius: 4px;
-  background: transparent;
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
 }
 
-.v2-root button.v2-thread__working:hover,
-.v2-root button.v2-thread__working--active { background: var(--v2-surface-hover); }
+.v2-root button.v2-thread__inspector-toggle:hover,
+.v2-root button.v2-thread__inspector-toggle--active { background: var(--v2-surface-hover); color: var(--v2-text-primary); }
 
 .v2-thread .v2-msg {
   grid-template-columns: 28px minmax(0, 1fr);
@@ -10435,6 +10457,7 @@ body.modern-ui.v2-canvas {
 .v2-thread .v2-msg__author,
 .v2-thread .v2-msg__author-btn { font-size: 13px; font-weight: 600; }
 .v2-thread .v2-msg__time { font-family: var(--v2-font-mono); font-size: 11px; }
+.v2-thread .v2-msg__avatar-btn { border-radius: 4px; }
 
 .v2-message-row--decision { padding: 8px 0; }
 
@@ -10550,7 +10573,131 @@ body.modern-ui.v2-canvas {
 }
 
 @media (max-width: 760px) {
-  .v2-thread__header { padding: 10px 14px; }
-  .v2-thread__working { display: none; }
-  .v2-composer { margin: 8px 14px 14px; }
+  .v2-thread__header {
+    min-height: 66px;
+    padding: 8px 14px;
+  }
+
+  .v2-thread__header-row { align-items: center; gap: 8px; }
+  .v2-thread__title-line { display: block; }
+  .v2-thread__title h1 { font-size: 20px; line-height: 24px; }
+  .v2-thread__title p { display: none; }
+  .v2-thread__working--desktop { display: none; }
+  .v2-thread__working--mobile { display: block; color: var(--v2-accent-text); }
+
+  .v2-thread .v2-msg__author,
+  .v2-thread .v2-msg__author-btn { font-size: 15px; }
+  .v2-thread .v2-msg__time,
+  .v2-thread .v2-msg__ruled { font-size: 12px; }
+  .v2-thread .v2-msg__content { font-size: 15px; line-height: 22px; }
+
+  .v2-composer { margin: 8px 16px 62px; border: 0; background: transparent; }
+  .v2-composer__field { display: flex; align-items: stretch; gap: 12px; }
+  .v2-root .v2-composer__field > textarea {
+    min-height: 44px;
+    height: 44px;
+    flex: 1;
+    padding: 11px 12px;
+    resize: none;
+    border: 1px solid var(--v2-border);
+    border-radius: 4px;
+    background: var(--v2-surface);
+    line-height: 20px;
+  }
+  .v2-composer__actions { min-height: 0; padding: 0; border: 0; }
+  .v2-root button.v2-composer__attach,
+  .v2-composer__posts-as { display: none; }
+  .v2-root button.v2-composer__send {
+    width: 44px;
+    min-height: 44px;
+    padding: 0;
+    border-radius: 4px;
+    font-size: 11px;
+  }
+
+  /* The workspace is edge-to-edge on a phone. Rail and pod list are drawers,
+     while the transcript, composer, and tab bar share the white canvas. */
+  .v2-shell,
+  .v2-shell--no-inspector,
+  .v2-shell--feature {
+    grid-template-columns: minmax(0, 1fr);
+    padding: 0;
+    gap: 0;
+    background: #fff;
+  }
+  .v2-pane--rail { display: none; }
+  .v2-pane--main { background: #fff; }
+
+  /* The inspector becomes the artboard's bottom sheet; its header toggle is
+     intentionally always present so the sheet cannot become unreachable. */
+  .v2-pane--inspector {
+    top: auto;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: min(76dvh, 620px);
+    border: 1px solid var(--v2-border);
+    border-bottom: 0;
+    border-radius: 12px 12px 0 0;
+    box-shadow: 0 -12px 32px rgba(17, 24, 39, 0.14);
+  }
+
+  .v2-chat__mobile-nav-btn {
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+  }
+  .v2-chat__mobile-nav-btn svg { width: 16px; height: 16px; }
+
+  .v2-mobile-tabs {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 40;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    height: 54px;
+    padding: 5px 14px;
+    border-top: 1px solid var(--v2-border);
+    background: #fff;
+  }
+  .v2-root button.v2-mobile-tabs__item {
+    position: relative;
+    display: grid;
+    width: 44px;
+    height: 32px;
+    justify-self: center;
+    padding: 0;
+    place-items: center;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--v2-text-secondary);
+  }
+  .v2-root button.v2-mobile-tabs__item svg { width: 18px; height: 18px; }
+  .v2-root button.v2-mobile-tabs__item--active { background: var(--v2-ink); color: var(--v2-on-ink); }
+  .v2-root button.v2-mobile-tabs__item:hover:not(:disabled) { background: var(--v2-surface-hover); color: var(--v2-text-primary); }
+  .v2-root button.v2-mobile-tabs__item--active:hover:not(:disabled) { background: var(--v2-ink-hover); color: var(--v2-on-ink); }
+  .v2-mobile-tabs__badge {
+    position: absolute;
+    top: -4px;
+    right: -2px;
+    display: grid;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 3px;
+    place-items: center;
+    border: 2px solid #fff;
+    border-radius: 999px;
+    background: var(--v2-accent);
+    color: #fff;
+    font: 700 10px/1 var(--v2-font-mono);
+  }
+}
+
+.v2-mobile-tabs { display: none; }
+
+@media (max-width: 760px) {
+  .v2-mobile-tabs { display: grid; }
 }

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -10334,7 +10334,10 @@ body.modern-ui.v2-canvas {
   font: 400 11px/16px var(--v2-font);
 }
 
-.v2-root button.v2-decision-card__other { border-style: dashed; }
+.v2-root button.v2-decision-card__other {
+  border-style: dashed;
+  color: var(--v2-accent-text);
+}
 
 .v2-decision-card__other-form {
   display: flex;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -10319,7 +10319,7 @@ body.modern-ui.v2-canvas {
   font: 500 12px/18px var(--v2-font);
 }
 
-.v2-root button.v2-decision-card__choice--recommended {
+.v2-root button.v2-decision-card__choice--primary {
   border-color: var(--v2-accent);
   background: var(--v2-accent);
   color: var(--v2-on-ink);
@@ -10327,7 +10327,7 @@ body.modern-ui.v2-canvas {
 
 .v2-root button.v2-decision-card__choice:hover:not(:disabled),
 .v2-root button.v2-decision-card__other:hover:not(:disabled) { background: var(--v2-surface-hover); }
-.v2-root button.v2-decision-card__choice--recommended:hover:not(:disabled) { background: var(--v2-accent-strong); }
+.v2-root button.v2-decision-card__choice--primary:hover:not(:disabled) { background: var(--v2-accent-strong); }
 
 .v2-decision-card__option > span {
   color: var(--v2-text-muted);
@@ -10335,7 +10335,8 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-root button.v2-decision-card__other {
-  border-style: dashed;
+  border: 0;
+  background: transparent;
   color: var(--v2-accent-text);
 }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -10065,11 +10065,15 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-workspace-inspector__label {
+  display: block;
   margin: 0 0 10px;
+  overflow: hidden;
   color: var(--v2-text-muted);
   font: 500 11px/14px var(--v2-font-mono);
   letter-spacing: 0.02em;
+  text-overflow: clip;
   text-transform: lowercase;
+  white-space: nowrap;
 }
 
 .v2-workspace-inspector__rows {
@@ -10414,7 +10418,9 @@ body.modern-ui.v2-canvas {
   white-space: nowrap;
 }
 
-.v2-thread__working::before { content: '●'; color: var(--v2-accent); }
+.v2-thread__working::before { content: '●'; color: var(--v2-text-muted); }
+
+.v2-thread__working--active::before { color: var(--v2-accent); }
 
 .v2-thread__working--mobile { display: none; }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -1021,7 +1021,7 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-pods__create-submit {
-  background: var(--v2-accent);
+  background: var(--v2-ink);
   color: #fff;
 }
 
@@ -10402,7 +10402,7 @@ body.modern-ui.v2-canvas {
   margin: 0;
   overflow: hidden;
   color: var(--v2-text-primary);
-  font: 700 22px/28px var(--v2-font);
+  font: 700 22px/28px var(--v2-font-display);
   letter-spacing: -0.01em;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -10453,12 +10453,19 @@ body.modern-ui.v2-canvas {
 
 .v2-thread .v2-msg--grouped { padding: 2px 0; }
 .v2-thread .v2-msg__avatar-ghost { width: 28px; }
-.v2-thread .v2-avatar { width: 28px; height: 28px; border-radius: 4px; }
+.v2-thread .v2-avatar {
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 4px;
+  box-shadow: none;
+}
 .v2-thread .v2-msg__head { height: 18px; gap: 6px; }
 .v2-thread .v2-msg__author,
 .v2-thread .v2-msg__author-btn { font-size: 13px; font-weight: 600; }
-.v2-thread .v2-msg__time { font-family: var(--v2-font-mono); font-size: 11px; }
+.v2-thread .v2-msg__time { font: 500 11px/16px var(--v2-font-mono); }
 .v2-thread .v2-msg__avatar-btn { border-radius: 4px; }
+.v2-thread .v2-msg__actions { border-radius: 4px; box-shadow: none; }
 
 .v2-message-row--decision { padding: 8px 0; }
 
@@ -10581,7 +10588,7 @@ body.modern-ui.v2-canvas {
 
   .v2-thread__header-row { align-items: center; gap: 8px; }
   .v2-thread__title-line { display: block; }
-  .v2-thread__title h1 { font-size: 20px; line-height: 24px; }
+  .v2-thread__title h1 { font: 700 20px/24px var(--v2-font-display); }
   .v2-thread__title p { display: none; }
   .v2-thread__working--desktop { display: none; }
   .v2-thread__working--mobile { display: block; color: var(--v2-accent-text); }
@@ -10591,6 +10598,13 @@ body.modern-ui.v2-canvas {
   .v2-thread .v2-msg__time,
   .v2-thread .v2-msg__ruled { font-size: 12px; }
   .v2-thread .v2-msg__content { font-size: 15px; line-height: 22px; }
+
+  /* The phone artboard makes every decision option a full-width, 44px row;
+     Other remains a centred text escape hatch beneath them. */
+  .v2-decision-card__options { align-items: stretch; flex-direction: column; }
+  .v2-decision-card__option { width: 100%; }
+  .v2-root button.v2-decision-card__choice { width: 100%; min-height: 44px; font-size: 15px; }
+  .v2-root button.v2-decision-card__other { align-self: center; min-height: 30px; }
 
   .v2-composer { margin: 8px 16px 62px; border: 0; background: transparent; }
   .v2-composer__field { display: flex; align-items: stretch; gap: 12px; }
@@ -10643,10 +10657,17 @@ body.modern-ui.v2-canvas {
     box-shadow: 0 -12px 32px rgba(17, 24, 39, 0.14);
   }
 
-  .v2-chat__mobile-nav-btn {
+  .v2-root button.v2-chat__mobile-nav-btn {
+    display: inline-grid;
     width: 28px;
     height: 28px;
+    flex: 0 0 28px;
+    place-items: center;
+    padding: 0;
+    border: 1px solid var(--v2-border);
     border-radius: 4px;
+    background: var(--v2-surface);
+    color: var(--v2-text-secondary);
   }
   .v2-chat__mobile-nav-btn svg { width: 16px; height: 16px; }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -10451,8 +10451,8 @@ body.modern-ui.v2-canvas {
 }
 .v2-thread .v2-msg__head { height: 18px; gap: 6px; }
 .v2-thread .v2-msg__author,
-.v2-thread .v2-msg__author-btn { font-size: 13px; font-weight: 600; }
-.v2-thread .v2-msg__time { font: 500 11px/16px var(--v2-font-mono); }
+.v2-thread .v2-msg__author-btn { font-size: 14px; font-weight: 600; }
+.v2-thread .v2-msg__time { font: 500 12px/16px var(--v2-font-mono); }
 .v2-thread .v2-msg__avatar-btn { border-radius: 4px; }
 .v2-thread .v2-msg__actions { border-radius: 4px; box-shadow: none; }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -7240,7 +7240,7 @@ body.modern-ui.v2-canvas {
 
   /* No hover on touch — but always-on clusters over every message are
      chrome over content (Sam, 2026-08-23). A tap on the message toggles
-     .v2-msg--reveal (V2MessageBubble.onBubbleTap, gated to hoverless
+     .v2-msg--reveal (V2MessageRow.onBubbleTap, gated to hoverless
      devices); only then does the cluster appear, at the 44px floor (craft
      baseline rule 9). Absolute positioning preserved — a static third
      child would break the avatar|body grid. */
@@ -9511,6 +9511,7 @@ body.modern-ui.v2-canvas {
 .v2-root:lang(zh) .v2-rail__brand,
 .v2-root:lang(zh) .v2-pods__title,
 .v2-root:lang(zh) .v2-chat__title,
+.v2-root:lang(zh) .v2-thread__title h1,
 .v2-root:lang(zh) .v2-first-run__title,
 .v2-root:lang(zh) .v2-chat__new-pod-title,
 .v2-root:lang(zh) button.v2-inspector__tab,
@@ -10253,3 +10254,300 @@ body.modern-ui.v2-canvas {
 .v2-root:lang(zh) .v2-workspace-inspector__actor,
 .v2-root:lang(zh) .v2-workspace-inspector__task-meta,
 .v2-root:lang(zh) .v2-workspace-inspector__foot button { font-size: 12px; }
+
+/* ---------- Workspace decision card (TASK-129 PR 3) ----------
+   A DecisionRequest is an in-thread fork, not prose the human must parse.
+   The cobalt 2px ring is reserved for this unresolved, human-owned choice. */
+.v2-decision-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 8px 0;
+  padding: 14px;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: 6px;
+  background: var(--v2-surface);
+  box-shadow: 0 0 0 2px var(--v2-accent);
+}
+
+.v2-decision-card--ruled { box-shadow: none; }
+
+.v2-decision-card__head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.v2-decision-card__head h3 {
+  min-width: 0;
+  margin: 0;
+  color: var(--v2-text-primary);
+  font: 600 14px/20px var(--v2-font);
+}
+
+.v2-decision-card__agent {
+  flex-shrink: 0;
+  color: var(--v2-accent-text);
+  font: 500 11px/14px var(--v2-font-mono);
+}
+
+.v2-decision-card__question {
+  margin: 0;
+  color: var(--v2-text-secondary);
+  font: 400 13px/19px var(--v2-font);
+}
+
+.v2-decision-card__options {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+}
+
+.v2-decision-card__option { display: inline-flex; align-items: center; gap: 5px; }
+
+.v2-root button.v2-decision-card__choice,
+.v2-root button.v2-decision-card__other,
+.v2-root button.v2-decision-card__other-form button {
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: 500 12px/18px var(--v2-font);
+}
+
+.v2-root button.v2-decision-card__choice--recommended {
+  border-color: var(--v2-accent);
+  background: var(--v2-accent);
+  color: var(--v2-on-ink);
+}
+
+.v2-root button.v2-decision-card__choice:hover:not(:disabled),
+.v2-root button.v2-decision-card__other:hover:not(:disabled) { background: var(--v2-surface-hover); }
+.v2-root button.v2-decision-card__choice--recommended:hover:not(:disabled) { background: var(--v2-accent-strong); }
+
+.v2-decision-card__option > span {
+  color: var(--v2-text-muted);
+  font: 400 11px/16px var(--v2-font);
+}
+
+.v2-root button.v2-decision-card__other { border-style: dashed; }
+
+.v2-decision-card__other-form {
+  display: flex;
+  flex: 1 1 100%;
+  gap: 6px;
+}
+
+.v2-decision-card__other-form input {
+  min-width: 0;
+  flex: 1;
+  min-height: 32px;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  padding: 5px 8px;
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: 400 13px/18px var(--v2-font);
+}
+
+.v2-decision-card__settled,
+.v2-decision-card__error { margin: 0; font: 500 12px/18px var(--v2-font); }
+.v2-decision-card__settled { color: var(--v2-text-secondary); }
+.v2-decision-card__error { color: #b91c1c; }
+
+/* ---------- Workspace thread and composer (TASK-129 PR 3) ---------- */
+
+.v2-thread__header {
+  flex: 0 0 auto;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--v2-border-soft);
+  background: var(--v2-surface);
+}
+
+.v2-thread__header-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.v2-thread__title {
+  min-width: 0;
+  flex: 1;
+}
+
+.v2-thread__title h1 {
+  margin: 0;
+  overflow: hidden;
+  color: var(--v2-text-primary);
+  font: 600 16px/20px var(--v2-font);
+  letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-thread__title p {
+  margin: 2px 0 0;
+  overflow: hidden;
+  color: var(--v2-text-muted);
+  font: 400 12px/16px var(--v2-font);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-thread__working {
+  flex: 0 0 auto;
+  color: var(--v2-text-muted);
+  font: 500 11px/16px var(--v2-font-mono);
+  white-space: nowrap;
+}
+
+.v2-thread__working::before { content: '●'; color: var(--v2-accent); }
+
+.v2-root button.v2-thread__working {
+  min-height: 28px;
+  padding: 4px 6px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+}
+
+.v2-root button.v2-thread__working:hover,
+.v2-root button.v2-thread__working--active { background: var(--v2-surface-hover); }
+
+.v2-thread .v2-msg {
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.v2-thread .v2-msg--grouped { padding: 2px 0; }
+.v2-thread .v2-msg__avatar-ghost { width: 28px; }
+.v2-thread .v2-avatar { width: 28px; height: 28px; border-radius: 4px; }
+.v2-thread .v2-msg__head { height: 18px; gap: 6px; }
+.v2-thread .v2-msg__author,
+.v2-thread .v2-msg__author-btn { font-size: 13px; font-weight: 600; }
+.v2-thread .v2-msg__time { font-family: var(--v2-font-mono); font-size: 11px; }
+
+.v2-message-row--decision { padding: 8px 0; }
+
+.v2-composer {
+  flex: 0 0 auto;
+  margin: 10px 14px 14px;
+  border: 1px solid var(--v2-border);
+  border-radius: 6px;
+  background: var(--v2-surface);
+}
+
+.v2-composer__target {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--v2-border-soft);
+  color: var(--v2-text-secondary);
+  font: 400 12px/16px var(--v2-font);
+}
+
+.v2-root button.v2-composer__target button {
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--v2-text-muted);
+  font-size: 18px;
+  line-height: 1;
+}
+
+.v2-composer__field { position: relative; }
+
+.v2-root .v2-composer__field > textarea {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 68px;
+  padding: 10px 12px 6px;
+  resize: vertical;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--v2-text-primary);
+  font: 400 14px/20px var(--v2-font);
+}
+
+.v2-composer__file { display: none; }
+
+.v2-composer__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 6px 8px 6px 10px;
+  border-top: 1px solid var(--v2-border-soft);
+}
+
+.v2-root button.v2-composer__attach {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--v2-text-secondary);
+}
+
+.v2-root button.v2-composer__attach:hover { background: var(--v2-surface-hover); color: var(--v2-text-primary); }
+
+.v2-composer__posts-as {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--v2-text-muted);
+  font: 500 11px/16px var(--v2-font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-root button.v2-composer__send {
+  min-height: 28px;
+  padding: 4px 12px;
+  border: 1px solid var(--v2-ink);
+  border-radius: 4px;
+  background: var(--v2-ink);
+  color: var(--v2-on-ink);
+  font: 600 12px/18px var(--v2-font);
+}
+
+.v2-root button.v2-composer__send:hover:not(:disabled) { background: var(--v2-ink-hover); }
+.v2-root button.v2-composer__send:disabled { cursor: not-allowed; opacity: 0.45; }
+
+.v2-composer__error {
+  margin: 0;
+  padding: 0 10px 8px;
+  color: #b91c1c;
+  font: 400 12px/16px var(--v2-font);
+}
+
+.v2-composer__warnings {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 10px 8px;
+  color: var(--v2-text-secondary);
+  font: 400 12px/16px var(--v2-font);
+}
+
+@media (max-width: 760px) {
+  .v2-thread__header { padding: 10px 14px; }
+  .v2-thread__working { display: none; }
+  .v2-composer { margin: 8px 14px 14px; }
+}


### PR DESCRIPTION
## TASK-129 PR 3 — stacked on #1555 / #1549

Replaces the legacy workspace chat and bubble route with the thread artboard surface.

- Deletes V2PodChat and V2MessageBubble; the route now composes V2Thread, V2MessageRow, V2DecisionCard, and V2Composer.
- Adds flat 28px-avatar message rows, a pod header with muted description and working count, one bordered composer, and 2px cobalt decision cards.
- Derives decision cards from the durable decision queue joined to their source message ID; choosing a card posts to the existing choose endpoint and settles in place.
- Preserves threads, reactions, uploads, PR cards, replies, and agent-delivery hints.
- Extracts transcript, starter, and message-action modules so route coordination does not own rendering details.
- Updates static layout invariants rather than deleting retired guards.

## Verification

- Frontend typecheck passed.
- Frontend test suite passed: 91 suites, 587 tests.
- Frontend production build passed.
- Focused lint has no errors; repository JSX warnings remain.

UX 1440/390 walk remains required. This is draft pending that review and the stacked cohesive cutover.