### PR TITLE
feat(v2): the where-step gains "On my computer" — pick a machine, watch the agent come up

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1150,7 +1150,9 @@
       "nameHint": "Lower-case letters, digits, and dashes. This is the identity your agent posts as.",
       "podLabel": "Install into pod",
       "podHint": "Your agent will be installed here. You can install it into more pods later.",
-      "loadingPods": "Loading pods…"
+      "loadingPods": "Loading pods…",
+      "machineLabel": "Computer",
+      "machineHint": "The daemon on this computer will adopt and start the agent."
     },
     "actions": {
       "install": "Install + generate token",
@@ -1160,7 +1162,9 @@
       "goToPod": "Go to your pod",
       "installAnother": "Install another",
       "runHere": "Run it here",
-      "starting": "Starting…"
+      "starting": "Starting…",
+      "assign": "Add to this computer",
+      "assigning": "Assigning…"
     },
     "footnote": {
       "preferCli": "Prefer the CLI?",
@@ -1200,7 +1204,8 @@
       "fileTooLarge": "That file is over the 256KB import ceiling — trim it or paste the relevant part.",
       "importFailed": "Import failed.",
       "hostedCap": "You already have a hosted agent (beta allows {{cap}}). Connect your own runtime for more.",
-      "hostedUnavailable": "Hosting isn't available on this instance yet. Connect your own runtime instead."
+      "hostedUnavailable": "Hosting isn't available on this instance yet. Connect your own runtime instead.",
+      "machineRequired": "Pick a computer first."
     },
     "listen": {
       "title": "One more step, or it can't answer you",
@@ -1220,7 +1225,10 @@
       "recommended": "RECOMMENDED",
       "yours": "YOUR MACHINE",
       "hostedMeta": "Live in ~10 seconds — no terminal, no keys",
-      "byoMeta": "MCP token + snippets for your editor"
+      "byoMeta": "MCP token + snippets for your editor",
+      "machine": "On my computer",
+      "machineHint": "Runs on a computer you've added — your files, your CLIs",
+      "machineMeta": "Needs the Commonly daemon running there"
     },
     "hosted": {
       "heading": "Running:",
@@ -1245,6 +1253,15 @@
     "persona": {
       "hiring": "Hiring",
       "none": "No colleague selected — this is the blank-agent path."
+    },
+    "machine": {
+      "online": "online",
+      "offline": "offline",
+      "heading": "Now starting:",
+      "running": "Running on {{machine}} — say hi in the pod.",
+      "waiting": "Waiting for the daemon on {{machine}} to pick it up…",
+      "slow": "Still waiting — check that commonly daemon run is active on {{machine}}. The agent starts the moment it's back.",
+      "openPod": "Open the pod"
     }
   },
   "compare": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1211,7 +1211,9 @@
       "nameHint": "小写字母、数字和连字符。这是你的智能体发帖时使用的身份。",
       "podLabel": "安装到 Pod",
       "podHint": "你的智能体会安装在这里。之后可以把它安装到更多 Pod。",
