### PR TITLE
feat(v2): the no-machines BYO page teaches the one-paste computer setup

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1276,6 +1276,13 @@
       "waiting": "Waiting for the daemon on {{machine}} to pick it up…",
       "slow": "Still waiting — check that commonly daemon run is active on {{machine}}. The agent starts the moment it's back.",
       "openPod": "Open the pod"
+    },
+    "addComputer": {
+      "title": "Add a computer",
+      "lead": "Want an agent running on your own machine? One paste in its terminal:",
+      "after": "Then reload this page — an “On my computer” option appears, and adding agents to that machine never needs a terminal again.",
+      "copy": "Copy",
+      "copied": "Copied"
     }
   },
   "compare": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1336,6 +1336,13 @@
       "waiting": "正在等待 {{machine}} 上的守护进程接管…",
       "slow": "仍在等待——请确认 {{machine}} 上正在运行 commonly daemon run，恢复后会立即启动该智能体。",
       "openPod": "打开 pod"
+    },
+    "addComputer": {
+      "title": "添加电脑",
+      "lead": "想让智能体在你自己的电脑上运行？在它的终端里粘贴一次：",
+      "after": "然后刷新本页——会出现“在我的电脑上”选项，之后往那台电脑添加智能体再也不需要终端。",
+      "copy": "复制",
+      "copied": "已复制"
     }
   },
   "agentProfile": {

--- a/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
@@ -77,11 +77,20 @@ describe('BYO on-my-computer mode', () => {
     expect(screen.getByTestId('byo-machine-select')).toHaveTextContent('Sam’s MacBook');
   });
 
-  test('no machines — no card, page untouched', async () => {
+  test('no machines — no card, and the one-paste setup panel shows instead', async () => {
     mockGet({ machines: [] });
     renderPage();
     await waitFor(() => expect(axios.get).toHaveBeenCalledWith('/api/machines', expect.anything()));
     expect(screen.queryByTestId('byo-mode-machine')).toBeNull();
+    expect(screen.getByTestId('byo-add-computer')).toBeInTheDocument();
+    expect(screen.getByTestId('byo-add-computer')).toHaveTextContent('commonly daemon register && commonly daemon install');
+  });
+
+  test('with machines the setup panel is gone', async () => {
+    mockGet();
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('byo-mode-machine')).toBeInTheDocument());
+    expect(screen.queryByTestId('byo-add-computer')).toBeNull();
   });
 
   test('picking a pod does not stomp an explicit mode choice', async () => {

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -58,6 +58,10 @@ type MachineRow = {
 };
 const MACHINE_STATUS_POLL_MS = 4000;
 const MACHINE_STATUS_MAX_TICKS = 30;
+// One-time computer setup (ADR-026 D1). Registration mints a machine-local
+// credential, so it is inherently a terminal act — this page's job is to
+// make it ONE paste, after which "On my computer" appears here.
+const DAEMON_SETUP_COMMAND = 'npm i -g @commonlyai/cli@latest && commonly login && commonly daemon register && commonly daemon install';
 const CLAUDE_FILE_NAME = 'CLAUDE.md';
 
 const sanitizeAgentName = (raw: string): string => raw
@@ -705,6 +709,23 @@ const V2AgentBYO: React.FC = () => {
               {t('agentByo.form.podHint')}
             </span>
           </label>
+          {machines.length === 0 && (
+            <div className="v2-byo__add-computer" data-testid="byo-add-computer">
+              <span className="v2-byo__label">{t('agentByo.addComputer.title')}</span>
+              <p className="v2-byo__hint">{t('agentByo.addComputer.lead')}</p>
+              <div className="v2-byo__add-computer-row">
+                <code>{DAEMON_SETUP_COMMAND}</code>
+                <button
+                  type="button"
+                  className="v2-byo__copy"
+                  onClick={() => copy('daemon-setup', DAEMON_SETUP_COMMAND)}
+                >
+                  {copied === 'daemon-setup' ? t('agentByo.addComputer.copied') : t('agentByo.addComputer.copy')}
+                </button>
+              </div>
+              <p className="v2-byo__hint">{t('agentByo.addComputer.after')}</p>
+            </div>
+          )}
           {error && <div className="v2-byo__error">{error}</div>}
           <button
             type="button"

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -6594,6 +6594,34 @@ body.modern-ui.v2-canvas {
   white-space: pre-wrap;
   word-break: break-all;
 }
+/* ADR-026 D1: one-paste computer setup, shown only while no machine exists. */
+.v2-byo__add-computer {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-md, 8px);
+  background: var(--v2-surface-hover, #f9fafb);
+}
+.v2-byo__add-computer-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.v2-byo__add-computer-row code {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: 6px;
+  background: var(--v2-surface, #fff);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: var(--v2-text-primary);
+  overflow-x: auto;
+  white-space: nowrap;
+}
 .v2-byo__cta-row {
   display: flex;
   gap: 12px;


### PR DESCRIPTION
Closes the last UX gap in the "Add a computer" story. The header CTA lands on the BYO page, but a user with no registered machines saw nothing about how to get one — the machine card only renders once `GET /api/machines` has rows.

Now the page (only in that empty state) shows a compact setup panel: *"Want an agent running on your own machine? One paste in its terminal:"* followed by `npm i -g @commonlyai/cli@latest && commonly login && commonly daemon register && commonly daemon install` with a copy button, and the honest promise — after this, adding agents to that machine never needs a terminal again. Registration mints a machine-local credential, so it's inherently a terminal act; one paste is the floor, and this reaches it. With machines present the panel yields to the "On my computer" card.

Pairs with #1570 (`daemon install`) — the pasted line ends in it, so merge that first.

Tests: empty-state shows the panel with the command, machines-present hides it; full frontend suite green, layout invariants pass, 0 eslint errors. en + zh-CN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtwYLMJAYuZ3grLQoXWMWT