### PR TITLE
feat(cli): commonly daemon run — the resident supervision loop (ADR-026 Phase 2, slice 2)

### DIFF
--- a/cli/__tests__/daemon-supervisor.test.mjs
+++ b/cli/__tests__/daemon-supervisor.test.mjs
@@ -1,0 +1,202 @@
+// ADR-026 Phase 2 slice 2: the supervision loop's decisions, with every side
+// effect injected — no processes, no network, no real timers.
+import { jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+import {
+  backoffMs,
+  BACKOFF_BASE_MS,
+  BACKOFF_MAX_MS,
+  createDaemonSupervisor,
+} from '../src/lib/daemon-supervisor.js';
+
+const record = {
+  machineDbId: '507f1f77bcf86cd799439011',
+  machineId: 'machine-a',
+  machineName: 'Mac A',
+  instanceUrl: 'https://api.commonly.me',
+  daemonToken: 'cm_daemon_secret',
+};
+
+const makeChild = () => {
+  const child = new EventEmitter();
+  child.kill = jest.fn();
+  return child;
+};
+
+const boundRow = (over = {}) => ({
+  agentName: 'wren-test',
+  instanceId: 'default',
+  state: 'bound',
+  podIds: ['pod-1'],
+  runtime: { runtimeType: 'wrapper', model: 'claude-opus-5' },
+  ...over,
+});
+
+const makeHarness = ({ rows, tokens = {}, mintResponses = [] } = {}) => {
+  const children = [];
+  const timers = [];
+  const client = {
+    get: jest.fn(async () => ({ agents: rows() })),
+    post: jest.fn(async (path, body) => {
+      if (path === '/api/agent-binding/runtime-token') {
+        const next = mintResponses.shift();
+        if (next instanceof Error) throw next;
+        return next || { token: 'cm_agent_minted' };
+      }
+      return { ok: true, path, body };
+    }),
+  };
+  const saveToken = jest.fn((name, rec) => { tokens[name] = rec; });
+  const supervisor = createDaemonSupervisor({
+    record,
+    client,
+    spawnChild: jest.fn((name) => {
+      const child = makeChild();
+      children.push({ name, child });
+      return child;
+    }),
+    loadToken: (name) => tokens[name] || null,
+    saveToken,
+    resolveAdapter: jest.fn(async () => 'claude'),
+    setTimeoutFn: (fn, ms) => { timers.push({ fn, ms }); return timers.length; },
+    clearTimeoutFn: jest.fn(),
+  });
+  return {
+    supervisor, client, children, timers, saveToken, tokens,
+  };
+};
+
+describe('backoff', () => {
+  test('doubles from the base and caps', () => {
+    expect(backoffMs(0)).toBe(BACKOFF_BASE_MS);
+    expect(backoffMs(1)).toBe(BACKOFF_BASE_MS * 2);
+    expect(backoffMs(20)).toBe(BACKOFF_MAX_MS);
+  });
+});
+
+describe('tick', () => {
+  test('adopts a requested row, mints its token, writes the record, and spawns', async () => {
+    const { supervisor, client, children, saveToken } = makeHarness({
+      rows: () => [boundRow({ state: 'requested' })],
+    });
+    await supervisor.tick();
+
+    expect(client.post).toHaveBeenCalledWith('/api/agent-binding/adopt', {
+      agentName: 'wren-test', instanceId: 'default',
+    });
+    expect(saveToken).toHaveBeenCalledWith('wren-test', expect.objectContaining({
+      agentName: 'wren-test',
+      runtimeToken: 'cm_agent_minted',
+      instanceUrl: record.instanceUrl,
+      podId: 'pod-1',
+      adapter: 'claude',
+    }));
+    expect(children).toHaveLength(1);
+    expect(supervisor.agentStates()).toEqual([
+      expect.objectContaining({ agentName: 'wren-test', state: 'running', restarts: 0 }),
+    ]);
+  });
+
+  test('an existing token file skips the mint entirely', async () => {
+    const { supervisor, client, children } = makeHarness({
+      rows: () => [boundRow()],
+      tokens: { 'wren-test': { agentName: 'wren-test', runtimeToken: 'cm_agent_old' } },
+    });
+    await supervisor.tick();
+    expect(client.post).not.toHaveBeenCalledWith('/api/agent-binding/runtime-token', expect.anything());
+    expect(children).toHaveLength(1);
+  });
+
+  test('answers token_exists with an explicit rotate, never silently', async () => {
+    const conflict = Object.assign(new Error('exists'), { status: 409, body: { code: 'token_exists' } });
+    const { supervisor, client, children } = makeHarness({
+      rows: () => [boundRow()],
+      mintResponses: [conflict, { token: 'cm_agent_rotated' }],
+    });
+    await supervisor.tick();
+    expect(client.post).toHaveBeenCalledWith('/api/agent-binding/runtime-token', expect.objectContaining({ rotate: true }));
+    expect(children).toHaveLength(1);
+  });
+
+  test('a lost adopt race drops the row without spawning', async () => {
+    const { supervisor, client, children } = makeHarness({ rows: () => [boundRow({ state: 'requested' })] });
+    client.post.mockImplementation(async (path) => {
+      if (path === '/api/agent-binding/adopt') {
+        throw Object.assign(new Error('bound elsewhere'), { status: 409 });
+      }
+      return { token: 'cm_agent_minted' };
+    });
+    await supervisor.tick();
+    expect(children).toHaveLength(0);
+  });
+
+  test('an agent that leaves the work list is stopped', async () => {
+    let assigned = [boundRow()];
+    const { supervisor, children } = makeHarness({
+      rows: () => assigned,
+      tokens: { 'wren-test': { agentName: 'wren-test' } },
+    });
+    await supervisor.tick();
+    expect(children).toHaveLength(1);
+
+    assigned = [];
+    await supervisor.tick();
+    expect(children[0].child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+});
+
+describe('supervision (D6)', () => {
+  test('respawns only from the exit event, with backoff and a crash count', async () => {
+    const { supervisor, children, timers } = makeHarness({
+      rows: () => [boundRow()],
+      tokens: { 'wren-test': { agentName: 'wren-test' } },
+    });
+    await supervisor.tick();
+    expect(children).toHaveLength(1);
+
+    // A second tick while the child runs must NOT double-spawn.
+    await supervisor.tick();
+    expect(children).toHaveLength(1);
+
+    children[0].child.emit('exit', 1);
+    expect(supervisor.agentStates()[0]).toEqual(expect.objectContaining({ state: 'crashed', restarts: 1 }));
+    expect(timers).toHaveLength(1);
+    expect(timers[0].ms).toBe(BACKOFF_BASE_MS);
+
+    // A tick during backoff must not spawn either — the timer owns the respawn.
+    await supervisor.tick();
+    expect(children).toHaveLength(1);
+
+    timers[0].fn();
+    expect(children).toHaveLength(2);
+    expect(supervisor.agentStates()[0].state).toBe('running');
+  });
+
+  test('a clean exit records stopped, and stop() terminates without respawn', async () => {
+    const { supervisor, children, timers } = makeHarness({
+      rows: () => [boundRow()],
+      tokens: { 'wren-test': { agentName: 'wren-test' } },
+    });
+    await supervisor.tick();
+    supervisor.stop();
+    expect(children[0].child.kill).toHaveBeenCalledWith('SIGTERM');
+    children[0].child.emit('exit', 0);
+    expect(timers).toHaveLength(0);
+    expect(supervisor.agentStates()[0].state).toBe('stopped');
+  });
+});
+
+describe('heartbeat', () => {
+  test('reports the supervised states on the machine heartbeat', async () => {
+    const { supervisor, client } = makeHarness({
+      rows: () => [boundRow()],
+      tokens: { 'wren-test': { agentName: 'wren-test' } },
+    });
+    await supervisor.tick();
+    await supervisor.heartbeat();
+    expect(client.post).toHaveBeenCalledWith(`/api/machines/${record.machineDbId}/heartbeat`, {
+      agents: [expect.objectContaining({ agentName: 'wren-test', state: 'running' })],
+    });
+  });
+});

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.28",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/cli",
-      "version": "0.1.28",
+      "version": "0.1.32",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "license": "Apache-2.0",
-  "description": "The Commonly CLI \u2014 connect agents, manage pods, iterate fast",
+  "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",
   "main": "./src/index.js",
   "bin": {

--- a/cli/src/commands/daemon.js
+++ b/cli/src/commands/daemon.js
@@ -6,10 +6,20 @@
  * later slices; this command never reads an agent runtime credential.
  */
 
-import { hostname } from 'os';
+import { hostname, homedir } from 'os';
+import { spawn } from 'child_process';
+import { existsSync, mkdirSync, openSync } from 'fs';
+import { join } from 'path';
 import { createClient } from '../lib/api.js';
 import { getToken, resolveInstanceUrl } from '../lib/config.js';
 import { loadDaemonRecord, saveDaemonRecord } from '../lib/daemon-store.js';
+import {
+  createDaemonSupervisor,
+  DEFAULT_HEARTBEAT_MS,
+  DEFAULT_POLL_MS,
+} from '../lib/daemon-supervisor.js';
+import { loadAgentToken, saveAgentToken } from './agent.js';
+import { getAdapter } from '../lib/adapters/index.js';
 
 const requireDaemonRecord = () => {
   const record = loadDaemonRecord();
@@ -80,6 +90,20 @@ export const getDaemonMachineStatus = async ({ client }) => {
   return response?.machine || null;
 };
 
+// The adapter names a binary on THIS machine — the one fact the server cannot
+// know (same reasoning as `agent run`'s env bootstrap). A server-declared
+// preference is honored when that CLI is installed; otherwise probe the known
+// ones in order.
+export const resolveAdapterForRuntime = async (runtime, registry = { getAdapter }) => {
+  const candidates = [runtime?.adapter, 'claude', 'codex'].filter(Boolean);
+  for (const name of candidates) {
+    const adapter = registry.getAdapter(name);
+    // eslint-disable-next-line no-await-in-loop
+    if (adapter && await adapter.detect()) return name;
+  }
+  return null;
+};
+
 export const registerDaemon = (program) => {
   const daemon = program.command('daemon').description('Manage the local Commonly daemon');
 
@@ -143,6 +167,58 @@ Examples:
         console.log(`Heartbeat accepted for ${response?.machine?.name || record.machineName}.`);
       } catch (error) {
         console.error(`Daemon heartbeat failed: ${error.message}`);
+        process.exitCode = 1;
+      }
+    });
+
+  // ── run (ADR-026 Phase 2, slice 2) ────────────────────────────────────────
+  daemon
+    .command('run')
+    .description('Run the resident supervisor: adopt requested agents, keep bound agents running, report per-agent state')
+    .option('--poll <ms>', 'Work-list poll interval in ms', String(DEFAULT_POLL_MS))
+    .option('--heartbeat <ms>', 'Heartbeat interval in ms', String(DEFAULT_HEARTBEAT_MS))
+    .action(async (opts) => {
+      try {
+        const record = requireDaemonRecord();
+        const client = createClient({ instance: record.instanceUrl, token: record.daemonToken });
+        const logsDir = join(homedir(), '.commonly', 'logs', 'daemon');
+        if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
+        const stampLog = (line) => console.log(`${new Date().toISOString()} ${line}`);
+
+        const supervisor = createDaemonSupervisor({
+          record,
+          client,
+          // One child per agent, logging to its own file. The child is the
+          // ordinary `commonly agent run <name>` — the daemon is its
+          // supervisor, never its replacement (D6).
+          spawnChild: (agentName) => {
+            const out = openSync(join(logsDir, `${agentName}.log`), 'a');
+            return spawn(process.execPath, [process.argv[1], 'agent', 'run', agentName], {
+              stdio: ['ignore', out, out],
+            });
+          },
+          loadToken: loadAgentToken,
+          saveToken: saveAgentToken,
+          resolveAdapter: (runtime) => resolveAdapterForRuntime(runtime),
+          log: stampLog,
+        });
+
+        stampLog(`daemon supervising for ${record.machineName} — poll ${opts.poll}ms, heartbeat ${opts.heartbeat}ms (ctrl+c to stop)`);
+        await supervisor.tick();
+        await supervisor.heartbeat();
+        const pollTimer = setInterval(() => supervisor.tick(), Number(opts.poll) || DEFAULT_POLL_MS);
+        const heartbeatTimer = setInterval(() => supervisor.heartbeat(), Number(opts.heartbeat) || DEFAULT_HEARTBEAT_MS);
+        const shutdown = () => {
+          stampLog('daemon stopping — terminating supervised agents');
+          clearInterval(pollTimer);
+          clearInterval(heartbeatTimer);
+          supervisor.stop();
+          process.exit(0);
+        };
+        process.on('SIGINT', shutdown);
+        process.on('SIGTERM', shutdown);
+      } catch (error) {
+        console.error(`Daemon run failed: ${error.message}`);
         process.exitCode = 1;
       }
     });

--- a/cli/src/lib/daemon-supervisor.js
+++ b/cli/src/lib/daemon-supervisor.js
@@ -1,0 +1,211 @@
+/**
+ * ADR-026 Phase 2, slice 2: the resident supervision loop behind
+ * `commonly daemon run`.
+ *
+ * The server's work list (GET /api/agent-binding/assigned) is the source of
+ * truth (D2): a row `requested` gets adopted (the D3 CAS — the server refuses
+ * the loser of a race cleanly), a row `bound` gets provisioned (token file)
+ * and supervised (a `commonly agent run <name>` child), and a supervised
+ * agent that leaves the list gets stopped. Per-agent state rides every
+ * machine heartbeat (D5).
+ *
+ * D6 discipline: a replacement child is only ever scheduled from the previous
+ * child's 'exit' event — there is no code path that spawns a second runner
+ * for an agent whose child has not exited.
+ *
+ * All side effects (client, spawn, token file I/O, adapter detection, timers)
+ * are injected so the loop's decisions are testable without processes.
+ */
+
+export const DEFAULT_POLL_MS = 30_000;
+export const DEFAULT_HEARTBEAT_MS = 30_000;
+export const BACKOFF_BASE_MS = 5_000;
+export const BACKOFF_MAX_MS = 60_000;
+
+export const backoffMs = (restarts) => Math.min(
+  BACKOFF_MAX_MS,
+  BACKOFF_BASE_MS * 2 ** Math.max(0, Math.min(restarts, 10)),
+);
+
+const identityKey = (agentName, instanceId) => `${agentName} ${instanceId || 'default'}`;
+
+export const createDaemonSupervisor = ({
+  record,
+  client,
+  spawnChild, // (agentName) => child emitting 'exit'; must expose .kill()
+  loadToken, // (agentName) => token record | null
+  saveToken, // (agentName, record) => void
+  resolveAdapter, // async (runtime) => adapter name for THIS machine
+  log = () => {},
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+}) => {
+  // key → { agentName, instanceId, child, state, restarts, backoffTimer, desired }
+  const seats = new Map();
+  let stopped = false;
+
+  const agentStates = () => Array.from(seats.values()).map((s) => ({
+    agentName: s.agentName,
+    instanceId: s.instanceId,
+    state: s.state,
+    restarts: s.restarts,
+  }));
+
+  const startChild = (seat) => {
+    if (stopped || !seat.desired || seat.child) return;
+    seat.child = spawnChild(seat.agentName);
+    seat.state = 'running';
+    log(`[${seat.agentName}] supervising (restarts so far: ${seat.restarts})`);
+    seat.child.on('exit', (code) => {
+      seat.child = null;
+      if (stopped || !seat.desired) {
+        seat.state = 'stopped';
+        return;
+      }
+      seat.state = code === 0 ? 'stopped' : 'crashed';
+      seat.restarts += 1;
+      const delay = backoffMs(seat.restarts - 1);
+      log(`[${seat.agentName}] exited (code ${code}) — respawn in ${Math.round(delay / 1000)}s`);
+      seat.backoffTimer = setTimeoutFn(() => {
+        seat.backoffTimer = null;
+        startChild(seat);
+      }, delay);
+    });
+  };
+
+  const stopSeat = (seat) => {
+    seat.desired = false;
+    if (seat.backoffTimer) {
+      clearTimeoutFn(seat.backoffTimer);
+      seat.backoffTimer = null;
+    }
+    if (seat.child) {
+      log(`[${seat.agentName}] no longer assigned here — stopping`);
+      seat.child.kill('SIGTERM');
+    } else {
+      seat.state = 'stopped';
+    }
+  };
+
+  // Ensure ~/.commonly/tokens/<name>.json exists so `agent run` can boot.
+  // The mint refuses to clobber an existing token (409 token_exists); the
+  // binding to THIS machine is the owner's explicit takeover choice (D3), so
+  // that refusal is answered with rotate:true — loudly.
+  const ensureToken = async (row) => {
+    if (loadToken(row.agentName)) return true;
+    const body = { agentName: row.agentName, instanceId: row.instanceId };
+    let minted;
+    try {
+      minted = await client.post('/api/agent-binding/runtime-token', body);
+    } catch (error) {
+      if (error?.status === 409 && error?.body?.code === 'token_exists') {
+        log(`[${row.agentName}] a runtime token exists elsewhere — rotating it to this machine (the old token stops working)`);
+        try {
+          minted = await client.post('/api/agent-binding/runtime-token', { ...body, rotate: true });
+        } catch (rotateError) {
+          log(`[${row.agentName}] token rotation failed: ${rotateError.message}`);
+          return false;
+        }
+      } else {
+        log(`[${row.agentName}] token mint failed: ${error.message}`);
+        return false;
+      }
+    }
+    if (!minted?.token) {
+      log(`[${row.agentName}] mint returned no token — skipping`);
+      return false;
+    }
+    const adapter = await resolveAdapter(row.runtime || null);
+    if (!adapter) {
+      log(`[${row.agentName}] no usable CLI adapter on this machine — install claude or codex, or attach manually`);
+      return false;
+    }
+    saveToken(row.agentName, {
+      agentName: row.agentName,
+      instanceId: row.instanceId,
+      runtimeToken: minted.token,
+      instanceUrl: record.instanceUrl,
+      podId: row.podIds?.[0] || null,
+      adapter,
+    });
+    log(`[${row.agentName}] provisioned runtime token (adapter: ${adapter})`);
+    return true;
+  };
+
+  const tick = async () => {
+    if (stopped) return;
+    let assigned;
+    try {
+      assigned = await client.get('/api/agent-binding/assigned');
+    } catch (error) {
+      log(`work-list fetch failed: ${error.message}`);
+      return;
+    }
+    const rows = Array.isArray(assigned?.agents) ? assigned.agents : [];
+
+    const bound = [];
+    for (const row of rows) {
+      if (row.state === 'requested') {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await client.post('/api/agent-binding/adopt', {
+            agentName: row.agentName, instanceId: row.instanceId,
+          });
+          log(`[${row.agentName}] adopted onto this machine`);
+          bound.push(row);
+        } catch (error) {
+          // A clean CAS refusal (409) means another machine won — drop it.
+          log(`[${row.agentName}] adopt refused: ${error.message}`);
+        }
+      } else {
+        bound.push(row);
+      }
+    }
+
+    const desiredKeys = new Set();
+    for (const row of bound) {
+      const key = identityKey(row.agentName, row.instanceId);
+      desiredKeys.add(key);
+      let seat = seats.get(key);
+      if (!seat) {
+        seat = {
+          agentName: row.agentName,
+          instanceId: row.instanceId || 'default',
+          child: null,
+          state: 'stopped',
+          restarts: 0,
+          backoffTimer: null,
+          desired: true,
+        };
+        seats.set(key, seat);
+      }
+      seat.desired = true;
+      if (!seat.child && !seat.backoffTimer) {
+        // eslint-disable-next-line no-await-in-loop
+        if (await ensureToken(row)) startChild(seat);
+      }
+    }
+
+    for (const [key, seat] of seats) {
+      if (!desiredKeys.has(key) && seat.desired) stopSeat(seat);
+    }
+  };
+
+  const heartbeat = async () => {
+    if (stopped) return;
+    try {
+      await client.post(`/api/machines/${record.machineDbId}/heartbeat`, { agents: agentStates() });
+    } catch (error) {
+      log(`heartbeat failed: ${error.message}`);
+    }
+  };
+
+  const stop = () => {
+    stopped = true;
+    for (const seat of seats.values()) stopSeat(seat);
+  };
+
+  return {
+    tick, heartbeat, stop, agentStates,
+  };
+};


### PR DESCRIPTION
Companion to #1562 (merge that first — this loop consumes its three endpoints). Together they close ADR-026 Phase 2's adopt+spawn slice: after `commonly daemon register` + `commonly daemon run`, creating an agent in the web UI and pointing it at this machine is sufficient — the daemon notices, adopts, provisions, and keeps it running. No terminal per agent, ever again (D1/D2).

## What it does

`commonly daemon run` polls `GET /api/agent-binding/assigned` and reconciles:

- **requested** → `POST /adopt` (the D3 CAS; a lost race logs and drops — the other machine won cleanly)
- **bound** → ensure `~/.commonly/tokens/<name>.json` exists: mint via `POST /runtime-token` (daemon-lineage credential), resolve the adapter for THIS machine (server preference honored when installed, else probe claude/codex), write the record — then spawn the ordinary `commonly agent run <name>` as a supervised child logging to `~/.commonly/logs/daemon/<name>.log`. The daemon is `agent run`'s supervisor, never its replacement.
- **gone from the list** → SIGTERM the child, report `stopped`.

Heartbeats now carry `agents: [{agentName, instanceId, state, restarts}]` (D5), so the server renders truthful per-agent liveness.

**D6:** a replacement child is scheduled exclusively from the previous child's `exit` event — a tick during a running child or during backoff spawns nothing (both pinned by tests). Crash respawn backs off 5s→60s. `token_exists` on mint is answered with an explicit `rotate:true` and a loud log line: binding to this machine was the owner's takeover choice, and the old token stops working by design.

## Verification

30 CLI suites green (420 tests, 8 new): adopt→mint→record→spawn, existing-token skip, rotate-on-conflict, lost-race drop, de-assignment stop, double-spawn prevention across ticks and backoff, clean-exit/stop() semantics, heartbeat payload shape. CLI lint green. cli 0.1.31 → 0.1.32.

Remaining Phase 2 residue (next, separate PRs): the UI machine picker wired to `POST /api/agent-binding/request` (the "Add a computer" where-step), and `commonly daemon install` (launchd/systemd registration, D1's install-once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtwYLMJAYuZ3grLQoXWMWT