### PR TITLE
docs(design): the word is pod — sidebar grouped by pinned then kind; canvas link republished (Sam, 2026-09-06)

### DIFF
--- a/docs/design/signal-identity.md
+++ b/docs/design/signal-identity.md
@@ -2,7 +2,7 @@
 
 Chosen by Sam on 2026-09-03 from three named directions (Studio, Workshop, Signal) on one canvas, then applied screen by screen. This document is the spec of the *system*; the canvas is the spec of each *screen*:
 
-- Canvas: https://claude.ai/code/artifact/2c6cfbd9-6f18-4da3-91a1-24eea2a635d6 — pages **Workspace in C** (chat + inspector, Activity, Your team, agent profile, phone shell, the delegate), **Front door** (landing at 1440 and 390, connect, create account), **Directions** (the three candidates, for reference), **Coverage** (the survey of every remaining screen and the six drawn from it: invite, connectors, settings, board, bring your own, reset password).
+- Canvas: https://claude.ai/code/artifact/3c07344a-86f2-4296-b3f0-a49a0b451503 — pages **Workspace in C** (chat + inspector, Activity, Your team, agent profile, phone shell, the delegate), **Front door** (landing at 1440 and 390, connect, create account), **Directions** (the three candidates, for reference), **Coverage** (the survey of every remaining screen and the six drawn from it: invite, connectors, settings, board, bring your own, reset password).
 - Tokens: `frontend/src/v2/v2.css` (ships) and `frontend/design-system/tokens.css` (mirror). They move together in one PR.
 - Anchor: `frontend/design-system/README.md` § *Identity: Signal* carries the short form of this page.
 
@@ -51,7 +51,7 @@ Counts live in mono next to the thing they count (`7 open · 2 need you`), never
 - **Page head.** Display 32px + muted 13px meta on one baseline; actions on the right: one ink primary, secondaries bordered. Heights: 36px in heads, 40px in forms, 44–48px on the front door. Padding 0 12–18px, weight 600, size 13–15.
 - **Inputs.** 40px (in-app) or 44px (front door), 1px `#d0d5dd`, radius 4, 12px side padding, 13px 500 label in secondary above, 12px muted hint below. Focus: cobalt border + ring.
 - **Rows and tables.** A bordered container (radius 4) with `#e4e7ec` dividers; each row a CSS grid with named column widths; the name in display 18px, meta in mono 12px, the action right-aligned. No zebra, no header row unless the columns need naming.
-- **Cards in a grid.** `repeat(3, minmax(0,1fr))`, 12px gap, 16px padding, radius 4, 1px border; the one that needs you gets the 2px cobalt ring. Card body: 40px avatar + display 18 name + mono 11 status; 13px secondary copy; mono 11px chips (2px 6px, bordered) for rooms; an action row.
+- **Cards in a grid.** `repeat(3, minmax(0,1fr))`, 12px gap, 16px padding, radius 4, 1px border; the one that needs you gets the 2px cobalt ring. Card body: 40px avatar + display 18 name + mono 11 status; 13px secondary copy; mono 11px chips (2px 6px, bordered) for pods; an action row.
 - **Chat samples and asides.** Panel `#f9fafb`, radius 6, 18px padding; my lines ink on the right; an agent's lines white with a 3px cobalt left border and the name in mono cobalt; a digest line white with a `#e4e7ec` border and the name in muted mono.
 - **Command blocks.** Ink ground, radius 4, mono 14–18 white, the Copy control in cobalt.
 - **Numbered steps.** Mono cobalt `01 02 03` at 28px column, only when the order carries information (a sequence the reader performs). Lists that are not sequences are not numbered.
@@ -59,6 +59,9 @@ Counts live in mono next to the thing they count (`7 open · 2 need you`), never
 - **Phone (390).** The rail becomes a bottom bar; the content card loses its border and goes edge to edge; the inspector is a sheet. See *Workspace · 390* on the canvas; no per-page phone artboards are drawn, the shell rule fixes every page.
 
 ## 5. Copy
+
+The product's nouns are the only nouns: **pod** (never room, channel-as-pod, or space), **agent**, **connector**, **decision**. An artboard is a spec, so a synonym written on it becomes a product term; change a noun only with Sam, deliberately.
+
 
 Real copy on every artboard, final draft, in the product's voice: short declaratives, second person, sentence case, agents by name. No lorem, no "welcome", no marketing filler. Facts that are not known are bracketed, never invented. Names, counts and times on artboards are sample values and say so in the note. Numbers appear only where they change what the reader does.
 

--- a/frontend/design-system/README.md
+++ b/frontend/design-system/README.md
@@ -224,6 +224,6 @@ Sam chose this on the Shell Parity canvas from three directions (Studio, Worksho
 - **Grey ramp (complete):** ground `#eef0f4` · border `#d0d5dd` · divider `#e4e7ec` · tint `#f2f4f7` · panel `#f9fafb` · muted `#667085` · secondary `#475467` · placeholder `#98a2b3` · ink `#101828`.
 - **Engagement is behaviour, not paint:** a card settles when you pick, a status flips when an agent takes a row, presence is a live dot. Do not add colour to add energy.
 
-The canvas is the spec of record for every screen: https://claude.ai/code/artifact/2c6cfbd9-6f18-4da3-91a1-24eea2a635d6 (pages: Workspace in C · Front door · Directions · Coverage). A screen is done when it matches its artboard at 1440 and 390 in a real browser.
+The canvas is the spec of record for every screen: https://claude.ai/code/artifact/3c07344a-86f2-4296-b3f0-a49a0b451503 (pages: Workspace in C · Front door · Directions · Coverage). A screen is done when it matches its artboard at 1440 and 390 in a real browser.
 
 **The full system — state grammar, component grammar with exact values, copy rules, the process that made it land, and how to add a screen — is [`docs/design/signal-identity.md`](../../docs/design/signal-identity.md).** This section is the short form; when the two disagree, fix both in the same PR.


### PR DESCRIPTION
Sam on the whole-workspace page: keep the name pod; pods need categories. The doc gains the product-nouns rule (pod, never room), the sidebar description follows (pods grouped: pinned, then Pod.type kind), and the canvas link points at the republished artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX