### PR TITLE
fix: authoritative uncapped needs-you counts (TASK-126)

### DIFF
--- a/backend/__tests__/service/attentionQueue.counts.test.js
+++ b/backend/__tests__/service/attentionQueue.counts.test.js
@@ -1,0 +1,50 @@
+const mongoose = require('mongoose');
+const Pod = require('../../models/Pod');
+const AttentionItem = require('../../models/AttentionItem');
+const service = require('../../services/attentionItemService');
+const { setupMongoDb, closeMongoDb, clearMongoDb } = require('../utils/testUtils');
+
+describe('uncapped attention counts — persisted query and membership', () => {
+  beforeAll(setupMongoDb);
+  afterAll(closeMongoDb);
+  afterEach(clearMongoDb);
+
+  it('counts beyond 80, excludes revoked membership and other recipients, and recounts after acknowledgement', async () => {
+    const recipient = new mongoose.Types.ObjectId();
+    const other = new mongoose.Types.ObjectId();
+    const [busy, omitted, revoked] = await Pod.create([
+      { name: 'Busy', type: 'team', createdBy: recipient, members: [recipient] },
+      { name: 'Outside display cap', type: 'team', createdBy: other, members: [recipient] },
+      { name: 'Revoked', type: 'team', createdBy: other, members: [other] },
+    ]);
+    const make = (id, pod, kind = 'mention', who = recipient, status = 'open') => ({
+      recipientUserId: who, podId: pod._id, kind, status,
+      source: { type: kind === 'mention' ? 'message' : 'approval', id }, title: id,
+      createdAt: new Date('2026-09-01T00:00:00Z'),
+    });
+    await AttentionItem.insertMany([
+      ...Array.from({ length: 90 }, (_, i) => make(`mention-${i}`, busy)),
+      ...Array.from({ length: 4 }, (_, i) => make(`approval-${i}`, busy, 'approval')),
+      { ...make('oldest', omitted), createdAt: new Date('2020-01-01') },
+      make('revoked', revoked), make('other-user', busy, 'mention', other),
+      make('closed', busy, 'mention', recipient, 'resolved'),
+    ]);
+    const queue = await service.getOpenQueue(recipient);
+    expect(queue.count).toBe(95);
+    expect(queue.countsByPod).toEqual({ [busy.id]: 94, [omitted.id]: 1 });
+    expect(queue.items).toHaveLength(12);
+    expect(queue.items.filter((item) => item.kind === 'mention')).toHaveLength(8);
+    expect(queue.items.some((item) => item.podId === omitted.id)).toBe(false);
+
+    const old = await AttentionItem.findOne({ 'source.id': 'oldest' });
+    expect(await service.acknowledgeMention(other, old.id)).toMatchObject({ success: false });
+    expect(await service.acknowledgeMention(recipient, old.id)).toMatchObject({ success: true });
+    const next = await service.getOpenQueue(recipient);
+    expect(next.count).toBe(94);
+    expect(next.countsByPod).toEqual({ [busy.id]: 94 });
+  });
+
+  it('returns an authoritative empty shape for invalid recipients', async () => {
+    expect(await service.getOpenQueue('invalid')).toEqual({ items: [], count: 0, countsByPod: {}, composePodId: null });
+  });
+});

