### PR TITLE
feat: model choice from the UI reaches the seat — and changing it restarts the seat

### DIFF
--- a/cli/__tests__/daemon-supervisor.test.mjs
+++ b/cli/__tests__/daemon-supervisor.test.mjs
@@ -98,6 +98,57 @@ describe('tick', () => {
     ]);
   });
 
+  test('a declared model lands in the token record environment', async () => {
+    const { supervisor, saveToken } = makeHarness({
+      rows: () => [boundRow({ runtime: { runtimeType: 'wrapper', model: 'opus' } })],
+    });
+    await supervisor.tick();
+    expect(saveToken).toHaveBeenCalledWith('wren-test', expect.objectContaining({
+      environment: { model: 'opus' },
+    }));
+  });
+
+  test('no declared model — no environment key invented', async () => {
+    const { supervisor, saveToken } = makeHarness({
+      rows: () => [boundRow({ runtime: { runtimeType: 'wrapper' } })],
+    });
+    await supervisor.tick();
+    expect(saveToken.mock.calls[0][1]).not.toHaveProperty('environment');
+  });
+
+  test('a model changed server-side updates the record and restarts the seat', async () => {
+    let model = 'opus';
+    const tokens = { 'wren-test': { agentName: 'wren-test', environment: { model: 'opus' } } };
+    const { supervisor, children, saveToken } = makeHarness({
+      rows: () => [boundRow({ runtime: { runtimeType: 'wrapper', model } })],
+      tokens,
+    });
+    await supervisor.tick();
+    expect(children).toHaveLength(1);
+    expect(saveToken).not.toHaveBeenCalled();
+
+    model = 'sonnet';
+    await supervisor.tick();
+    expect(saveToken).toHaveBeenCalledWith('wren-test', expect.objectContaining({
+      environment: { model: 'sonnet' },
+    }));
+    // Restart flows through the exit event (D6): kill now, respawn on exit.
+    expect(children[0].child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(children).toHaveLength(1);
+    children[0].child.emit('exit', 0);
+    // desired stays true → exit handler schedules the respawn.
+  });
+
+  test('a row without a model never strips a hand-set environment', async () => {
+    const tokens = { 'wren-test': { agentName: 'wren-test', environment: { model: 'opus' } } };
+    const { supervisor, saveToken } = makeHarness({
+      rows: () => [boundRow({ runtime: { runtimeType: 'wrapper' } })],
+      tokens,
+    });
+    await supervisor.tick();
+    expect(saveToken).not.toHaveBeenCalled();
+  });
+
   test('an existing token file skips the mint entirely', async () => {
     const { supervisor, client, children } = makeHarness({
       rows: () => [boundRow()],

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/cli",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/cli",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/lib/daemon-supervisor.js
+++ b/cli/src/lib/daemon-supervisor.js
@@ -87,12 +87,33 @@ export const createDaemonSupervisor = ({
     }
   };
 
+  // The server-declared runtime config carries the owner's model choice; the
+  // adapter reads it from the token record's environment (claude: --model).
+  const environmentFor = (row) => (
+    row.runtime?.model ? { model: String(row.runtime.model) } : null
+  );
+
   // Ensure ~/.commonly/tokens/<name>.json exists so `agent run` can boot.
   // The mint refuses to clobber an existing token (409 token_exists); the
   // binding to THIS machine is the owner's explicit takeover choice (D3), so
   // that refusal is answered with rotate:true — loudly.
+  // Returns 'ready' | 'changed' (record updated — the seat must restart to
+  // load it) | false.
   const ensureToken = async (row) => {
-    if (loadToken(row.agentName)) return true;
+    const existing = loadToken(row.agentName);
+    if (existing) {
+      // A model changed in the UI reaches the seat here: update the record,
+      // and let the caller restart the child (`agent run` reads its record
+      // once at boot). A row with NO declared model leaves the record alone —
+      // never strip an operator's hand-set environment.
+      const wanted = environmentFor(row);
+      if (wanted && existing.environment?.model !== wanted.model) {
+        saveToken(row.agentName, { ...existing, environment: { ...(existing.environment || {}), ...wanted } });
+        log(`[${row.agentName}] model changed to ${wanted.model} — restarting the seat to load it`);
+        return 'changed';
+      }
+      return 'ready';
+    }
     const body = { agentName: row.agentName, instanceId: row.instanceId };
     let minted;
     try {
@@ -120,6 +141,7 @@ export const createDaemonSupervisor = ({
       log(`[${row.agentName}] no usable CLI adapter on this machine — install claude or codex, or attach manually`);
       return false;
     }
+    const environment = environmentFor(row);
     saveToken(row.agentName, {
       agentName: row.agentName,
       instanceId: row.instanceId,
@@ -127,9 +149,10 @@ export const createDaemonSupervisor = ({
       instanceUrl: record.instanceUrl,
       podId: row.podIds?.[0] || null,
       adapter,
+      ...(environment ? { environment } : {}),
     });
-    log(`[${row.agentName}] provisioned runtime token (adapter: ${adapter})`);
-    return true;
+    log(`[${row.agentName}] provisioned runtime token (adapter: ${adapter}${environment ? `, model: ${environment.model}` : ''})`);
+    return 'ready';
   };
 
   const tick = async () => {
@@ -180,9 +203,14 @@ export const createDaemonSupervisor = ({
         seats.set(key, seat);
       }
       seat.desired = true;
-      if (!seat.child && !seat.backoffTimer) {
-        // eslint-disable-next-line no-await-in-loop
-        if (await ensureToken(row)) startChild(seat);
+      // eslint-disable-next-line no-await-in-loop
+      const ready = await ensureToken(row);
+      if (ready === 'changed' && seat.child) {
+        // desired stays true, so the exit handler respawns with the updated
+        // record — the restart path IS the D6 path, no second spawner.
+        seat.child.kill('SIGTERM');
+      } else if (ready && !seat.child && !seat.backoffTimer) {
+        startChild(seat);
       }
     }
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1160,7 +1160,13 @@
       "podHint": "Your agent will be installed here. You can install it into more pods later.",
       "loadingPods": "Loading pods…",
       "machineLabel": "Computer",
-      "machineHint": "The daemon on this computer will adopt and start the agent."
+      "machineHint": "The daemon on this computer will adopt and start the agent.",
+      "modelLabel": "Model",
+      "modelDefault": "Adapter default",
+      "modelOpus": "Opus — strongest reasoning",
+      "modelSonnet": "Sonnet — balanced",
+      "modelHaiku": "Haiku — fastest, cheapest",
+      "modelHint": "Which model the seat runs with. Uses your machine's own CLI login."
     },
     "actions": {
       "install": "Install + generate token",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1220,7 +1220,13 @@
       "podHint": "你的智能体会安装在这里。之后可以把它安装到更多 Pod。",
       "loadingPods": "正在加载 Pod…",
       "machineLabel": "电脑",
-      "machineHint": "这台电脑上的守护进程会接管并启动该智能体。"
+      "machineHint": "这台电脑上的守护进程会接管并启动该智能体。",
+      "modelLabel": "模型",
+      "modelDefault": "适配器默认",
+      "modelOpus": "Opus——推理最强",
+      "modelSonnet": "Sonnet——均衡",
+      "modelHaiku": "Haiku——最快、最省",
+      "modelHint": "该席位运行时使用的模型。走你电脑上自己的 CLI 登录。"
     },
     "actions": {
       "install": "安装并生成令牌",

--- a/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
@@ -133,4 +133,19 @@ describe('BYO on-my-computer mode', () => {
     // Honest until the daemon reports it: waiting, not live.
     expect(screen.getByTestId('byo-machine-waiting')).toBeInTheDocument();
   });
+
+  test('a chosen model rides the install as config.runtime.model; the default sends none', async () => {
+    mockGet();
+    axios.post.mockResolvedValue({ data: {} });
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('byo-mode-machine')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('byo-mode-machine'));
+    fireEvent.change(screen.getByTestId('byo-model-select'), { target: { value: 'opus' } });
+    fireEvent.click(screen.getByText('Add to this computer'));
+
+    await waitFor(() => expect(screen.getByTestId('byo-machine-result')).toBeInTheDocument());
+    expect(axios.post).toHaveBeenCalledWith('/api/registry/install', expect.objectContaining({
+      config: expect.objectContaining({ runtime: { runtimeType: 'wrapper', model: 'opus' } }),
+    }), expect.anything());
+  });
 });

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -128,6 +128,11 @@ const V2AgentBYO: React.FC = () => {
   // daemon on the chosen machine adopts, provisions, and starts the agent.
   const [machines, setMachines] = useState<MachineRow[]>([]);
   const [machineId, setMachineId] = useState<string>('');
+  // Model choice for the on-my-computer path. Aliases, not version-pinned
+  // ids: the seat runs on the USER's own CLI install, whose model ids move —
+  // 'opus'/'sonnet'/'haiku' stay valid across releases. Empty = the
+  // adapter's own default.
+  const [model, setModel] = useState<string>('');
   const [placed, setPlaced] = useState<{ agentName: string; machineId: string; machineName: string } | null>(null);
   const [placedState, setPlacedState] = useState<'waiting' | 'running' | 'slow'>('waiting');
 
@@ -333,7 +338,10 @@ const V2AgentBYO: React.FC = () => {
           agentName: cleanName,
           podId,
           scopes: DEFAULT_SCOPES,
-          config: { runtime: { runtimeType: 'wrapper' }, ...(personaCard ? { persona: personaCard.key } : {}) },
+          config: {
+            runtime: { runtimeType: 'wrapper', ...(model ? { model } : {}) },
+            ...(personaCard ? { persona: personaCard.key } : {}),
+          },
           displayName: personaCard?.name || cleanName,
         });
       } catch (installErr) {
@@ -649,6 +657,23 @@ const V2AgentBYO: React.FC = () => {
                 ))}
               </select>
               <span className="v2-byo__hint">{t('agentByo.form.machineHint')}</span>
+            </label>
+          )}
+          {mode === 'machine' && (
+            <label className="v2-byo__field">
+              <span className="v2-byo__label">{t('agentByo.form.modelLabel')}</span>
+              <select
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                className="v2-byo__input"
+                data-testid="byo-model-select"
+              >
+                <option value="">{t('agentByo.form.modelDefault')}</option>
+                <option value="opus">{t('agentByo.form.modelOpus')}</option>
+                <option value="sonnet">{t('agentByo.form.modelSonnet')}</option>
+                <option value="haiku">{t('agentByo.form.modelHaiku')}</option>
+              </select>
+              <span className="v2-byo__hint">{t('agentByo.form.modelHint')}</span>
             </label>
           )}
           <label className="v2-byo__field">


### PR DESCRIPTION
ADR-026 Phase 2, slice 4 — the second half of the original ask: hire an agent onto your computer AND choose what model it runs, from the UI.

## What changed

**UI (machine mode only):** a Model select — Adapter default / Opus / Sonnet / Haiku. Aliases rather than version-pinned ids on purpose: the seat runs on the user's own CLI install, whose concrete model ids move under it; the aliases stay valid across releases. The choice rides the install as `config.runtime.model`. Default sends nothing.

**Daemon:** the work list already serves `config.runtime` (#1562), and the supervisor now writes `environment: { model }` into the token record it provisions — the exact field `agent run` hands the claude adapter, which turns it into `--model` on every spawn *and* on the session-recovery retry path (the drifting-copy trap the adapter's own tests pin).

**Live reconfiguration:** each tick compares the served model against the local record. A difference updates the record and restarts the seat through the exit event — the same D6 single-spawner path as crash recovery, so no code path can produce two runners. A row with no declared model never touches a hand-set environment (operator seats stay sovereign).

Known residue: the codex adapter has no model-pin flag yet (claude-only for now), and there's no UI to *edit* the model on an existing installation — the daemon side already handles changes, so that's a manage-surface slice.

## Verification

5 new tests across both legs; cli 427 green + lint clean, frontend 616 green + 0 eslint errors. cli 0.1.32 → 0.1.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtwYLMJAYuZ3grLQoXWMWT