-      "loadingPods": "正在加载 Pod…"
+      "loadingPods": "正在加载 Pod…",
+      "machineLabel": "电脑",
+      "machineHint": "这台电脑上的守护进程会接管并启动该智能体。"
     },
     "actions": {
       "install": "安装并生成令牌",
@@ -1221,7 +1223,9 @@
       "goToPod": "前往你的 Pod",
       "installAnother": "再安装一个",
       "runHere": "在这里运行",
-      "starting": "正在启动…"
+      "starting": "正在启动…",
+      "assign": "添加到这台电脑",
+      "assigning": "分配中…"
     },
     "footnote": {
       "preferCli": "更喜欢用 CLI？",
@@ -1261,7 +1265,8 @@
       "fileTooLarge": "该文件超过 256KB 的导入上限——请精简，或只粘贴相关部分。",
       "importFailed": "导入失败。",
       "hostedCap": "你已有一个托管智能体（测试期允许 {{cap}} 个）。如需更多，请自带运行时。",
-      "hostedUnavailable": "此实例暂未开放托管。请改用自带运行时。"
+      "hostedUnavailable": "此实例暂未开放托管。请改用自带运行时。",
+      "machineRequired": "请先选择一台电脑。"
     },
     "listen": {
       "title": "还差一步，否则它无法回复你",
@@ -1281,7 +1286,10 @@
       "recommended": "推荐",
       "yours": "你的电脑",
       "hostedMeta": "约 10 秒上线——无需终端与密钥",
-      "byoMeta": "MCP 令牌 + 编辑器代码片段"
+      "byoMeta": "MCP 令牌 + 编辑器代码片段",
+      "machine": "在我的电脑上",
+      "machineHint": "在你已添加的电脑上运行——你的文件、你的 CLI",
+      "machineMeta": "需要那台电脑运行 Commonly 守护进程"
     },
     "hosted": {
       "heading": "运行中：",
@@ -1306,6 +1314,15 @@
     "persona": {
       "hiring": "正在雇佣",
       "none": "还没有选择同事——这是空白智能体路径。"
+    },
+    "machine": {
+      "online": "在线",
+      "offline": "离线",
+      "heading": "正在启动：",
+      "running": "已在 {{machine}} 上运行——去 pod 里打个招呼吧。",
+      "waiting": "正在等待 {{machine}} 上的守护进程接管…",
+      "slow": "仍在等待——请确认 {{machine}} 上正在运行 commonly daemon run，恢复后会立即启动该智能体。",
+      "openPod": "打开 pod"
     }
   },
   "agentProfile": {

--- a/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
@@ -1,0 +1,107 @@
+// @ts-nocheck
+// ADR-026 Phase 2 slice 3: the "on my computer" path. Pinned: the mode card
+// appears only when the user has daemon machines; submit installs with
+// runtimeType 'wrapper' and files a placement request (never a binding); the
+// result panel watches the daemon's per-agent heartbeat state.
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2AgentBYO from '../components/V2AgentBYO';
+import { AuthContext } from '../../context/AuthContext';
+
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+const axios = jest.requireMock('axios').default;
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'sam' },
+  user: { _id: 'u1', username: 'sam' },
+  token: 'user-jwt',
+  loading: false,
+  error: null,
+  isAuthenticated: true,
+  register: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  updateProfile: jest.fn(),
+};
+
+const machineRow = {
+  id: 'm1', machineId: 'mach-a', name: 'Sam’s MacBook', status: 'online', agentStates: [],
+};
+
+const mockGet = ({ machines = [machineRow] } = {}) => {
+  axios.get.mockImplementation((url) => {
+    if (url.startsWith('/api/hosted/availability')) {
+      return Promise.resolve({ data: { configured: false, caps: { agentsPerUser: 1, turnsPerDay: 200 } } });
+    }
+    if (url === '/api/pods') return Promise.resolve({ data: [{ _id: 'p1', name: 'Workspace', type: 'chat', createdBy: { _id: 'u1' } }] });
+    if (url === '/api/machines') return Promise.resolve({ data: { machines, offlineAfterMs: 90000 } });
+    return Promise.resolve({ data: {} });
+  });
+};
+
+const renderPage = () => render(
+  <AuthContext.Provider value={authValue}>
+    <MemoryRouter>
+      <V2AgentBYO />
+    </MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+afterEach(() => {
+  jest.clearAllMocks();
+  window.history.pushState({}, '', '/v2/agents/byo');
+});
+
+describe('BYO on-my-computer mode', () => {
+  test('a registered machine surfaces the mode card and picker', async () => {
+    mockGet();
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('byo-mode-machine')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('byo-mode-machine'));
+    expect(screen.getByTestId('byo-machine-select')).toBeInTheDocument();
+    expect(screen.getByTestId('byo-machine-select')).toHaveTextContent('Sam’s MacBook');
+  });
+
+  test('no machines — no card, page untouched', async () => {
+    mockGet({ machines: [] });
+    renderPage();
+    await waitFor(() => expect(axios.get).toHaveBeenCalledWith('/api/machines', expect.anything()));
+    expect(screen.queryByTestId('byo-mode-machine')).toBeNull();
+  });
+
+  test('submit installs a wrapper runtime and files the placement request', async () => {
+    mockGet();
+    axios.post.mockResolvedValue({ data: {} });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('byo-mode-machine')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('byo-mode-machine'));
+    fireEvent.click(screen.getByText('Add to this computer'));
+
+    await waitFor(() => expect(screen.getByTestId('byo-machine-result')).toBeInTheDocument());
+    expect(axios.post).toHaveBeenCalledWith('/api/registry/install', expect.objectContaining({
+      agentName: 'sam-agent',
+      podId: 'p1',
+      config: expect.objectContaining({ runtime: { runtimeType: 'wrapper' } }),
+    }), expect.anything());
+    expect(axios.post).toHaveBeenCalledWith('/api/agent-binding/request', {
+      agentName: 'sam-agent', instanceId: 'default', machineId: 'mach-a',
+    }, expect.anything());
+    // Honest until the daemon reports it: waiting, not live.
+    expect(screen.getByTestId('byo-machine-waiting')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -45,6 +45,19 @@ type HostedAvailability = {
   configured: boolean;
   caps: { agentsPerUser: number; turnsPerDay: number };
 };
+
+// ADR-026 Phase 2: a machine registered by `commonly daemon register`. The
+// heartbeat's per-agent states are what let this page WATCH the agent come up
+// instead of ending on "now run this command".
+type MachineRow = {
+  id: string;
+  machineId: string;
+  name: string;
+  status: 'online' | 'offline';
+  agentStates?: { agentName: string; instanceId: string; state: string }[];
+};
+const MACHINE_STATUS_POLL_MS = 4000;
+const MACHINE_STATUS_MAX_TICKS = 30;
 const CLAUDE_FILE_NAME = 'CLAUDE.md';
 
 const sanitizeAgentName = (raw: string): string => raw
@@ -107,9 +120,45 @@ const V2AgentBYO: React.FC = () => {
   // the token and hands it to the runtime server-side; nothing secret is
   // ever rendered on this screen.
   const [hosting, setHosting] = useState<HostedAvailability | null>(null);
-  const [mode, setMode] = useState<'hosted' | 'byo'>('byo');
+  const [mode, setMode] = useState<'hosted' | 'byo' | 'machine'>('byo');
   const [hosted, setHosted] = useState<{ agentName: string; podId: string } | null>(null);
   const [hostedState, setHostedState] = useState<'starting' | 'running' | 'slow'>('starting');
+  // ADR-026 Phase 2: "on my computer" — install + placement request; the
+  // daemon on the chosen machine adopts, provisions, and starts the agent.
+  const [machines, setMachines] = useState<MachineRow[]>([]);
+  const [machineId, setMachineId] = useState<string>('');
+  const [placed, setPlaced] = useState<{ agentName: string; machineId: string; machineName: string } | null>(null);
+  const [placedState, setPlacedState] = useState<'waiting' | 'running' | 'slow'>('waiting');
+
+  // Watch the placement come up: the machine heartbeat carries per-agent
+  // supervisor states, so "live" here means the daemon actually spawned it.
+  useEffect(() => {
+    if (!placed) return undefined;
+    let cancelled = false;
+    let ticks = 0;
+    setPlacedState('waiting');
+    const timer = setInterval(async () => {
+      ticks += 1;
+      try {
+        const data = await api.get<{ machines?: MachineRow[] }>('/api/machines');
+        if (cancelled) return;
+        const machine = (data?.machines || []).find((m) => m.machineId === placed.machineId);
+        const seat = machine?.agentStates?.find((s) => s.agentName === placed.agentName);
+        if (seat?.state === 'running') {
+          setPlacedState('running');
+          clearInterval(timer);
+          return;
+        }
+      } catch {
+        // keep polling — a transient status failure is not a stopped daemon
+      }
+      if (ticks >= MACHINE_STATUS_MAX_TICKS) {
+        setPlacedState('slow');
+        clearInterval(timer);
+      }
+    }, MACHINE_STATUS_POLL_MS);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, [api, placed]);
 
   // Same shape as the listening check below, against the runtime's own
   // status: the DO reports lastPollAt once its alarm loop has run. ~60s cap,
@@ -195,6 +244,17 @@ const V2AgentBYO: React.FC = () => {
       } catch {
         if (!cancelled) setHosting({ configured: false, caps: { agentsPerUser: 0, turnsPerDay: 0 } });
       }
+      // Third by design — the mode cards degrade gracefully without it.
+      try {
+        const machineList = await api.get<{ machines?: MachineRow[] }>('/api/machines');
+        if (cancelled) return;
+        if (Array.isArray(machineList?.machines) && machineList.machines.length > 0) {
+          setMachines(machineList.machines);
+          setMachineId((prev) => prev || machineList.machines[0].machineId);
+        }
+      } catch {
+        // No daemon machines — the "on my computer" card simply doesn't show.
+      }
     })();
     return () => { cancelled = true; };
   }, [api, podId, currentUser?._id]);
@@ -205,10 +265,12 @@ const V2AgentBYO: React.FC = () => {
   // turns this page from a form into a decision about a teammate.
   const previewName = sanitizeAgentName(name) || DEFAULT_AGENT_NAME;
   const previewPodName = pods.find((p) => p._id === (hosted?.podId || issued?.podId || podId))?.name || '';
-  const previewStatus: 'draft' | 'starting' | 'live' = hosted
-    ? (hostedState === 'running' ? 'live' : 'starting')
-    : (issued && listenState === 'listening' ? 'live' : 'draft');
-  const previewDisplayName = hosted?.agentName || issued?.agentName || previewName;
+  const previewStatus: 'draft' | 'starting' | 'live' = (() => {
+    if (hosted) return hostedState === 'running' ? 'live' : 'starting';
+    if (placed) return placedState === 'running' ? 'live' : 'starting';
+    return issued && listenState === 'listening' ? 'live' : 'draft';
+  })();
+  const previewDisplayName = hosted?.agentName || placed?.agentName || issued?.agentName || previewName;
 
   // Hosted path: install with runtimeType 'hosted' (the kernel's cap gate
   // answers 403 hosted_cap_reached), then ask the kernel to provision. No
@@ -246,6 +308,47 @@ const V2AgentBYO: React.FC = () => {
     }
   };
 
+  // On-my-computer path (ADR-026 Phase 2): install with runtimeType 'wrapper'
+  // + persona, then file the placement request. The daemon on that machine
+  // adopts (D3 CAS), mints the credential server-side (nothing secret renders
+  // here either), and starts the agent — the page watches it come up.
+  const submitMachine = async (cleanName: string) => {
+    if (!machineId) {
+      setError(t('agentByo.errors.machineRequired'));
+      return;
+    }
+    setSubmitting(true);
+    try {
+      try {
+        await api.post('/api/registry/install', {
+          agentName: cleanName,
+          podId,
+          scopes: DEFAULT_SCOPES,
+          config: { runtime: { runtimeType: 'wrapper' }, ...(personaCard ? { persona: personaCard.key } : {}) },
+          displayName: personaCard?.name || cleanName,
+        });
+      } catch (installErr) {
+        // Same identity-continuity tolerance as the BYO path below.
+        const msg = (installErr as { response?: { data?: { error?: string } } })
+          ?.response?.data?.error || '';
+        if (!/already installed/i.test(msg)) throw installErr;
+      }
+      await api.post('/api/agent-binding/request', {
+        agentName: cleanName, instanceId: 'default', machineId,
+      });
+      setPlaced({
+        agentName: cleanName,
+        machineId,
+        machineName: machines.find((m) => m.machineId === machineId)?.name || machineId,
+      });
+    } catch (err) {
+      const e = err as { response?: { data?: { error?: string; message?: string } }; message?: string };
+      setError(e.response?.data?.message || e.response?.data?.error || e.message || t('agentByo.errors.installFailed'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   const submit = async () => {
     setError(null);
     const cleanName = sanitizeAgentName(name);
@@ -259,6 +362,10 @@ const V2AgentBYO: React.FC = () => {
     }
     if (mode === 'hosted') {
       await submitHosted(cleanName);
+      return;
+    }
+    if (mode === 'machine') {
+      await submitMachine(cleanName);
       return;
     }
     setSubmitting(true);
@@ -473,9 +580,9 @@ const V2AgentBYO: React.FC = () => {
           <span>{t('agentByo.persona.none')}</span>
         </div>
       )}
-      {!issued && !hosted && (
+      {!issued && !hosted && !placed && (
         <div className="v2-byo__form">
-          {hosting?.configured && (
+          {(hosting?.configured || machines.length > 0) && (
             <div className="v2-byo__modes" role="group" aria-label={t('agentByo.mode.label')}>
               <button
                 type="button"
@@ -489,6 +596,20 @@ const V2AgentBYO: React.FC = () => {
                 <span className="v2-byo__hint">{t('agentByo.mode.hostedHint', { turns: hosting.caps.turnsPerDay })}</span>
                 <span className="v2-byo__mode-meta">{t('agentByo.mode.hostedMeta')}</span>
               </button>
+              {machines.length > 0 && (
+                <button
+                  type="button"
+                  className="v2-byo__mode"
+                  aria-pressed={mode === 'machine'}
+                  onClick={() => setMode('machine')}
+                  data-testid="byo-mode-machine"
+                >
+                  <span className="v2-byo__mode-kicker v2-byo__mode-kicker--quiet">{t('agentByo.mode.yours')}</span>
+                  <span className="v2-byo__mode-title">{t('agentByo.mode.machine')}</span>
+                  <span className="v2-byo__hint">{t('agentByo.mode.machineHint')}</span>
+                  <span className="v2-byo__mode-meta">{t('agentByo.mode.machineMeta')}</span>
+                </button>
+              )}
               <button
                 type="button"
                 className="v2-byo__mode"
@@ -502,6 +623,24 @@ const V2AgentBYO: React.FC = () => {
                 <span className="v2-byo__mode-meta">{t('agentByo.mode.byoMeta')}</span>
               </button>
             </div>
+          )}
+          {mode === 'machine' && (
+            <label className="v2-byo__field">
+              <span className="v2-byo__label">{t('agentByo.form.machineLabel')}</span>
+              <select
+                value={machineId}
+                onChange={(e) => setMachineId(e.target.value)}
+                className="v2-byo__input"
+                data-testid="byo-machine-select"
+              >
+                {machines.map((m) => (
+                  <option key={m.machineId} value={m.machineId}>
+                    {m.name} ({t(m.status === 'online' ? 'agentByo.machine.online' : 'agentByo.machine.offline')})
+                  </option>
+                ))}
+              </select>
+              <span className="v2-byo__hint">{t('agentByo.form.machineHint')}</span>
+            </label>
           )}
           <label className="v2-byo__field">
             <span className="v2-byo__label">{t('agentByo.form.nameLabel')}</span>
@@ -539,9 +678,11 @@ const V2AgentBYO: React.FC = () => {
             disabled={submitting || !podId}
             className="v2-byo__submit"
           >
-            {mode === 'hosted'
-              ? (submitting ? t('agentByo.actions.starting') : t('agentByo.actions.runHere'))
-              : (submitting ? t('agentByo.actions.issuing') : t('agentByo.actions.install'))}
+            {(() => {
+              if (mode === 'hosted') return submitting ? t('agentByo.actions.starting') : t('agentByo.actions.runHere');
+              if (mode === 'machine') return submitting ? t('agentByo.actions.assigning') : t('agentByo.actions.assign');
+              return submitting ? t('agentByo.actions.issuing') : t('agentByo.actions.install');
+            })()}
           </button>
           <p className="v2-byo__footnote">
             {t('agentByo.footnote.preferCli')} <code>{CLI_INSTALL_COMMAND}</code>, {t('agentByo.footnote.then')}{' '}
@@ -551,6 +692,31 @@ const V2AgentBYO: React.FC = () => {
             {' · '}
             <a href="https://github.com/Team-Commonly/commonly/blob/main/docs/MCP_INTEGRATION.md" target="_blank" rel="noopener noreferrer">{t('agentByo.footnote.fullWalkthrough')}</a>.
           </p>
+        </div>
+      )}
+
+      {placed && (
+        <div className="v2-byo__result" data-testid="byo-machine-result">
+          <div className="v2-byo__result-hero">
+            <V2Avatar name={placed.agentName} size="lg" kind={AGENT_KIND} seed={`${placed.agentName}:default`} online={placedState === 'running'} />
+            <h2>{t('agentByo.machine.heading')} <code>{placed.agentName}</code></h2>
+          </div>
+          {placedState === 'running' ? (
+            <p data-testid="byo-machine-running">{t('agentByo.machine.running', { machine: placed.machineName })}</p>
+          ) : (
+            <p data-testid={`byo-machine-${placedState}`}>
+              {placedState === 'slow'
+                ? t('agentByo.machine.slow', { machine: placed.machineName })
+                : t('agentByo.machine.waiting', { machine: placed.machineName })}
+            </p>
+          )}
+          <button
+            type="button"
+            className="v2-byo__submit"
+            onClick={() => navigate(podId ? `/v2/pods/${podId}` : '/v2')}
+          >
+            {t('agentByo.machine.openPod')}
+          </button>
         </div>
       )}
 


### PR DESCRIPTION
ADR-026 Phase 2, slice 3 — the UI end of the daemon loop. With #1562 (server work surface) and #1563 (`commonly daemon run`), this closes the arc Sam named: **adding an agent to your own computer is now a UI act.** Merge order: #1562 → #1563 → this (it degrades gracefully before then — the card only renders when `GET /api/machines` returns machines).

## What changed

- When the user has daemon-registered machines, the BYO where-step shows a third mode card, **On my computer**, beside "Run it here" and "Bring your own", with a machine picker (name + online/offline).
- Submit installs the agent (`runtimeType: 'wrapper'`, persona carried through exactly like the other two modes) and files the placement request (`POST /api/agent-binding/request`) — a directive, never a binding: the daemon on that machine adopts via the D3 CAS, mints the runtime credential server-side, and starts the agent. No secret ever renders in the browser on this path.
- The result panel is the D2 promise: instead of "now run this command," the page polls the machine list until the daemon's heartbeat reports the agent `running`, then flips live. After ~2 minutes it says honestly: check `commonly daemon run` on that machine — the agent starts the moment it's back.
- Users with no registered machines see the page exactly as before (no card, no noise). en + zh-CN keys added.

## Verification

3 new tests (card gated on machines existing; wrapper-install + request payloads asserted; waiting-not-live honesty) — full frontend suite 89/89, eslint 0 errors.

Known residue, deliberately out of scope: model choice from the UI needs the runtime config to flow into the daemon's token record environment (next slice), and machine *registration* is still CLI-side (`commonly daemon register`) until `daemon install` (D1) ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtwYLMJAYuZ3grLQoXWMWT