--- a/backend/__tests__/unit/services/attentionItemService.test.js
+++ b/backend/__tests__/unit/services/attentionItemService.test.js
@@ -112,10 +112,10 @@ describe('attentionItemService', () => {
   });
 
   it('returns only rows whose recipient is still a member and resolves by recipient-owned id', async () => {
-    mockFind.mockReturnValue({ sort: () => ({ limit: () => ({ lean: async () => [
+    mockFind.mockReturnValue({ sort: () => ({ lean: async () => [
       { _id: 'attention-1', recipientUserId: '507f191e810c19729de860ea', podId: 'pod-1', kind: 'mention', source: { type: 'message', id: '41' }, title: 'Mention', createdAt: new Date() },
       { _id: 'attention-2', recipientUserId: '507f191e810c19729de860ea', podId: 'pod-2', kind: 'approval', source: { type: 'approval', id: 'a-1' }, title: 'Old access', createdAt: new Date() },
-    ] }) }) });
+    ] }) });
     mockPodFind.mockReturnValue(chain([
       { _id: 'pod-1', name: 'Current', createdBy: '507f191e810c19729de860ea', members: [] },
       { _id: 'pod-2', name: 'Removed', createdBy: 'someone-else', members: [] },

--- a/backend/services/attentionItemService.ts
+++ b/backend/services/attentionItemService.ts
@@ -328,12 +328,13 @@ export const resolveMany = async (sourceType: SourceType, sourceIds: unknown[]):
   }
 };
 
-export const getOpenQueue = async (recipientUserId: unknown): Promise<{ items: any[]; count: number; composePodId: string | null }> => {
+export const getOpenQueue = async (recipientUserId: unknown): Promise<{ items: any[]; count: number; countsByPod: Record<string, number>; composePodId: string | null }> => {
   // Route callers carry a real Mongo id. Returning an empty queue for a bad
   // value keeps malformed/read-only callers from turning a cast error into a
   // 500 and makes the authorization boundary explicit.
-  if (!/^[a-f\d]{24}$/i.test(String(recipientUserId))) return { items: [], count: 0, composePodId: null };
-  const rows = await AttentionItem.find({ recipientUserId, status: 'open' }).sort({ createdAt: -1 }).limit(80).lean();
+  if (!/^[a-f\d]{24}$/i.test(String(recipientUserId))) return { items: [], count: 0, countsByPod: {}, composePodId: null };
+  // Counts include every accessible open item; only the rendered cards are capped.
+  const rows = await AttentionItem.find({ recipientUserId, status: 'open' }).sort({ createdAt: -1 }).lean();
   const podIds = [...new Set(rows.map((row: any) => String(row.podId)))];
   const pods = await Pod.find({ _id: { $in: podIds } }).select('_id name createdBy members').lean();
   const allowed = new Map(pods.filter((pod: any) => isCurrentMember(pod, recipientUserId)).map((pod: any) => [String(pod._id), pod]));
@@ -354,7 +355,12 @@ export const getOpenQueue = async (recipientUserId: unknown): Promise<{ items: a
       messageId: row.messageId, threadRootId: row.threadRootId, options: row.options || [], createdAt: row.createdAt,
     });
   }
-  return { items: picked, count: valid.length, composePodId: picked.find((row) => row.kind === 'mention')?.podId || null };
+  const countsByPod = valid.reduce((counts: Record<string, number>, row: any) => {
+    const podId = String(row.podId);
+    counts[podId] = (counts[podId] || 0) + 1;
+    return counts;
+  }, {});
+  return { items: picked, count: valid.length, countsByPod, composePodId: picked.find((row) => row.kind === 'mention')?.podId || null };
 };
 
 export const acknowledgeMention = async (recipientUserId: unknown, attentionItemId: string): Promise<{ success: boolean; error?: string }> => {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -21,8 +21,7 @@ const CurrentPath = () => {
   return <div data-testid="current-path">{location.pathname}{location.search}</div>;
 };
 
-// The queue now arrives from /decision-queue (TASK-083) — recap.needsYou is
-// only the degrade path when that endpoint fails.
+// Only the queue endpoint supplies attention; recap is not a fallback.
 const decisionQueue = {
   items: [
     {
@@ -38,6 +37,7 @@ const decisionQueue = {
     },
   ],
   count: 2,
+  countsByPod: { 'pod-1': 2 },
   composePodId: 'pod-1',
 };
 
@@ -73,13 +73,8 @@ describe('V2ActivityPage', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    // Default: the decision-queue endpoint FAILS, exercising the designed
-    // degrade path (fall back to recap.needsYou) — which also keeps the
-    // pre-existing tests' order-based mockResolvedValueOnce chains valid,
-    // since their Once values feed the recap call and this implementation
-    // catches the queue call. The first test overrides with real items.
     mockGet.mockImplementation((url: string) => {
-      if (url === '/api/activity/decision-queue') return Promise.reject(new Error('queue down'));
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: decisionQueue });
       return Promise.resolve({ data: recap });
     });
     await act(async () => { await i18n.changeLanguage('en'); });
@@ -131,15 +126,16 @@ describe('V2ActivityPage', () => {
   });
 
   test('acknowledges a mention explicitly instead of treating a feed read as acknowledgement', async () => {
-    mockGet
-      .mockResolvedValueOnce({ data: recap })
-      .mockResolvedValue({ data: { ...recap, needsYou: [] } });
+    let reads = 0;
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue'
+      ? (++reads === 1 ? { ...decisionQueue, items: [decisionQueue.items[0]], count: 1 } : { items: [], count: 0, countsByPod: {} })
+      : recap }));
     mockPost.mockResolvedValue({ data: { success: true } });
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Acknowledge' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
-      '/api/activity/mention-1/acknowledge',
+      '/api/activity/attention-1/acknowledge',
       {},
       expect.objectContaining({ headers: expect.any(Object) }),
     ));
@@ -147,7 +143,8 @@ describe('V2ActivityPage', () => {
   });
 
   test('keeps an empty Needs you state honest', async () => {
-    mockGet.mockResolvedValue({ data: { ...recap, needsYou: [] } });
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue'
+      ? { items: [], count: 0, countsByPod: {} } : recap }));
     renderPage();
 
     expect(await screen.findByText('Nothing is waiting on you')).toBeInTheDocument();
@@ -155,7 +152,8 @@ describe('V2ActivityPage', () => {
   });
 
   test('turns a truly empty workspace into the three factual onboarding rows', async () => {
-    mockGet.mockResolvedValue({ data: { ...recap, needsYou: [], agents: [], board: [] } });
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue'
+      ? { items: [], count: 0, countsByPod: {} } : { ...recap, needsYou: [], agents: [], board: [] } }));
     const onGuide = jest.fn();
     window.addEventListener(FIRST_RUN_REOPEN_EVENT, onGuide);
     renderPage();
