### PR TITLE
fix(v2): picking a pod no longer stomps the where-step mode choice

### DIFF
--- a/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
@@ -84,6 +84,35 @@ describe('BYO on-my-computer mode', () => {
     expect(screen.queryByTestId('byo-mode-machine')).toBeNull();
   });
 
+  test('picking a pod does not stomp an explicit mode choice', async () => {
+    // Caught live 2026-09-06: the mount effect re-runs on pod change and
+    // re-asserted the hosted default, flipping "Add to this computer" back
+    // into "Run it here" — my submit went down the hosted path.
+    mockGet();
+    axios.get.mockImplementation((url) => {
+      if (url.startsWith('/api/hosted/availability')) {
+        return Promise.resolve({ data: { configured: true, caps: { agentsPerUser: 1, turnsPerDay: 200 } } });
+      }
+      if (url === '/api/pods') {
+        return Promise.resolve({
+          data: [
+            { _id: 'p1', name: 'Workspace', type: 'chat', createdBy: { _id: 'u1' } },
+            { _id: 'p2', name: 'Playground', type: 'team', createdBy: { _id: 'u1' } },
+          ],
+        });
+      }
+      if (url === '/api/machines') return Promise.resolve({ data: { machines: [machineRow], offlineAfterMs: 90000 } });
+      return Promise.resolve({ data: {} });
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('byo-mode-machine')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('byo-mode-machine'));
+    fireEvent.change(screen.getByRole('combobox', { name: /install into pod/i }), { target: { value: 'p2' } });
+    // The effect refetches on podId change; the mode must survive it.
+    await waitFor(() => expect(screen.getByText('Add to this computer')).toBeInTheDocument());
+    expect(screen.getByTestId('byo-mode-machine')).toHaveAttribute('aria-pressed', 'true');
+  });
+
   test('submit installs a wrapper runtime and files the placement request', async () => {
     mockGet();
     axios.post.mockResolvedValue({ data: {} });

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -121,6 +121,7 @@ const V2AgentBYO: React.FC = () => {
   // ever rendered on this screen.
   const [hosting, setHosting] = useState<HostedAvailability | null>(null);
   const [mode, setMode] = useState<'hosted' | 'byo' | 'machine'>('byo');
+  const modeDefaulted = React.useRef(false);
   const [hosted, setHosted] = useState<{ agentName: string; podId: string } | null>(null);
   const [hostedState, setHostedState] = useState<'starting' | 'running' | 'slow'>('starting');
   // ADR-026 Phase 2: "on my computer" — install + placement request; the
@@ -239,7 +240,15 @@ const V2AgentBYO: React.FC = () => {
         if (cancelled) return;
         if (availability && typeof availability.configured === 'boolean') {
           setHosting(availability);
-          if (availability.configured) setMode('hosted');
+          // Default to hosted ONCE. This effect re-runs on every pod change
+          // (podId is a dep), and re-asserting the default here silently
+          // stomped an explicit mode choice — caught live 2026-09-06: pick
+          // "On my computer", pick a pod, and the submit button turns back
+          // into "Run it here".
+          if (availability.configured && !modeDefaulted.current) {
+            modeDefaulted.current = true;
+            setMode('hosted');
+          }
         }
       } catch {
         if (!cancelled) setHosting({ configured: false, caps: { agentsPerUser: 0, turnsPerDay: 0 } });


### PR DESCRIPTION
The mount effect re-runs on every pod change (podId is a dep) and re-asserted the hosted default each time — so an explicit "On my computer" or "Bring your own" choice silently flipped back to "Run it here" after picking a pod. Caught live during the Phase 2 E2E verify: the submit went down the hosted path and attempted a hosted provision. The default now applies exactly once (ref-guarded).

Regression test reproduces the live sequence: choose machine mode → change pod → the mode and its "Add to this computer" submit survive. 7/7 in the touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtwYLMJAYuZ3grLQoXWMWT