### PR TITLE
feat(daemon): Phase 2 work surface — placement requests, work list, runtime mint, agent-state heartbeats

### DIFF
--- a/backend/__tests__/unit/routes/agentBinding.phase2.test.js
+++ b/backend/__tests__/unit/routes/agentBinding.phase2.test.js
@@ -1,0 +1,213 @@
+// ADR-026 Phase 2 work surface on mongodb-memory-server: a placement request
+// is a directive (never a binding), the daemon work list is scoped by the
+// credential's machineId AND the owner's installation set, and the runtime
+// mint requires the D3 binding, carries daemon lineage, and rotates totally
+// (ledger + both legacy stores) or not at all.
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../../../middleware/auth', () => {
+  const mw = (req, res, next) => { req.user = { id: global.__CALLER_ID }; next(); };
+  mw.touchLastActive = jest.fn();
+  return mw;
+});
+
+const { hash } = require('../../../utils/secret');
+
+let mongod; let app; let AgentCredential; let User; let AgentInstallation; let Machine;
+const DAEMON_A = `cm_daemon_${'a'.repeat(32)}`;
+const DAEMON_B = `cm_daemon_${'b'.repeat(32)}`;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  AgentCredential = require('../../../models/AgentCredential');
+  User = require('../../../models/User');
+  Machine = require('../../../models/Machine');
+  AgentInstallation = require('../../../models/AgentRegistry').AgentInstallation;
+  app = express();
+  app.use(express.json());
+  app.use('/api/agent-binding', require('../../../routes/agentBinding'));
+});
+
+afterAll(async () => { await mongoose.disconnect(); await mongod.stop(); });
+
+let owner; let bot; let daemonCredA;
+beforeEach(async () => {
+  await Promise.all([
+    User.deleteMany({}), AgentCredential.deleteMany({}), AgentInstallation.deleteMany({}), Machine.deleteMany({}),
+  ]);
+  owner = await User.create({ username: `o${Date.now() % 1e6}`, email: `o${Date.now()}@x.com`, password: 'x'.repeat(12) });
+  global.__CALLER_ID = String(owner._id);
+  bot = await User.create({
+    username: `b${Date.now() % 1e6}`, email: `b${Date.now()}@agents.commonly.local`, password: 'x'.repeat(12),
+    isBot: true, botMetadata: { agentName: 'wren-test', instanceId: 'default' },
+  });
+  await AgentInstallation.create({
+    agentName: 'wren-test', instanceId: 'default', podId: new mongoose.Types.ObjectId(),
+    version: '1.0.0', status: 'active', installedBy: owner._id,
+    config: { runtime: { runtimeType: 'wrapper', model: 'claude-opus-5' } },
+  });
+  for (const [tok, mid] of [[DAEMON_A, 'machine-a'], [DAEMON_B, 'machine-b']]) {
+    // eslint-disable-next-line no-await-in-loop
+    const cred = await AgentCredential.create({
+      tokenHash: hash(tok), kind: 'daemon', ownerUserId: owner._id, machineId: mid, scopes: ['machine:heartbeat', 'agents:adopt'],
+    });
+    if (mid === 'machine-a') daemonCredA = cred;
+  }
+  await Machine.create({ ownerUserId: owner._id, machineId: 'machine-a', name: 'Mac A' });
+  await Machine.create({ ownerUserId: owner._id, machineId: 'machine-b', name: 'Mac B' });
+});
+
+const requestPlacement = (machineId) => request(app)
+  .post('/api/agent-binding/request')
+  .send({ agentName: 'wren-test', instanceId: 'default', machineId });
+
+const adopt = (tok) => request(app)
+  .post('/api/agent-binding/adopt')
+  .set('Authorization', `Bearer ${tok}`)
+  .send({ agentName: 'wren-test', instanceId: 'default' });
+
+const assigned = (tok) => request(app)
+  .get('/api/agent-binding/assigned')
+  .set('Authorization', `Bearer ${tok}`);
+
+const mint = (tok, body = {}) => request(app)
+  .post('/api/agent-binding/runtime-token')
+  .set('Authorization', `Bearer ${tok}`)
+  .send({ agentName: 'wren-test', instanceId: 'default', ...body });
+
+describe('placement request', () => {
+  it('records a directive without binding, and null withdraws it', async () => {
+    const res = await requestPlacement('machine-a');
+    expect(res.status).toBe(200);
+    let identity = await User.findById(bot._id).lean();
+    expect(identity.botMetadata.requestedMachineId).toBe('machine-a');
+    expect(identity.botMetadata.machineId ?? null).toBeNull();
+
+    const withdrawn = await requestPlacement(null);
+    expect(withdrawn.status).toBe(200);
+    identity = await User.findById(bot._id).lean();
+    expect(identity.botMetadata.requestedMachineId).toBeNull();
+  });
+
+  it('404s a machine the caller does not own', async () => {
+    await Machine.updateOne({ machineId: 'machine-b' }, { ownerUserId: new mongoose.Types.ObjectId() });
+    const res = await requestPlacement('machine-b');
+    expect(res.status).toBe(404);
+  });
+
+  it('403s a caller without the installation', async () => {
+    global.__CALLER_ID = String(new mongoose.Types.ObjectId());
+    const res = await requestPlacement('machine-a');
+    expect(res.status).toBe(403);
+  });
+
+  it('409s when the agent is bound to a different machine', async () => {
+    await User.updateOne({ _id: bot._id }, { $set: { 'botMetadata.machineId': 'machine-b' } });
+    const res = await requestPlacement('machine-a');
+    expect(res.status).toBe(409);
+    expect(res.body.boundTo).toBe('machine-b');
+  });
+});
+
+describe('daemon work list', () => {
+  it('shows a requested agent only to the requested machine, with its runtime config', async () => {
+    await requestPlacement('machine-a');
+
+    const seenByA = await assigned(DAEMON_A);
+    expect(seenByA.status).toBe(200);
+    expect(seenByA.body.agents).toEqual([expect.objectContaining({
+      agentName: 'wren-test',
+      instanceId: 'default',
+      state: 'requested',
+      runtime: expect.objectContaining({ model: 'claude-opus-5' }),
+    })]);
+
+    const seenByB = await assigned(DAEMON_B);
+    expect(seenByB.body.agents).toEqual([]);
+  });
+
+  it('flips to bound after adopt, and adopt consumes the request', async () => {
+    await requestPlacement('machine-a');
+    expect((await adopt(DAEMON_A)).status).toBe(200);
+
+    const identity = await User.findById(bot._id).lean();
+    expect(identity.botMetadata.machineId).toBe('machine-a');
+    expect(identity.botMetadata.requestedMachineId).toBeNull();
+
+    const seenByA = await assigned(DAEMON_A);
+    expect(seenByA.body.agents).toEqual([expect.objectContaining({ state: 'bound' })]);
+  });
+
+  it('excludes identities outside the owner installation set', async () => {
+    // Another user's agent lands on the same machineId string — never listed.
+    await User.create({
+      username: 'stranger-bot', email: 'sb@agents.commonly.local', password: 'x'.repeat(12),
+      isBot: true, botMetadata: { agentName: 'stranger-agent', instanceId: 'default', machineId: 'machine-a' },
+    });
+    const seenByA = await assigned(DAEMON_A);
+    expect(seenByA.body.agents).toEqual([]);
+  });
+});
+
+describe('runtime-token mint', () => {
+  it('refuses an unbound agent', async () => {
+    const res = await mint(DAEMON_A);
+    expect(res.status).toBe(409);
+  });
+
+  it('mints a lineage-carrying credential for a bound agent', async () => {
+    await adopt(DAEMON_A);
+    const res = await mint(DAEMON_A);
+    expect(res.status).toBe(201);
+    expect(res.body.token).toMatch(/^cm_agent_/);
+    expect(res.body.rotated).toBe(false);
+
+    const row = await AgentCredential.findOne({ kind: 'runtime', tokenHash: hash(res.body.token) }).lean();
+    expect(row).toEqual(expect.objectContaining({
+      machineId: 'machine-a',
+      parentId: daemonCredA._id,
+      status: 'active',
+    }));
+  });
+
+  it('refuses to overwrite an existing token without rotate:true', async () => {
+    await adopt(DAEMON_A);
+    await mint(DAEMON_A);
+    const res = await mint(DAEMON_A);
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('token_exists');
+  });
+
+  it('rotate:true revokes the ledger row and clears both legacy stores', async () => {
+    await adopt(DAEMON_A);
+    const first = await mint(DAEMON_A);
+    // Simulate the legacy installation-side copy the old attach flow wrote.
+    await AgentInstallation.updateMany(
+      { agentName: 'wren-test', instanceId: 'default' },
+      { $set: { runtimeTokens: [{ tokenHash: hash(first.body.token), label: 'legacy copy', createdAt: new Date() }] } },
+    );
+
+    const second = await mint(DAEMON_A, { rotate: true });
+    expect(second.status).toBe(201);
+    expect(second.body.rotated).toBe(true);
+    expect(second.body.token).not.toBe(first.body.token);
+
+    const oldRow = await AgentCredential.findOne({ tokenHash: hash(first.body.token) }).lean();
+    expect(oldRow.status).toBe('revoked');
+    const identity = await User.findById(bot._id).lean();
+    expect(identity.agentRuntimeTokens.map((t) => t.tokenHash)).toEqual([hash(second.body.token)]);
+    const install = await AgentInstallation.findOne({ agentName: 'wren-test' }).lean();
+    expect(install.runtimeTokens || []).toEqual([]);
+  });
+
+  it('never mints for a daemon whose machine does not hold the binding', async () => {
+    await adopt(DAEMON_A);
+    const res = await mint(DAEMON_B);
+    expect(res.status).toBe(409);
+    expect(res.body.boundTo).toBe('machine-a');
+  });
+});

