### PR TITLE
fix: narrow mention resolution to thread or explicit replies

### DIFF
--- a/backend/__tests__/service/showcase.test.js
+++ b/backend/__tests__/service/showcase.test.js
@@ -4,6 +4,7 @@ const jwt = require('jsonwebtoken');
 const User = require('../../models/User');
 const Pod = require('../../models/Pod');
 const Message = require('../../models/Message');
+const PGMessage = require('../../models/pg/Message');
 const showcaseRoutes = require('../../routes/showcase');
 const adminPodsRoutes = require('../../routes/admin/pods');
 const podRoutes = require('../../routes/pods');
@@ -13,9 +14,12 @@ const {
   setupMongoDb,
   closeMongoDb,
   clearMongoDb,
+  setupPgDb,
+  closePgDb,
 } = require('../utils/testUtils');
 
 const { isShowcaseWorthy } = showcaseRoutes;
+const REAL_DATABASES = process.env.INTEGRATION_TEST === 'true';
 
 describe('Showcase (public read-only) routes', () => {
   let app;
@@ -27,11 +31,13 @@ describe('Showcase (public read-only) routes', () => {
   let publicPod;
   let privatePod;
   let personalPod;
+  let pgPool;
   // A real-but-nonexistent ObjectId — must 404 the SAME way a private pod does.
   const missingPodId = '0123456789abcdef01234567';
 
   beforeAll(async () => {
     await setupMongoDb();
+    if (REAL_DATABASES) pgPool = await setupPgDb();
     process.env.JWT_SECRET = 'test-jwt-secret';
 
     app = express();
@@ -148,11 +154,32 @@ describe('Showcase (public read-only) routes', () => {
       messageType: 'text',
       createdAt: new Date('2026-01-01T00:00:06Z'),
     });
+
+    // The route is PG-first: a healthy empty PG read does NOT fall back to
+    // Mongo. Seed the primary store in Tier 1, not just its fallback.
+    if (pgPool) {
+      for (const user of [humanUser, botUser]) {
+        await pgPool.query('INSERT INTO users (_id, username, is_bot) VALUES ($1, $2, $3)',
+          [String(user._id), user.username, Boolean(user.isBot)]);
+      }
+      await pgPool.query('INSERT INTO pods (id, name, type, created_by) VALUES ($1, $2, $3, $4)',
+        [String(publicPod._id), publicPod.name, publicPod.type, String(humanUser._id)]);
+      const seeded = await Message.find({ podId: publicPod._id }).lean();
+      for (const message of seeded) {
+        await pgPool.query(
+          'INSERT INTO messages (pod_id, user_id, content, message_type, created_at) VALUES ($1, $2, $3, $4, $5)',
+          [String(message.podId), String(message.userId), message.content, message.messageType, message.createdAt]);
+      }
+    }
   });
 
   afterAll(async () => {
     await clearMongoDb();
     await closeMongoDb();
+    if (pgPool) {
+      await closePgDb();
+      await require('../../config/db-pg').pool.end();
+    }
   });
 
   describe('GET /api/showcase/:podId', () => {
@@ -199,8 +226,17 @@ describe('Showcase (public read-only) routes', () => {
   });
 
   describe('GET /api/showcase/:podId/messages', () => {
-    it('returns filtered, whitelisted messages for a public pod (anon)', async () => {
-      const res = await request(app).get(`/api/showcase/${publicPod._id}/messages`);
+    it.each(['primary', 'Mongo fallback'])('returns filtered, whitelisted messages for a public pod (anon): %s', async (store) => {
+      // Fault injection exercises the real Mongo fallback, not a mocked feed.
+      const failure = store === 'Mongo fallback'
+        ? jest.spyOn(PGMessage, 'findByPodId').mockRejectedValueOnce(new Error('injected PG outage'))
+        : null;
+      let res;
+      try {
+        res = await request(app).get(`/api/showcase/${publicPod._id}/messages`);
+      } finally {
+        failure?.mockRestore();
+      }
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('hasMore');
       const contents = res.body.messages.map((m) => m.content);
@@ -216,6 +252,17 @@ describe('Showcase (public read-only) routes', () => {
       expect(JSON.stringify(res.body)).not.toMatch(/email|@test\.com/i);
       const botMsg = res.body.messages.find((m) => m.author.isBot);
       expect(botMsg.author.displayName).toBe('Pixel');
+    });
+
+    (REAL_DATABASES ? it : it.skip)('does not substitute Mongo history for a successful empty PG read', async () => {
+      const emptyPrimaryPod = await Pod.create({
+        name: 'Empty primary', type: 'team', createdBy: humanUser._id,
+        members: [humanUser._id], publicRead: true,
+      });
+      await Message.create({ podId: emptyPrimaryPod._id, userId: humanUser._id, content: 'Mongo-only history' });
+      const res = await request(app).get(`/api/showcase/${emptyPrimaryPod._id}/messages`);
+      expect(res.status).toBe(200);
+      expect(res.body.messages).toEqual([]);
     });
 
     it('returns 404 for a private pod', async () => {

--- a/backend/__tests__/service/threading.derivation.test.js
+++ b/backend/__tests__/service/threading.derivation.test.js
@@ -92,23 +92,50 @@ d('thread_root_id derivation, executed', () => {
     expect(root.thread_root_id).toBeNull();
   });
 
-  test('a PG post resolves its recipient\'s earlier Mongo mention before returning', async () => {
+  test.each(['unthreaded', 'other-thread', 'same-thread', 'explicit-reply'])(
+    'mention resolution and sweep require scoped reply evidence: %s', async (mode) => {
     const AttentionItem = require('../../models/AttentionItem');
+    const { sweepResolvedMentionAttention } = require('../../services/attentionItemService');
+    await AttentionItem.deleteMany({});
+    const root = await insert('mention root');
+    const otherRoot = await insert('unrelated root');
+    await pool.query('UPDATE messages SET created_at = $1 WHERE pod_id = $2', [new Date('2019-01-01'), POD]);
     const attention = await AttentionItem.create({
       recipientUserId: USER,
       podId: POD,
       kind: 'mention',
-      source: { type: 'message', id: 'earlier-mention' },
+      source: { type: 'message', id: String(root.id) },
+      messageId: String(root.id),
+      // Explicit replies must also work for a legacy item without a root.
+      ...(mode === 'explicit-reply' ? {} : { threadRootId: String(root.id) }),
       title: 'Earlier mention',
       sourceCreatedAt: new Date('2020-01-01T00:00:00Z'),
     });
 
-    await insert('a later post without an at-mention');
+    await PGMessage.create(POD, USER, 'a later post', 'text',
+      mode === 'explicit-reply' ? root.id : null, null,
+      mode === 'same-thread' ? root.id : mode === 'other-thread' ? otherRoot.id : null);
 
     const resolved = await AttentionItem.findById(attention._id).lean();
-    expect(resolved.status).toBe('resolved');
-    expect(resolved.resolvedBy).toBe('replied');
-    expect(resolved.resolvedAt).toBeInstanceOf(Date);
+    const shouldResolve = mode === 'same-thread' || mode === 'explicit-reply';
+    if (!shouldResolve) {
+      expect(resolved.status).toBe('open');
+      expect(resolved.resolvedBy).toBeFalsy();
+    } else {
+      expect(resolved.status).toBe('resolved');
+      expect(resolved.resolvedBy).toBe('replied');
+      expect(resolved.resolvedAt).toBeInstanceOf(Date);
+    }
+    // Exercise the maintenance SQL against the same real message history.
+    await AttentionItem.updateOne({ _id: attention._id }, {
+      $set: { status: 'open' }, $unset: { resolvedBy: '', resolvedAt: '' },
+    });
+    const dry = await sweepResolvedMentionAttention();
+    expect(dry).toMatchObject({ scanned: 1, eligible: Number(shouldResolve), resolved: 0 });
+    expect((await AttentionItem.findById(attention._id)).status).toBe('open');
+    const applied = await sweepResolvedMentionAttention({ apply: true });
+    expect(applied).toMatchObject({ eligible: Number(shouldResolve), resolved: Number(shouldResolve) });
+    expect((await AttentionItem.findById(attention._id)).status).toBe(shouldResolve ? 'resolved' : 'open');
   });
 
   test('a direct reply inherits the root id', async () => {

--- a/backend/__tests__/unit/models/PgMessage.test.js
+++ b/backend/__tests__/unit/models/PgMessage.test.js
@@ -136,14 +136,14 @@ describe('PG Message model', () => {
     expect(msg).toHaveProperty('messageType');
   });
 
-  it('checks for a later post without paging the pod history', async () => {
+  it('checks for a later scoped reply without paging the pod history', async () => {
     const after = new Date('2026-09-06T08:00:00.000Z');
     pool.query.mockResolvedValueOnce({ rows: [{ found: 1 }] });
 
-    await expect(Message.hasMessageByUserAfter('pod-1', 'user-1', after)).resolves.toBe(true);
+    await expect(Message.hasReplyByUserAfter('pod-1', 'user-1', after, { messageId: '42', threadRootId: '40' })).resolves.toBe(true);
     expect(pool.query).toHaveBeenCalledWith(
       expect.stringContaining('created_at > $3'),
-      ['pod-1', 'user-1', after],
+      ['pod-1', 'user-1', after, '42', '40'],
     );
   });
 

--- a/backend/__tests__/unit/services/attentionItemService.test.js
+++ b/backend/__tests__/unit/services/attentionItemService.test.js
@@ -13,10 +13,10 @@ const mockMongoMessageFindById = jest.fn();
 const mockMongoMessageExists = jest.fn();
 jest.mock('../../../models/Message', () => ({ findById: mockMongoMessageFindById, exists: mockMongoMessageExists }));
 const mockPgMessageFindById = jest.fn();
-const mockPgMessageHasMessageByUserAfter = jest.fn();
+const mockPgMessageHasReplyByUserAfter = jest.fn();
 jest.mock('../../../models/pg/Message', () => ({
   findById: mockPgMessageFindById,
-  hasMessageByUserAfter: mockPgMessageHasMessageByUserAfter,
+  hasReplyByUserAfter: mockPgMessageHasReplyByUserAfter,
 }));
 
 const chain = (value) => ({ select: () => ({ lean: async () => value }) });
@@ -140,6 +140,8 @@ describe('attentionItemService', () => {
       recipientUserId: 'sam',
       podId: 'pod-1',
       repliedAt: new Date('2026-09-06T08:00:00.000Z'),
+      threadRootId: '40',
+      replyToMessageId: '42',
     });
 
     expect(result).toBe(1);
@@ -149,6 +151,7 @@ describe('attentionItemService', () => {
         podId: 'pod-1',
         kind: 'mention',
         status: 'open',
+        $and: [{ $or: [{ threadRootId: '40' }, { messageId: '42' }] }],
         $or: [
           { sourceCreatedAt: { $lt: new Date('2026-09-06T08:00:00.000Z') } },
           { sourceCreatedAt: { $exists: false }, createdAt: { $lt: new Date('2026-09-06T08:00:00.000Z') } },
@@ -156,6 +159,13 @@ describe('attentionItemService', () => {
       }),
       { $set: expect.objectContaining({ status: 'resolved', resolvedBy: 'replied' }) },
     );
+  });
+
+  it.each([{}, { threadRootId: null, replyToMessageId: null }, { threadRootId: '', replyToMessageId: '' }])('leaves unthreaded posts open without querying Mongo: %j', async (scope) => {
+    await expect(AttentionItemService.resolveMentionAttentionForReply({
+      recipientUserId: 'sam', podId: 'pod-1', repliedAt: new Date(), ...scope,
+    })).resolves.toBe(0);
+    expect(mockUpdateMany).not.toHaveBeenCalled();
   });
 
   it('stamps explicit acknowledgement differently from a reply', async () => {
@@ -167,29 +177,42 @@ describe('attentionItemService', () => {
     );
   });
 
-  it('sweeps legacy mentions only when the recipient really posted after the source, with the replied stamp', async () => {
+  it('sweeps legacy mentions only when the recipient replied after the source, with the replied stamp', async () => {
     const row = {
       _id: 'attention-1',
       recipientUserId: 'sam',
       podId: 'pod-1',
       kind: 'mention',
       source: { type: 'message', id: '42' },
+      messageId: '42', threadRootId: '40',
       createdAt: new Date('2026-09-05T10:00:00.000Z'),
     };
     mockFind.mockReturnValue({ sort: () => ({ lean: async () => [row] }) });
     mockPgMessageFindById.mockResolvedValue({ createdAt: new Date('2026-09-05T09:00:00.000Z') });
-    mockPgMessageHasMessageByUserAfter.mockResolvedValue(true);
+    mockPgMessageHasReplyByUserAfter.mockResolvedValue(true);
 
     const result = await AttentionItemService.sweepResolvedMentionAttention({ apply: true });
 
     expect(result).toEqual({ scanned: 1, eligible: 1, resolved: 1, unavailable: 0 });
-    expect(mockPgMessageHasMessageByUserAfter).toHaveBeenCalledWith(
+    expect(mockPgMessageHasReplyByUserAfter).toHaveBeenCalledWith(
       'pod-1', 'sam', new Date('2026-09-05T09:00:00.000Z'),
+      { messageId: '42', threadRootId: '40' },
     );
     expect(mockUpdateOne).toHaveBeenCalledWith(
       { _id: 'attention-1', kind: 'mention', status: 'open' },
       { $set: expect.objectContaining({ status: 'resolved', resolvedBy: 'replied', sourceCreatedAt: new Date('2026-09-05T09:00:00.000Z') }) },
     );
+  });
+
+  it('keeps Mongo fallback mentions open when no reply edges are persisted', async () => {
+    mockFind.mockReturnValue({ sort: () => ({ lean: async () => [{
+      _id: 'attention-mongo', source: { type: 'message', id: '507f191e810c19729de860ea' },
+      sourceCreatedAt: new Date('2026-01-01'), podId: 'pod-1', recipientUserId: 'sam',
+    }] }) });
+    const result = await AttentionItemService.sweepResolvedMentionAttention({ apply: true });
+    expect(result).toMatchObject({ eligible: 0, resolved: 0 });
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+    expect(mockMongoMessageExists).not.toHaveBeenCalled();
   });
 
   it('materializes a blocked board row once for each current human recipient', async () => {

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -18,6 +18,7 @@ interface MessageRow {
   // for ordinary messages.
   payload?: unknown;
   reply_to_message_id?: string;
+  thread_root_id?: string | number | null;
   created_at: unknown;
   updated_at?: unknown;
   username?: string;
@@ -170,6 +171,8 @@ class Message {
         podId,
         recipientUserId: userId,
         repliedAt: row.created_at,
+        threadRootId: row.thread_root_id,
+        replyToMessageId: row.reply_to_message_id,
       });
       return row;
     } catch (error) {
@@ -273,14 +276,16 @@ class Message {
   // The attention sweep needs an existence check, not a bounded page of
   // messages. Keep that fact at the message store so an old mention can be
   // resolved without reconstructing a pod's history in application memory.
-  static async hasMessageByUserAfter(
+  static async hasReplyByUserAfter(
     podId: string,
     userId: string,
     after: Date,
+    target: { messageId: string; threadRootId?: string | null },
   ): Promise<boolean> {
     const result = await (pool as PgPool).query(
-      'SELECT 1 FROM messages WHERE pod_id = $1 AND user_id = $2 AND created_at > $3 LIMIT 1',
-      [podId, userId, after],
+      `SELECT 1 FROM messages WHERE pod_id = $1 AND user_id = $2 AND created_at > $3
+       AND (reply_to_message_id = $4::int OR thread_root_id = $5::int) LIMIT 1`,
+      [podId, userId, after, target.messageId, target.threadRootId || null],
     );
     return result.rows.length > 0;
   }

--- a/backend/scripts/sweep-resolved-mention-attention.ts
+++ b/backend/scripts/sweep-resolved-mention-attention.ts
@@ -1,6 +1,7 @@
 /**
  * Resolve legacy mention AttentionItems whose recipient already replied in
- * the same pod after the source mention was posted.
+ * the same thread or to the source message, after it was posted. Unrelated
+ * posts do not qualify. Already-resolved items are not changed by this script.
  *
  * Dry run by default:
  *   npm run sweep:resolved-mention-attention

--- a/backend/services/attentionItemService.ts
+++ b/backend/services/attentionItemService.ts
@@ -116,21 +116,29 @@ const validDate = (value: unknown): Date | null => {
 };
 
 /**
- * A recipient's later post is a real answer to earlier mentions in this pod.
- * It deliberately does not resolve a mention in another pod, an older post,
- * or an attention item owned by somebody else.
+ * Sam's 2026-09-06 ruling: only a later post in the mention's thread or an
+ * explicit reply to its message is a reply. An unrelated pod post is not.
  */
 export const resolveMentionAttentionForReply = async ({
   recipientUserId,
   podId,
   repliedAt,
+  threadRootId,
+  replyToMessageId,
 }: {
   recipientUserId: unknown;
   podId: unknown;
   repliedAt: unknown;
+  threadRootId?: unknown;
+  replyToMessageId?: unknown;
 }): Promise<number> => {
   const at = validDate(repliedAt);
   if (!recipientUserId || !podId || !at) return 0;
+  const targets: Record<string, unknown>[] = [];
+  if (threadRootId) targets.push({ threadRootId: String(threadRootId) });
+  if (replyToMessageId) targets.push({ messageId: String(replyToMessageId) });
+  // Also avoids a Mongo round-trip on ordinary, unthreaded chat writes.
+  if (!targets.length) return 0;
   try {
     const result = await AttentionItem.updateMany(
       {
@@ -138,6 +146,7 @@ export const resolveMentionAttentionForReply = async ({
         podId,
         kind: 'mention',
         status: 'open',
+        $and: [{ $or: targets }],
         // sourceCreatedAt is written on all new rows. The createdAt fallback
         // gives the one-shot sweep's legacy population an honest temporary
         // path until it is examined against its source message.
@@ -173,24 +182,24 @@ const sourceTimeForMention = async (row: any): Promise<Date | null> => {
 const recipientRepliedAfterMention = async (row: any, sourceCreatedAt: Date): Promise<boolean> => {
   const sourceId = String(row?.source?.id || '');
   if (/^\d+$/.test(sourceId)) {
-    return PGMessage.hasMessageByUserAfter(
+    return PGMessage.hasReplyByUserAfter(
       String(row.podId),
       String(row.recipientUserId),
       sourceCreatedAt,
+      { messageId: row.messageId || sourceId, threadRootId: row.threadRootId },
     );
   }
-  return Boolean(await Message.exists({
-    podId: row.podId,
-    userId: row.recipientUserId,
-    createdAt: { $gt: sourceCreatedAt },
-  }));
+  // Mongo fallback messages have no persisted reply/thread edges. There is
+  // no evidence of a reply to use here; explicit acknowledgement still works.
+  return false;
 };
 
 /**
  * One-shot repair for mentions created before reply-resolution existed. It
  * reads each source directly, resolves only rows whose recipient actually
- * posted later in the same pod, and records the same `replied` stamp as the
- * live write path. Call from the explicit maintenance script; retries are
+ * replied later in the same thread or to the source message, and records the
+ * same `replied` stamp as the live write path. Call from the explicit
+ * maintenance script; retries are
  * safe because only still-open rows are updated.
  */
 export const sweepResolvedMentionAttention = async ({ apply = false }: { apply?: boolean } = {}) => {

--- a/docs/runbooks/mention-attention-resolution.md
+++ b/docs/runbooks/mention-attention-resolution.md
@@ -1,0 +1,40 @@
+# Mention attention resolution
+
+Sam's 2026-09-06 ruling (Sharpen decision card 64261, reply 64274)
+supersedes TASK-130's original broad, any-later-post rule.
+
+An open mention resolves with `resolvedBy: 'replied'` only when a later
+message by its recipient, in the same pod, either belongs to its non-null
+`threadRootId` or explicitly replies to its `messageId`. An unrelated post
+does not resolve it. Explicit acknowledgement remains a separate
+`resolvedBy: 'acknowledged'` path. Neither path resolves another recipient's
+attention or another kind of attention.
+
+The PostgreSQL writer passes persisted reply and thread IDs, including
+automatically derived roots, to the attention resolver. Unthreaded writes
+skip the resolution query. Mongo fallback messages do not persist thread or
+reply edges; they cannot provide this evidence and remain open unless
+explicitly acknowledged.
+
+## Legacy open mentions
+
+`npm run sweep:resolved-mention-attention` in `backend/` defaults to a dry run.
+Its PostgreSQL query uses the same later-recipient/thread-or-reply rule.
+Missing or unreadable source evidence must not be interpreted as a reply.
+Inspect `scanned`, `eligible`, `resolved`, and `unavailable` before considering
+`--apply`. Production application requires explicit operator authorization;
+the semantics ruling is not that authorization.
+
+The script only considers open mentions. It does not reopen, relabel, or
+otherwise repair items already resolved under the superseded broad rule.
+Those require a separately authorized, source-backed corrective operation.
+The old broad-rule eligible count is not an estimate for the narrow sweep:
+rerun the dry run after the narrow implementation is deployed.
+
+## Regression proof
+
+`backend/__tests__/service/threading.derivation.test.js` executes the live
+writer and sweep against real MongoDB and PostgreSQL. It distinguishes an
+unthreaded post, a different thread, an ordinary same-thread post without a
+reply edge, and a direct reply to a legacy item without a thread ID. Each
+case checks the live state, dry-run nonmutation, and applied sweep outcome.


### PR DESCRIPTION
## Summary

Implements Sam's **Narrow, replied** ruling (Sharpen card 64261, reply 64274) for TASK-130. This explicitly supersedes the earlier any-later-post test and behavior.

- A later recipient post resolves an open mention only in the same pod AND either its non-null thread or by explicit reply to its message ID. Unrelated posts remain open and skip Mongo resolution entirely when unthreaded.
- Pass persisted PostgreSQL thread/reply edges, including automatically derived roots, into the resolver.
- Apply the same scope to the legacy open-item sweep's existence query. No production sweep has been run.
- Mongo fallback messages have no persisted thread/reply edges, so no reply is inferred there. Explicit acknowledgement remains available. No schema change.
- Document semantics and operational limits in `docs/runbooks/mention-attention-resolution.md`.

## Verification

Node 22, real disposable PostgreSQL 16 + MongoDB 7:
- Three service suites + attention/PG unit suites: **42/42**.
- Additional Mongo model, AttentionItem, thread derivation/pg-mem, and activity queue suites: **25/25**.
- Backend `npm run tsc:check` and `git diff --check`: pass.

The four real-store cases run both live writes and dry-run/apply sweep checks: unthreaded, other-thread, same-thread without a reply edge, and explicit reply to a legacy item without a thread ID.

Mutations run separately and restored:
1. Restore broad live resolution (remove scope + early return): **2 red**, unthreaded and other-thread become resolved.
2. Drop persisted scope fields from PG writer: **2 red**, same-thread and explicit-reply remain open.
3. Restore broad sweep SQL only: **2 red**, unthreaded and other-thread incorrectly become eligible.

## Not included

No deploy, production `--apply`, relabel, or reopening of previously resolved items. The 79 reported broad-resolved live items require a separately authorized corrective operation; this PR does not claim to repair them. The prior 250 eligible estimate is stale under the new semantics and must be remeasured after deployment. TASK-125 handoff cards/counts remain separate and unclaimed pending TASK-130 live verification. No claim that the current turn proves receipt of a typed `decision.ruled` event: this turn was triggered by a review message.
