### PR TITLE
fix(v2): open inspector by default on wide screens

### DIFF
--- a/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
+++ b/frontend/src/v2/__tests__/V2LayoutSelection.test.tsx
@@ -127,6 +127,37 @@ describe('V2Layout default pod selection', () => {
     expect(phoneViewport.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
   });
 
+  test.each([
+    [390, null, false],
+    [1199, null, false],
+    [1200, null, true],
+    [1440, null, true],
+    [1440, '1', false],
+    [1199, '0', true],
+  ])('inspector visibility at %ipx with stored preference %s is %s', (width, preference, visible) => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: jest.fn((query: string) => ({
+        matches: query === '(max-width: 760px)' ? Number(width) <= 760 : Number(width) >= 1200,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+    if (preference !== null) localStorage.setItem('v2.inspectorCollapsed', String(preference));
+
+    render(
+      <MemoryRouter initialEntries={['/v2/pods/workspace']}>
+        <Routes>
+          <Route path="/v2/pods/:podId" element={<V2Layout selectionMode="param" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('workspace-inspector') !== null).toBe(visible);
+    expect(localStorage.getItem('v2.inspectorCollapsed')).toBe(preference);
+  });
+
   test('lands a new user in their oldest own workspace instead of auto-joined HQ', async () => {
     renderAutoLayout();
 

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -30,13 +30,13 @@ const isPhoneViewport = (): boolean => (
 const readInspectorCollapsed = (): boolean => {
   try {
     const v = localStorage.getItem(INSPECTOR_PREF_KEY);
-    // Default to collapsed — pod chat reads better when the third column is
-    // out of the way until you ask for it. See user feedback 2026-04-30.
-    if (v === null) return true;
-    return v === '1';
+    if (v !== null) return v === '1';
   } catch {
-    return true;
+    // Unavailable storage uses the same default as a fresh session.
   }
+  // The artboard opens the desktop inspector by default; narrower viewports
+  // keep it closed until requested. Explicit preferences take precedence.
+  return !(typeof window !== 'undefined' && window.matchMedia?.('(min-width: 1200px)').matches);
 };
 
 const writeInspectorCollapsed = (next: boolean) => {


### PR DESCRIPTION
Fresh sessions at widths of 1200px and above now open the workspace inspector on their first render, matching the artboard default ruled in pod message 64201. Previously an absent preference always collapsed it.

Saved preferences still apply, the phone initializer still forces its sheet closed, and narrower fresh sessions remain collapsed. Unavailable storage uses the same viewport default without writing a preference.

Validation: 107 layout/selection and invariant tests pass, plus TypeScript. The cases cover 1199/1200 boundaries, 1440, phone startup, and saved preferences. Restoring the old always-collapsed default fails precisely the two fresh-desktop cases. No CSS changed; no new browser walk performed, as requested.