--- a/backend/__tests__/unit/routes/machines.test.js
+++ b/backend/__tests__/unit/routes/machines.test.js
@@ -84,12 +84,17 @@ describe('machine lifecycle routes', () => {
   it('uses the daemon credential only for the matching heartbeat', async () => {
     mockRecordMachineHeartbeat.mockResolvedValue({ id: '0123456789abcdef01234567', status: 'online' });
 
-    const res = await request(app).post('/api/machines/0123456789abcdef01234567/heartbeat');
+    const agents = [{ agentName: 'wren-test', instanceId: 'default', state: 'running', restarts: 0 }];
+    const res = await request(app)
+      .post('/api/machines/0123456789abcdef01234567/heartbeat')
+      .send({ agents });
 
     expect(res.status).toBe(200);
+    // D5: the reported agent states ride the same heartbeat, verbatim — the
+    // service owns validation.
     expect(mockRecordMachineHeartbeat).toHaveBeenCalledWith(expect.objectContaining({
       machineId: 'daemon-machine',
-    }));
+    }), agents);
     expect(mockFindMachine).toHaveBeenCalledWith({
       _id: '0123456789abcdef01234567',
       machineId: 'daemon-machine',

--- a/backend/__tests__/unit/services/machineService.test.js
+++ b/backend/__tests__/unit/services/machineService.test.js
@@ -63,6 +63,31 @@ describe('ADR-026 machine lifecycle service', () => {
     expect(result.lastSeenAt).toBeInstanceOf(Date);
   });
 
+  it('stores reported agent states wholesale, drops malformed entries, and preserves the last report when the array is absent', async () => {
+    const ownerUserId = new mongoose.Types.ObjectId();
+    const { machine } = await machineService.registerMachine({ ownerUserId, name: 'Agent Mac' });
+    const persisted = await Machine.findById(machine.id);
+
+    const reported = await machineService.recordMachineHeartbeat(persisted, [
+      { agentName: 'Wren-Test', state: 'running', restarts: 2 },
+      { agentName: 'kai-test', instanceId: 'ci', state: 'crashed', restarts: -3 },
+      { agentName: '', state: 'running' },
+      { agentName: 'bad-state', state: 'sleeping' },
+    ]);
+    expect(reported.agentStates).toEqual([
+      { agentName: 'wren-test', instanceId: 'default', state: 'running', restarts: 2 },
+      { agentName: 'kai-test', instanceId: 'ci', state: 'crashed', restarts: 0 },
+    ]);
+
+    // A Phase-1 daemon that reports no array must not erase the last report.
+    const unchanged = await machineService.recordMachineHeartbeat(await Machine.findById(machine.id));
+    expect(unchanged.agentStates).toHaveLength(2);
+
+    // An explicit empty array IS a report: nothing is supervised any more.
+    const cleared = await machineService.recordMachineHeartbeat(await Machine.findById(machine.id), []);
+    expect(cleared.agentStates).toEqual([]);
+  });
+
   it('returns only the credential-bound machine for daemon status', async () => {
     const ownerUserId = new mongoose.Types.ObjectId();
     const first = await machineService.registerMachine({ ownerUserId, name: 'First Mac' });

--- a/backend/models/Machine.ts
+++ b/backend/models/Machine.ts
@@ -2,6 +2,18 @@ import mongoose, { Document, Schema, Types } from 'mongoose';
 
 export type MachineStatus = 'online' | 'offline';
 
+// ADR-026 D5: per-agent supervisor state, reported by the daemon on each
+// heartbeat. 'crashed' means the supervisor observed an abnormal exit and is
+// backing off; restarts counts supervisor-initiated respawns since adoption.
+export type AgentRunState = 'running' | 'stopped' | 'crashed';
+
+export interface IMachineAgentState {
+  agentName: string;
+  instanceId: string;
+  state: AgentRunState;
+  restarts: number;
+}
+
 export interface IMachine extends Document {
   ownerUserId: Types.ObjectId;
   // Opaque server-assigned identifier. Agent identities bind to this value in
@@ -10,6 +22,7 @@ export interface IMachine extends Document {
   name: string;
   lastSeenAt: Date | null;
   status: MachineStatus;
+  agentStates: IMachineAgentState[];
   createdAt: Date;
   updatedAt: Date;
 }
@@ -23,6 +36,18 @@ const MachineSchema = new Schema<IMachine>(
     // Last reported status. Read APIs derive an offline view from lastSeenAt
     // instead of mutating this row merely because a status page was opened.
     status: { type: String, enum: ['online', 'offline'], default: 'offline' },
+    // D5: replaced wholesale by each heartbeat that carries an agents array —
+    // the daemon's report is the truth, so no per-entry merging.
+    agentStates: {
+      type: [{
+        _id: false,
+        agentName: { type: String, required: true },
+        instanceId: { type: String, required: true, default: 'default' },
+        state: { type: String, enum: ['running', 'stopped', 'crashed'], required: true },
+        restarts: { type: Number, default: 0, min: 0 },
+      }],
+      default: [],
+    },
   },
   { timestamps: true, collection: 'machines' },
 );

--- a/backend/models/User.ts
+++ b/backend/models/User.ts
@@ -134,6 +134,10 @@ export interface IUser extends Document {
     instanceId?: string;
     // ADR-026 D3: the machine this identity is bound to (adoption CAS).
     machineId?: string | null;
+    // ADR-026 Phase 2: an owner's pending "run this on machine X" ask. The
+    // daemon on X sees it in its work list and performs the adopt CAS; it is
+    // a directive, never a binding — the CAS remains the only binding writer.
+    requestedMachineId?: string | null;
     runtime?: string;
     icon?: string;
   };
@@ -266,6 +270,8 @@ const userSchema = new Schema<IUser>({
     instanceId: { type: String },
     // ADR-026 D3 — declared or Mongoose strips it (the #1282 lesson).
     machineId: { type: String, default: null },
+    // ADR-026 Phase 2 — same lesson: declared or stripped.
+    requestedMachineId: { type: String, default: null },
   },
   avatarMetadata: {
     style: {

--- a/backend/routes/agentBinding.ts
+++ b/backend/routes/agentBinding.ts
@@ -98,7 +98,9 @@ router.post('/adopt', bindingRateLimit, daemonAuth('agents:adopt'), async (req: 
         'botMetadata.instanceId': instanceId,
         $or: [{ 'botMetadata.machineId': null }, { 'botMetadata.machineId': { $exists: false } }],
       },
-      { $set: { 'botMetadata.machineId': machine.machineId } },
+      // A successful adopt consumes any pending placement request — the
+      // binding IS the fulfilled request, whichever machine it named.
+      { $set: { 'botMetadata.machineId': machine.machineId, 'botMetadata.requestedMachineId': null } },
     );
     if (result.modifiedCount === 1) {
       return res.json({ adopted: true, agentName, instanceId, machineId: machine.machineId });
@@ -116,6 +118,201 @@ router.post('/adopt', bindingRateLimit, daemonAuth('agents:adopt'), async (req: 
     });
   } catch (err) {
     console.error('adopt error:', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// ADR-026 Phase 2: placement request — the OWNER (human JWT, i.e. the UI's
+// "run it on <machine>" choice) asks for an agent to run on one of their
+// machines. This writes a DIRECTIVE, never a binding: the daemon on that
+// machine sees the request in /assigned and performs the adopt CAS itself,
+// so D3's "no adoption without a user choice" and "one binding writer" both
+// hold. machineId: null withdraws the request.
+router.post('/request', bindingRateLimit, auth, async (req: express.Request & { user?: { id?: string } }, res: express.Response) => {
+  try {
+    const agentName = normalize(req.body?.agentName);
+    const instanceId = normalize(req.body?.instanceId) || 'default';
+    if (!agentName) return res.status(400).json({ message: 'agentName required' });
+    const requestedMachineId = req.body?.machineId === null ? null : String(req.body?.machineId || '').trim();
+    if (requestedMachineId === '') return res.status(400).json({ message: 'machineId required (null to withdraw)' });
+
+    const ownership = await ownsAgent(req.user?.id, agentName, instanceId);
+    if (!ownership.owned) {
+      return res.status(403).json({
+        message: ownershipFailureMessage[ownership.failure],
+        code: ownership.failure,
+      });
+    }
+
+    if (requestedMachineId) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Machine = require('../models/Machine');
+      const machine = await Machine.findOne({ machineId: requestedMachineId, ownerUserId: req.user?.id }).select('_id').lean();
+      if (!machine) return res.status(404).json({ message: 'Machine not found' });
+    }
+
+    const identity = await User.findOne({
+      isBot: true, 'botMetadata.agentName': agentName, 'botMetadata.instanceId': instanceId,
+    }).select('botMetadata.machineId').lean();
+    if (!identity) return res.status(404).json({ message: 'Agent identity not found' });
+    if (requestedMachineId && identity.botMetadata?.machineId
+        && identity.botMetadata.machineId !== requestedMachineId) {
+      return res.status(409).json({
+        message: 'Agent is bound to another machine — release it first',
+        boundTo: identity.botMetadata.machineId,
+      });
+    }
+
+    await User.updateOne(
+      { _id: identity._id },
+      { $set: { 'botMetadata.requestedMachineId': requestedMachineId } },
+    );
+    return res.json({
+      requested: Boolean(requestedMachineId), agentName, instanceId, machineId: requestedMachineId,
+    });
+  } catch (err) {
+    console.error('placement request error:', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// ADR-026 Phase 2: the daemon's work list. Ownership authority is the
+// installation set (same sole-installer basis as ownsAgent): start from the
+// owner's active installations, then join to identities bound to — or
+// requested onto — THIS machine (credential-derived machineId, never input).
+router.get('/assigned', bindingRateLimit, daemonAuth('agents:adopt'), async (req: DaemonAuthedRequest, res: express.Response) => {
+  try {
+    const machine = req.machine!;
+    if (!machine.machineId) return res.status(400).json({ message: 'Daemon credential carries no machineId' });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { AgentInstallation } = require('../models/AgentRegistry');
+    const installs = await AgentInstallation.find({ installedBy: machine.ownerUserId, status: 'active' })
+      .select('agentName instanceId podId config').lean();
+    if (!installs.length) return res.json({ agents: [] });
+
+    const byIdentity = new Map<string, { agentName: string; instanceId: string; podIds: string[]; runtime: unknown }>();
+    for (const install of installs) {
+      const agentName = normalize(install.agentName);
+      const instanceId = normalize(install.instanceId) || 'default';
+      const key = `${agentName} ${instanceId}`;
+      // AgentInstallation.config is a Mongoose Map; lean() yields a plain
+      // object, but stay defensive about both shapes.
+      const config = install.config instanceof Map
+        ? Object.fromEntries(install.config)
+        : (install.config || {});
+      const entry = byIdentity.get(key) || {
+        agentName, instanceId, podIds: [], runtime: null,
+      };
+      if (install.podId) entry.podIds.push(String(install.podId));
+      if (!entry.runtime && config.runtime) entry.runtime = config.runtime;
+      byIdentity.set(key, entry);
+    }
+
+    const identities = await User.find({
+      isBot: true,
+      $or: [
+        { 'botMetadata.machineId': machine.machineId },
+        { 'botMetadata.requestedMachineId': machine.machineId },
+      ],
+    }).select('botMetadata.agentName botMetadata.instanceId botMetadata.machineId botMetadata.requestedMachineId').lean();
+
+    const agents = identities.flatMap((identity: { botMetadata?: Record<string, unknown> }) => {
+      const meta = identity.botMetadata || {};
+      const key = `${normalize(meta.agentName)} ${normalize(meta.instanceId) || 'default'}`;
+      const entry = byIdentity.get(key);
+      // An identity outside the owner's installation set (shared, or another
+      // user's) never appears in this daemon's work list.
+      if (!entry) return [];
+      return [{
+        agentName: entry.agentName,
+        instanceId: entry.instanceId,
+        state: meta.machineId === machine.machineId ? 'bound' : 'requested',
+        podIds: entry.podIds,
+        runtime: entry.runtime,
+      }];
+    });
+    return res.json({ agents });
+  } catch (err) {
+    console.error('assigned list error:', err);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// ADR-026 Phase 2 (D4.5 consumer): mint the runtime credential for an agent
+// BOUND to this machine, as a child of this machine's daemon credential —
+// lineage makes machine removal revoke it transitively. If a token already
+// exists it lives on some other machine's disk; rotate:true is the explicit
+// "this machine takes over" step and invalidates the old token everywhere.
+router.post('/runtime-token', bindingRateLimit, daemonAuth('agents:adopt'), async (req: DaemonAuthedRequest, res: express.Response) => {
+  try {
+    const agentName = normalize(req.body?.agentName);
+    const instanceId = normalize(req.body?.instanceId) || 'default';
+    if (!agentName) return res.status(400).json({ message: 'agentName required' });
+    const machine = req.machine!;
+    if (!machine.machineId) return res.status(400).json({ message: 'Daemon credential carries no machineId' });
+
+    const ownership = await ownsAgent(machine.ownerUserId, agentName, instanceId);
+    if (!ownership.owned) {
+      return res.status(403).json({
+        message: ownershipFailureMessage[ownership.failure],
+        code: ownership.failure,
+      });
+    }
+
+    const agentUser = await User.findOne({
+      isBot: true, 'botMetadata.agentName': agentName, 'botMetadata.instanceId': instanceId,
+    });
+    if (!agentUser) return res.status(404).json({ message: 'Agent identity not found' });
+    if (agentUser.botMetadata?.machineId !== machine.machineId) {
+      return res.status(409).json({
+        message: 'Agent is not bound to this machine — adopt it first',
+        boundTo: agentUser.botMetadata?.machineId || null,
+      });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const AgentCredential = require('../models/AgentCredential');
+    const hasToken = (agentUser.agentRuntimeTokens || []).length > 0;
+    if (hasToken && req.body?.rotate !== true) {
+      return res.status(409).json({
+        message: 'Agent already has a runtime token — pass rotate:true to invalidate it and mint one for this machine',
+        code: 'token_exists',
+      });
+    }
+    if (hasToken) {
+      // Rotation must be total: revoke the ledger rows AND clear both legacy
+      // stores (User + installation copies), or the old bearer keeps working
+      // through the legacy auth fallback.
+      const hashes = (agentUser.agentRuntimeTokens || []).map((t: { tokenHash: string }) => t.tokenHash);
+      await AgentCredential.updateMany(
+        { tokenHash: { $in: hashes }, kind: 'runtime' },
+        { $set: { status: 'revoked', revokedAt: new Date() } },
+      );
+      agentUser.agentRuntimeTokens = [];
+      await agentUser.save();
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { AgentInstallation } = require('../models/AgentRegistry');
+      await AgentInstallation.updateMany({ agentName, instanceId }, { $set: { runtimeTokens: [] } });
+    }
+
+    // req.machine is deliberately a minimal projection (Vera's S1 ruling), so
+    // re-derive the issuing daemon credential for parent lineage.
+    const daemonCredential = await AgentCredential.findOne({
+      kind: 'daemon', machineId: machine.machineId, ownerUserId: machine.ownerUserId, status: 'active',
+    }).select('_id').lean();
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { issueRuntimeTokenForAgent } = require('./registry/tokens');
+    const minted = await issueRuntimeTokenForAgent(agentUser, `Daemon mint (${machine.machineId})`, null, {
+      ownerUserId: machine.ownerUserId,
+      parentId: daemonCredential?._id || null,
+      machineId: machine.machineId,
+    });
+    return res.status(201).json({
+      agentName, instanceId, token: minted.token, rotated: hasToken,
+    });
+  } catch (err) {
+    console.error('runtime-token mint error:', err);
     return res.status(500).json({ message: 'Server error' });
   }
 });
@@ -140,7 +337,9 @@ router.post('/release', bindingRateLimit, auth, async (req: express.Request & { 
     }
     const result = await User.updateOne(
       { isBot: true, 'botMetadata.agentName': agentName, 'botMetadata.instanceId': instanceId },
-      { $set: { 'botMetadata.machineId': null } },
+      // Withdraw any pending placement too — a release means "stop running
+      // this anywhere", not "fail over to the requested machine".
+      { $set: { 'botMetadata.machineId': null, 'botMetadata.requestedMachineId': null } },
     );
     if (!result.matchedCount) return res.status(404).json({ message: 'Agent identity not found' });
     return res.json({ released: true, agentName, instanceId });

--- a/backend/routes/machines.ts
+++ b/backend/routes/machines.ts
@@ -75,7 +75,7 @@ router.post(
         ownerUserId: req.machine?.ownerUserId,
       });
       if (!machine) return res.status(403).json({ message: 'Access denied' });
-      return res.json({ machine: await recordMachineHeartbeat(machine) });
+      return res.json({ machine: await recordMachineHeartbeat(machine, req.body?.agents) });
     } catch (error) {
       console.error('Error recording machine heartbeat:', error);
       return res.status(500).json({ message: 'Server error' });

--- a/backend/services/machineService.ts
+++ b/backend/services/machineService.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { Types } from 'mongoose';
-import Machine, { IMachine } from '../models/Machine';
+import Machine, { IMachine, IMachineAgentState } from '../models/Machine';
 import AgentCredential from '../models/AgentCredential';
 import User from '../models/User';
 import { issueDaemonCredential } from './daemonCredentialService';
@@ -16,6 +16,34 @@ export interface MachineView {
   name: string;
   lastSeenAt: Date | null;
   status: 'online' | 'offline';
+  agentStates: IMachineAgentState[];
+}
+
+// D5 heartbeat payload bounds. A daemon reports every agent it supervises;
+// anything beyond the machine-level cap is a malfunctioning reporter, not a
+// bigger fleet — drop the tail rather than storing unbounded caller input.
+export const MAX_REPORTED_AGENT_STATES = 100;
+const AGENT_RUN_STATES = new Set(['running', 'stopped', 'crashed']);
+
+export function normalizeAgentStates(raw: unknown): IMachineAgentState[] | null {
+  if (raw === undefined || raw === null) return null;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .slice(0, MAX_REPORTED_AGENT_STATES)
+    .map((entry) => {
+      const e = (entry || {}) as Record<string, unknown>;
+      const agentName = String(e.agentName || '').trim().toLowerCase();
+      const state = String(e.state || '');
+      if (!agentName || !AGENT_RUN_STATES.has(state)) return null;
+      const restarts = Number(e.restarts);
+      return {
+        agentName,
+        instanceId: String(e.instanceId || '').trim().toLowerCase() || 'default',
+        state: state as IMachineAgentState['state'],
+        restarts: Number.isFinite(restarts) && restarts > 0 ? Math.floor(restarts) : 0,
+      };
+    })
+    .filter((entry): entry is IMachineAgentState => entry !== null);
 }
 
 export interface MachineListView {
@@ -39,6 +67,12 @@ const serializeMachine = (machine: IMachine | LeanMachine, now = new Date()): Ma
     status: lastSeenAt && now.getTime() - lastSeenAt.getTime() <= MACHINE_OFFLINE_AFTER_MS
       ? 'online'
       : 'offline',
+    agentStates: ((machine.agentStates || []) as IMachineAgentState[]).map((s) => ({
+      agentName: s.agentName,
+      instanceId: s.instanceId,
+      state: s.state,
+      restarts: s.restarts,
+    })),
   };
 };
 
@@ -104,9 +138,16 @@ export async function getMachineForDaemon({
   return machine ? serializeMachine(machine) : null;
 }
 
-export async function recordMachineHeartbeat(machine: IMachine): Promise<MachineView> {
+export async function recordMachineHeartbeat(
+  machine: IMachine,
+  agentStates?: unknown,
+): Promise<MachineView> {
   machine.lastSeenAt = new Date();
   machine.status = 'online';
+  // A heartbeat WITHOUT an agents array leaves the last report standing (a
+  // Phase-1 daemon keeps working); one WITH the array replaces it wholesale.
+  const normalized = normalizeAgentStates(agentStates);
+  if (normalized !== null) machine.agentStates = normalized;
   await machine.save();
   return serializeMachine(machine.toObject ? machine.toObject() : machine);
 }
@@ -149,6 +190,8 @@ export async function removeMachine({
 module.exports = {
   MACHINE_OFFLINE_AFTER_MS,
   MAX_MACHINES_PER_OWNER,
+  MAX_REPORTED_AGENT_STATES,
+  normalizeAgentStates,
   listMachinesForOwner,
   getMachineForDaemon,
   recordMachineHeartbeat,


### PR DESCRIPTION
ADR-026 Phase 2, slice 1 — the server-side surface a resident daemon needs before `commonly daemon run` (slice 2, next PR) can exist. All driver-layer; no kernel change.

## What changed

**Placement request** — `POST /api/agent-binding/request` (owner JWT). The UI's "run it on \<machine\>" choice, stored as a directive (`botMetadata.requestedMachineId`), never a binding. D3 holds: the adopt CAS remains the only binding writer, a successful adopt consumes the request, release withdraws it. Ownership is the same sole-installer predicate as adopt; the target machine must be owned by the caller; a bound-elsewhere identity 409s with `boundTo`.

**Daemon work list** — `GET /api/agent-binding/assigned` (daemon token, `agents:adopt` scope). Identities bound to or requested onto THIS machine (credential-derived machineId, never caller input), intersected with the owner's active installation set — an identity outside it never appears. Each row carries `state: bound|requested`, podIds, and the installation's `config.runtime` so the daemon can provision (model pin included) without another read.

**Runtime credential mint** — `POST /api/agent-binding/runtime-token` (daemon token). Requires the D3 binding to this machine; mints the `cm_agent_*` token as a child of the machine's daemon credential (D4.5 lineage — machine removal already cascade-revokes descendants). An existing token 409s `token_exists` unless `rotate:true`; rotation is total — ledger row revoked AND both legacy stores cleared (User.agentRuntimeTokens + installation runtimeTokens copies), otherwise the old bearer would keep working through the legacy auth fallback. `req.machine` stays the minimal S1 projection; the parent credential is re-derived server-side.

**Agent-state heartbeats (D5)** — `POST /api/machines/:id/heartbeat` now accepts `agents: [{agentName, instanceId, state: running|stopped|crashed, restarts}]`, validated and capped in the service, replaced wholesale per report. An absent array preserves the last report (a Phase-1 daemon keeps working); an explicit empty array is itself a report. States serialize on every machine view, so the UI can render "nothing is running gavin-codex" truthfully.

## Verification

31 tests green across the four daemon suites: 13 new (placement directive semantics, work-list machine+owner scoping, mint lineage/rotation totality/wrong-machine refusal, heartbeat state normalization + preserve-vs-clear), plus the existing adoption CAS suite untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtwYLMJAYuZ3grLQoXWMWT