@@ -296,5 +294,21 @@ describe('V2ActivityPage', () => {
       expect.objectContaining({ headers: expect.any(Object) }),
     ));
     expect(composer).toHaveValue('');
+  });
+
+  test('renders the uncapped count, not the displayed card count', async () => {
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue'
+      ? { ...decisionQueue, count: 91, countsByPod: { 'pod-1': 91 } } : recap }));
+    renderPage();
+    expect(await screen.findByLabelText('91 waiting on you')).toHaveTextContent('91');
+  });
+
+  test('does not substitute recap attention or claim empty on queue failure', async () => {
+    mockGet.mockImplementation((url: string) => url === '/api/activity/decision-queue'
+      ? Promise.reject(new Error('queue down')) : Promise.resolve({ data: recap }));
+    renderPage();
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+    expect(screen.queryByText('Review requested')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nothing is waiting on you')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/__tests__/V2AgentBYOListenVerify.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOListenVerify.test.tsx
@@ -11,6 +11,8 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom';
 import V2AgentBYO from '../components/V2AgentBYO';
 import { AuthContext } from '../../context/AuthContext';
+// This suite owns the BYO request sequence, not the rail's attention query.
+jest.mock('../components/V2NavRail', () => () => null);
 
 jest.mock('axios', () => {
   const mock = {

--- a/frontend/src/v2/__tests__/V2AgentBYOMemory.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOMemory.test.tsx
@@ -8,6 +8,8 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom';
 import V2AgentBYO from '../components/V2AgentBYO';
 import { AuthContext } from '../../context/AuthContext';
+// This suite owns the BYO request sequence, not the rail's attention query.
+jest.mock('../components/V2NavRail', () => () => null);
 
 jest.mock('axios', () => {
   const mock = {

--- a/frontend/src/v2/__tests__/V2AgentBYOPodPicker.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOPodPicker.test.tsx
@@ -10,6 +10,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import V2AgentBYO from '../components/V2AgentBYO';
 import { AuthContext } from '../../context/AuthContext';
+// This suite owns the BYO request sequence, not the rail's attention query.
+jest.mock('../components/V2NavRail', () => () => null);
 
 jest.mock('axios', () => {
   const mock = {

--- a/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
+++ b/frontend/src/v2/__tests__/V2CommunityNav.test.tsx
@@ -60,6 +60,12 @@ describe('Community navigation', () => {
     await i18nReady;
   });
 
+  test('rail shows the full queue count, not a capped card count or 99+', async () => {
+    mockAxiosGet.mockResolvedValue({ data: { items: [], count: 105, countsByPod: { hidden: 105 } } });
+    renderRail();
+    expect(await screen.findByLabelText('105 waiting on you')).toHaveTextContent('105');
+  });
+
   beforeEach(() => {
     process.env.REACT_APP_COMMUNITY_POD_ID = COMMUNITY_POD_ID;
     process.env.REACT_APP_COMMUNITY_INVITE_TOKEN = COMMUNITY_INVITE_TOKEN;

--- a/frontend/src/v2/__tests__/V2Inspector.test.tsx
+++ b/frontend/src/v2/__tests__/V2Inspector.test.tsx
@@ -35,6 +35,7 @@ const renderInspector = (props: Partial<React.ComponentProps<typeof V2Inspector>
   <MemoryRouter>
     <V2Inspector
       detail={detail as any}
+      attentionCount={1}
       attentionItems={[{
         id: 'decision-1', kind: 'decision', title: 'Slack default mode', actorName: 'Wren', podId: 'pod-1', messageId: 'message-7',
       }]}
@@ -100,15 +101,22 @@ describe('V2Inspector', () => {
 
   test('does not render a stale attention item from another pod', async () => {
     mockGet.mockResolvedValue({ tasks: [] });
-    renderInspector({ attentionItems: [{ id: 'other', kind: 'decision', title: 'Other pod', podId: 'pod-2' }] });
+    renderInspector({ attentionCount: 0, attentionItems: [{ id: 'other', kind: 'decision', title: 'Other pod', podId: 'pod-2' }] });
     await waitFor(() => expect(screen.getByText('Nothing. Wren is working.')).toBeInTheDocument());
     expect(screen.queryByText('Other pod')).not.toBeInTheDocument();
   });
 
   test('uses the settled-workspace empty copy when no agent is working', async () => {
     mockGet.mockImplementation(() => Promise.resolve({ items: [], tasks: [] }));
-    renderInspector({ detail: { ...detail, agents: [] } as any, attentionItems: [] });
+    renderInspector({ detail: { ...detail, agents: [] } as any, attentionCount: 0, attentionItems: [] });
 
     expect(await screen.findByText('Nothing open.')).toBeInTheDocument();
+  });
+
+  test('does not claim nothing open when this pod falls outside the display cap', async () => {
+    renderInspector({ attentionCount: 83, attentionItems: [] });
+    fireEvent.click(await screen.findByRole('button', { name: '83 waiting on you' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/v2/activity');
+    expect(screen.queryByText(/Nothing/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodsSidebar.community.test.tsx
@@ -47,7 +47,7 @@ const renderSidebar = (pods, selectedPodId = 'sharpen') => render(
   <MemoryRouter initialEntries={['/v2/pods/sharpen']}>
     <V2PodsSidebar
       selectedPodId={selectedPodId}
-      attentionItems={[{ id: 'decision-1', kind: 'decision', title: 'Choose workspace', podId: 'sharpen' }]}
+      attentionCountByPod={{ sharpen: 91 }}
       podsState={{
         pods,
         loading: false,
@@ -150,7 +150,7 @@ describe('V2PodsSidebar workspace groups', () => {
   test('uses the decision queue count only on the selected room and retains no legacy controls', async () => {
     renderSidebar([pod('sharpen', 'Sharpen', 'team', [human('me'), human('other')])]);
 
-    expect(await screen.findByLabelText('1 needs you')).toHaveTextContent('1');
+    expect(await screen.findByLabelText('91 needs you')).toHaveTextContent('91');
     expect(screen.queryByPlaceholderText('Search pods...')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'All' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Community' })).not.toBeInTheDocument();

--- a/frontend/src/v2/__tests__/useV2PodAttention.test.tsx
+++ b/frontend/src/v2/__tests__/useV2PodAttention.test.tsx
@@ -1,0 +1,24 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useV2PodAttention, notifyAttentionChanged } from '../hooks/useV2PodAttention';
+
+const mockGet = jest.fn();
+jest.mock('../hooks/useV2Api', () => ({ useV2Api: () => ({ get: mockGet }) }));
+
+test('uses uncapped endpoint totals even when a pod has no displayed cards, and refreshes after resolution', async () => {
+  mockGet.mockResolvedValue({ items: [], count: 91, countsByPod: { hidden: 91 } });
+  const { result } = renderHook(() => useV2PodAttention());
+  await waitFor(() => expect(result.current.count).toBe(91));
+  expect(result.current.countByPod).toEqual({ hidden: 91 });
+  mockGet.mockResolvedValue({ items: [], count: 0, countsByPod: {} });
+  act(() => { notifyAttentionChanged(); });
+  await waitFor(() => expect(result.current.count).toBe(0));
+  expect(result.current.countByPod).toEqual({});
+});
+
+test('an unavailable queue is unknown, not an invented zero', async () => {
+  mockGet.mockRejectedValue(new Error('offline'));
+  const { result } = renderHook(() => useV2PodAttention());
+  await act(async () => {});
+  expect(result.current.count).toBeNull();
+  expect(result.current.items).toEqual([]);
+});

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -214,6 +214,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(podAttention).toContain("'/api/activity/decision-queue'");
     expect(v2Layout).toContain('useV2PodAttention()');
     expect(v2Layout).toContain('attentionItems={attention.items}');
+    expect(v2Layout).toContain('attentionCountByPod={attention.countByPod}');
+    expect(v2Layout).toContain('needsYouCount={attention.count}');
+    expect(v2Layout).toContain('attentionCount={attention.count === null ? null : (attention.countByPod[selectedPodId] || 0)}');
     expect(v2Layout).toContain('needsYouCount={selectedPodId ? (attention.countByPod[selectedPodId] || 0) : 0}');
     expect(podsSidebar).toContain('attentionCountByPod');
     expect(podsSidebar).toContain('selected && attentionCount > 0');

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import V2Avatar from './V2Avatar';
 import { requestFirstRunGuide } from '../firstRunGuide';
+import { ATTENTION_CHANGED, notifyAttentionChanged } from '../hooks/useV2PodAttention';
 
 type ActivityWindow = 'today' | '7d';
 
@@ -92,6 +93,18 @@ const V2ActivityPage: React.FC = () => {
   const [composeError, setComposeError] = useState<string | null>(null);
 
   const [queue, setQueue] = useState<NeedsYouItem[]>([]);
+  const [queueCount, setQueueCount] = useState<number | null>(null);
+  const [queueFailed, setQueueFailed] = useState(false);
+
+  useEffect(() => {
+    const refresh = () => setReloadKey((value) => value + 1);
+    globalThis.window.addEventListener(ATTENTION_CHANGED, refresh);
+    globalThis.window.addEventListener('focus', refresh);
+    return () => {
+      globalThis.window.removeEventListener(ATTENTION_CHANGED, refresh);
+      globalThis.window.removeEventListener('focus', refresh);
+    };
+  }, []);
 
   useEffect(() => {
     let active = true;
@@ -99,9 +112,8 @@ const V2ActivityPage: React.FC = () => {
     setError(null);
     const token = localStorage.getItem('token');
     const headers = { 'x-auth-token': token ?? '' };
-    // The recap paints the room; the decision queue is the reason the page
-    // exists (TASK-083). They load together, but a queue failure must not
-    // blank the recap — degrade to recap.needsYou (mentions + approvals).
+    // Recap and attention are independent facts. A failed queue read must
+    // never substitute recap mentions or pretend the queue is empty.
     Promise.all([
       axios.get<ActivityRecap>('/api/activity/recap', {
         headers,
@@ -110,6 +122,8 @@ const V2ActivityPage: React.FC = () => {
       axios.get<{
         items: Array<NeedsYouItem & { createdAt?: string | null }>;
         composePodId?: string | null;
+        count: number;
+        countsByPod: Record<string, number>;
       }>(
         '/api/activity/decision-queue',
         { headers },
@@ -118,9 +132,6 @@ const V2ActivityPage: React.FC = () => {
       .then(([recapResponse, queueResponse]) => {
         if (!active) return;
         setRecap(recapResponse.data);
-        // A well-formed queue response has an items ARRAY. Anything else —
-        // endpoint failed (null), older server, malformed body — degrades to
-        // recap.needsYou (mentions + approvals) rather than an empty queue.
         const rawItems = queueResponse?.data?.items;
         const availablePods = recapResponse.data.pods || [];
         const setComposeDefault = (candidate = '') => {
@@ -129,11 +140,16 @@ const V2ActivityPage: React.FC = () => {
             current && availablePods.some((pod) => pod.id === current) ? current : fallback
           ));
         };
-        if (!Array.isArray(rawItems)) {
-          setQueue(recapResponse.data.needsYou || []);
+        if (!Array.isArray(rawItems) || typeof queueResponse?.data?.count !== 'number'
+          || (podId !== 'all' && !queueResponse?.data?.countsByPod)) {
+          setQueue([]);
+          setQueueCount(null);
+          setQueueFailed(true);
           setComposeDefault();
           return;
         }
+        setQueueFailed(false);
+        setQueueCount(podId === 'all' ? queueResponse!.data.count : (queueResponse!.data.countsByPod?.[podId] || 0));
         const queueItems = rawItems.map((item) => ({
           ...item,
           detail: item.detail || '',
@@ -184,6 +200,7 @@ const V2ActivityPage: React.FC = () => {
         { headers: { 'x-auth-token': token ?? '' } },
       );
       if (!response.data?.success) throw new Error('Approval action failed');
+      notifyAttentionChanged();
       setReloadKey((value) => value + 1);
     } catch {
       setActionError(t('activity.approval.actionFailed'));
@@ -204,6 +221,7 @@ const V2ActivityPage: React.FC = () => {
         { headers: { 'x-auth-token': token ?? '' } },
       );
       if (!response.data?.ok) throw new Error('Decision ruling failed');
+      notifyAttentionChanged();
       setOtherDecisionId(null);
       setOtherDecisionValue('');
       setReloadKey((value) => value + 1);
@@ -235,6 +253,7 @@ const V2ActivityPage: React.FC = () => {
         { headers: { 'x-auth-token': token ?? '' } },
       );
       setComposeDraft('');
+      notifyAttentionChanged();
       setReloadKey((value) => value + 1);
     } catch {
       setComposeError(t('activity.compose.actionFailed'));
@@ -266,6 +285,7 @@ const V2ActivityPage: React.FC = () => {
       setRepliedIds((prev) => new Set(prev).add(item.id));
       setReplyDrafts((prev) => ({ ...prev, [item.id]: '' }));
       if (item.attentionItemId) await axios.post(`/api/activity/${item.attentionItemId}/acknowledge`, {}, { headers: { 'x-auth-token': token ?? '' } }).catch(() => null);
+      notifyAttentionChanged();
       setReloadKey((value) => value + 1);
     } catch {
       setActionError(t('activity.mention.actionFailed'));
@@ -286,6 +306,7 @@ const V2ActivityPage: React.FC = () => {
         { headers: { 'x-auth-token': token ?? '' } },
       );
       if (!response.data?.success) throw new Error('Mention acknowledgement failed');
+      notifyAttentionChanged();
       setReloadKey((value) => value + 1);
     } catch {
       setActionError(t('activity.mention.actionFailed'));
@@ -295,7 +316,7 @@ const V2ActivityPage: React.FC = () => {
   };
 
   const isDayZero = podId === 'all'
-    && queue.length === 0
+    && queueCount === 0
     && recap?.agents.length === 0
     && recap.board.length === 0;
 
@@ -366,10 +387,10 @@ const V2ActivityPage: React.FC = () => {
           <section className="v2-activity__section" aria-labelledby="activity-needs-you">
             <div className="v2-activity__section-heading">
               <h2 id="activity-needs-you">{t('activity.needsYou.title')}</h2>
-              {!isDayZero && queue.length > 0 && <span className="v2-activity__count" aria-label={t('activity.needsYou.countLabel', { count: queue.length })}>{queue.length}</span>}
+              {!isDayZero && queueCount !== null && queueCount > 0 && <span className="v2-activity__count" aria-label={t('activity.needsYou.countLabel', { count: queueCount })}>{queueCount}</span>}
               <p>{t('activity.needsYou.description')}</p>
             </div>
-            {isDayZero ? (
+            {queueFailed ? <p role="status">{t('activity.loadFailed')}</p> : isDayZero ? (
               <div className="v2-activity__queue">
                 <article className="v2-activity__queue-row v2-activity__queue-row--onboarding">
                   <span className="v2-activity__queue-mark" aria-hidden="true">1</span>
@@ -411,8 +432,10 @@ const V2ActivityPage: React.FC = () => {
               </div>
             ) : queue.length === 0 ? (
               <div className="v2-activity__empty">
-                <strong>{t('activity.needsYou.emptyTitle')}</strong>
-                <span>{t('activity.needsYou.emptyDescription')}</span>
+                {queueCount === 0 ? <>
+                  <strong>{t('activity.needsYou.emptyTitle')}</strong>
+                  <span>{t('activity.needsYou.emptyDescription')}</span>
+                </> : <strong>{t('activity.needsYou.countLabel', { count: queueCount })}</strong>}
               </div>
             ) : (
               <div className="v2-activity__queue">

--- a/frontend/src/v2/components/V2Inspector.tsx
+++ b/frontend/src/v2/components/V2Inspector.tsx
@@ -10,6 +10,7 @@ import { V2AttentionItem } from '../hooks/useV2PodAttention';
 interface V2InspectorProps {
   detail: UseV2PodDetailResult;
   attentionItems?: V2AttentionItem[];
+  attentionCount?: number | null;
   onClose?: () => void;
   onOpenInvite?: () => void;
 }
@@ -62,7 +63,7 @@ const agentState = (
   return { kind: 'idle' };
 };
 
-const V2Inspector: React.FC<V2InspectorProps> = ({ detail, attentionItems = [], onClose, onOpenInvite }) => {
+const V2Inspector: React.FC<V2InspectorProps> = ({ detail, attentionItems = [], attentionCount = null, onClose, onOpenInvite }) => {
   const { pod, agents } = detail;
   const api = useV2Api();
   const navigate = useNavigate();
@@ -167,7 +168,12 @@ const V2Inspector: React.FC<V2InspectorProps> = ({ detail, attentionItems = [], 
         <section className="v2-workspace-inspector__card" aria-labelledby="workspace-inspector-needs-you">
           <h2 id="workspace-inspector-needs-you" className="v2-workspace-inspector__label">{t('inspector.workspace.needsYou')}</h2>
           <div className="v2-workspace-inspector__rows">
-            {attention.length === 0 && <p className="v2-workspace-inspector__empty">{emptyAttentionCopy}</p>}
+            {attentionCount === 0 && <p className="v2-workspace-inspector__empty">{emptyAttentionCopy}</p>}
+            {attentionCount !== null && attentionCount > 0 && (
+              <button type="button" className="v2-workspace-inspector__attention" onClick={() => navigate('/v2/activity')}>
+                {t('activity.needsYou.countLabel', { count: attentionCount })}
+              </button>
+            )}
             {attention.map((item) => (
               <button key={`${item.kind}:${item.id}`} type="button" className="v2-workspace-inspector__attention" onClick={() => openAttention(item)}>
                 <span>{item.title}</span>

--- a/frontend/src/v2/components/V2Layout.tsx
+++ b/frontend/src/v2/components/V2Layout.tsx
@@ -10,7 +10,7 @@ import V2FirstRunHero from './V2FirstRunHero';
 import V2MobileTabs from './V2MobileTabs';
 import { useV2Pods } from '../hooks/useV2Pods';
 import { useV2PodDetail } from '../hooks/useV2PodDetail';
-import { useV2PodAttention } from '../hooks/useV2PodAttention';
+import { useV2PodAttention, notifyAttentionChanged } from '../hooks/useV2PodAttention';
 import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
 import { useAuth } from '../../context/AuthContext';
 
@@ -202,7 +202,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
 
   return (
     <div className={shellClass}>
-      <V2NavRail onPodsMobileNav={openMobileNav} />
+      <V2NavRail onPodsMobileNav={openMobileNav} needsYouCount={attention.count} />
       {mobileNavOpen && (
         <button
           type="button"
@@ -214,7 +214,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
       <V2PodsSidebar
         selectedPodId={selectedPodId}
         podsState={podsState}
-        attentionItems={attention.items}
+        attentionCountByPod={attention.countByPod}
         mobileOpen={mobileNavOpen}
         onMobileClose={closeMobileNav}
       />
@@ -228,7 +228,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
         onOpenInvite={inviteEnabled ? openInvite : undefined}
         onOpenFile={openFile}
         onOpenMobileNav={openMobileNav}
-        onDecisionSettled={attention.refresh}
+        onDecisionSettled={notifyAttentionChanged}
       />
       <V2MobileTabs
         podId={selectedPodId}
@@ -246,6 +246,7 @@ const V2Layout: React.FC<V2LayoutProps> = ({ selectionMode = 'auto' }) => {
           <V2Inspector
             detail={detail}
             attentionItems={attention.items}
+            attentionCount={attention.count === null ? null : (attention.countByPod[selectedPodId] || 0)}
             onClose={toggleInspector}
             onOpenInvite={inviteEnabled ? () => openInvite() : undefined}
           />

--- a/frontend/src/v2/components/V2NavRail.tsx
+++ b/frontend/src/v2/components/V2NavRail.tsx
@@ -5,6 +5,8 @@ import V2LangSwitch from './V2LangSwitch';
 import V2AccountMenu from './V2AccountMenu';
 import { useAuth } from '../../context/AuthContext';
 import { useTranslation } from 'react-i18next';
+import Badge from '@mui/material/Badge';
+import { useV2PodAttention } from '../hooks/useV2PodAttention';
 
 interface NavItem {
   key: string;
@@ -45,17 +47,20 @@ interface V2NavRailProps {
   // single chat with no way back to the list). Undefined on surfaces without a
   // drawer (feature pages) — those fall back to plain navigation.
   onPodsMobileNav?: () => void;
+  needsYouCount?: number | null;
 }
 
 const isMobileViewport = (): boolean => (
   typeof window !== 'undefined' && !!window.matchMedia?.('(max-width: 760px)').matches
 );
 
-const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
+const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav, needsYouCount }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { logout } = useAuth();
   const { t } = useTranslation();
+  const attention = useV2PodAttention(needsYouCount === undefined);
+  const count = needsYouCount === undefined ? attention.count : needsYouCount;
   // Labels resolve at render so the rail tooltip (v2.css attr(data-label))
   // follows the active locale — NAV_ITEMS.label is the English fallback.
   const navLabel = (item: NavItem) => t(`common.nav.${item.key}`, { defaultValue: item.label });
@@ -97,9 +102,17 @@ const V2NavRail: React.FC<V2NavRailProps> = ({ onPodsMobileNav }) => {
                 className={`v2-rail__item${isActive(item) ? ' v2-rail__item--active' : ''}`}
                 onClick={() => handleNavClick(item)}
                 title={navLabel(item)}
+                aria-label={item.key === 'activity' && count !== null && count > 0
+                  ? `${navLabel(item)}: ${t('activity.needsYou.countLabel', { count })}` : navLabel(item)}
                 data-label={navLabel(item)}
               >
-                <span className="v2-rail__item-icon">{item.icon}</span>
+                <span className="v2-rail__item-icon">
+                  {item.key === 'activity' && count !== null && count > 0 ? (
+                    <Badge badgeContent={count} max={Number.MAX_SAFE_INTEGER} aria-label={t('activity.needsYou.countLabel', { count })}>
+                      {item.icon}
+                    </Badge>
+                  ) : item.icon}
+                </span>
                 <span className="v2-rail__item-label">{navLabel(item)}</span>
               </button>
               {item.dividerAfter && <span className="v2-rail__divider" aria-hidden="true" />}

--- a/frontend/src/v2/components/V2PodsSidebar.tsx
+++ b/frontend/src/v2/components/V2PodsSidebar.tsx
@@ -5,7 +5,6 @@ import V2Avatar from './V2Avatar';
 import { UseV2PodsResult, V2Pod, V2PodMember, useV2Pods } from '../hooks/useV2Pods';
 import { useV2Api } from '../hooks/useV2Api';
 import { useV2Pinned } from '../hooks/useV2Pinned';
-import { V2AttentionItem } from '../hooks/useV2PodAttention';
 import { useAuth } from '../../context/AuthContext';
 
 interface Connector {
@@ -18,7 +17,7 @@ interface Connector {
 interface V2PodsSidebarProps {
   selectedPodId: string | null;
   podsState?: UseV2PodsResult;
-  attentionItems?: V2AttentionItem[];
+  attentionCountByPod?: Record<string, number>;
   // The drawer only exists below 760px. Desktop always shows this column.
   mobileOpen?: boolean;
   onMobileClose?: () => void;
@@ -122,7 +121,7 @@ const directMemberFor = (pod: V2Pod, currentUserId?: string): V2PodMember | unde
 );
 
 const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
-  selectedPodId, podsState, attentionItems = [], mobileOpen = false, onMobileClose,
+  selectedPodId, podsState, attentionCountByPod = {}, mobileOpen = false, onMobileClose,
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -158,12 +157,6 @@ const V2PodsSidebar: React.FC<V2PodsSidebarProps> = ({
     const directPods = pods.filter(isDirectPod);
     return { podGroups: groupWorkspacePods(roomPods, pinned), direct: sortPods(directPods) };
   }, [pods, pinned]);
-
-  const attentionCountByPod = useMemo(() => attentionItems.reduce<Record<string, number>>((counts, item) => {
-    if (!item.podId) return counts;
-    counts[item.podId] = (counts[item.podId] || 0) + 1;
-    return counts;
-  }, {}), [attentionItems]);
 
   const channels = useMemo(() => connectors.map((connector) => {
     const podId = typeof connector.podId === 'object' ? connector.podId?._id : connector.podId;

--- a/frontend/src/v2/hooks/useV2PodAttention.ts
+++ b/frontend/src/v2/hooks/useV2PodAttention.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useV2Api } from './useV2Api';
 
 export interface V2AttentionItem {
@@ -17,32 +17,47 @@ export interface V2AttentionItem {
  * inspector list, and the phone tab badge are views of this result, not
  * independently refreshed counters that can disagree.
  */
-export const useV2PodAttention = () => {
+export const ATTENTION_CHANGED = 'v2:attention-changed';
+export const notifyAttentionChanged = () => window.dispatchEvent(new Event(ATTENTION_CHANGED));
+
+export const useV2PodAttention = (enabled = true) => {
   const api = useV2Api();
   const apiRef = useRef(api);
   apiRef.current = api;
   const [items, setItems] = useState<V2AttentionItem[]>([]);
+  const [count, setCount] = useState<number | null>(null);
+  const [countByPod, setCountByPod] = useState<Record<string, number>>({});
+  const generation = useRef(0);
 
   const refresh = useCallback(async () => {
+    if (!enabled) return;
+    const request = ++generation.current;
     try {
-      const data = await apiRef.current.get<{ items?: V2AttentionItem[] }>('/api/activity/decision-queue');
-      setItems(Array.isArray(data?.items) ? data.items : []);
+      const data = await apiRef.current.get<{ items: V2AttentionItem[]; count: number; countsByPod: Record<string, number> }>('/api/activity/decision-queue');
+      if (request !== generation.current) return;
+      if (!Array.isArray(data?.items) || typeof data.count !== 'number' || !data.countsByPod) throw new Error('Invalid attention queue');
+      setItems(data.items);
+      setCount(data.count);
+      setCountByPod(data.countsByPod);
     } catch {
       // Attention is additive UI. A transient read failure must not invent a
       // stale count or block the pod surface; the next refresh retries it.
+      if (request !== generation.current) return;
       setItems([]);
+      setCount(null);
+      setCountByPod({});
     }
-  }, []);
+  }, [enabled]);
 
   useEffect(() => {
     void refresh();
+    window.addEventListener(ATTENTION_CHANGED, refresh);
+    window.addEventListener('focus', refresh);
+    return () => {
+      generation.current += 1;
+      window.removeEventListener(ATTENTION_CHANGED, refresh);
+      window.removeEventListener('focus', refresh);
+    };
   }, [refresh]);
-
-  const countByPod = useMemo(() => items.reduce<Record<string, number>>((counts, item) => {
-    if (!item.podId) return counts;
-    counts[item.podId] = (counts[item.podId] || 0) + 1;
-    return counts;
-  }, {}), [items]);
-
-  return { items, countByPod, refresh };
+  return { items, count, countByPod, refresh };
 };


### PR DESCRIPTION
## Summary
- Make `/api/activity/decision-queue` count every accessible open item, not only the newest 80; return uncapped `count` and `countsByPod` while retaining 12-card/8-mention display limits.
- Activity and the rail use the global total; pod sidebar, inspector and phone use per-pod totals. Activity's pod filter uses the corresponding pod total. Never substitute recap mentions on queue failure or call an omitted card an empty queue.
- Refresh attention consumers on acknowledgement/ruling/message actions and window focus. No direction C layout/CSS work and no production repair/sweep.

Implements TASK-126, rulings 63938 / 64287 / 64301. The rail had no badge on main; this adds the requested count with the existing MUI Badge component, keeping the rail dimensions and CSS unchanged. Inspector exposes its full total and an Activity exit even when none of its cards are in the capped sample.

## Verification
- Frontend: 628/628 across 94 suites; typecheck and production build pass.
- Backend: focused service/unit set 16/16; new persisted-query suite also 2/2 against a disposable real MongoDB; backend typecheck passes.
- Regression fixture has 95 accessible open items across two pods, plus revoked-access, other-recipient and resolved exclusions; checks 12/8 display limits and recount after acknowledgement.
- Mutations, restored: reintroducing `.limit(80)` gives 1 red (95 expected, 80 actual); replacing endpoint count with `items.length` in the hook gives 1 red (91 expected, 0 actual).
- Browser: production components rendered against a local synthetic API fixture at 1440 and 390. Global 95 vs selected-pod 91, omitted pod still has inspector count, phone badge 91, acknowledgement refresh clears counts. This is local fixture proof, not a signed-in live-data walk. A fixture hot reload logged a duplicate createRoot warning; no production-console-clean claim.
- Three unrelated BYO unit suites now mock their rail boundary so rail reads cannot consume their order-dependent BYO API responses; rail count behavior has its own test.

## Gates / limits
- Review, fresh-head CI and UX carry required before Lily presses; first independent PR of the tranche.
- Previously broad-resolved attention remains untouched. Counts reflect persisted open rows, not a correction of those historical rows.
- TASK-127 catch-up freshness is a separate PR. Direction C awaits rendered artboards.
