### PR TITLE
feat(v2): direction C PR 2a — one-line composer, attachments as thumbnails and chips, scroll-to-load history

### DIFF
--- a/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.phantom-directive.test.js
@@ -155,6 +155,21 @@ describe('AgentMessageService phantom-upload-directive footer', () => {
     expect(persistedDoc.content).toContain('[[upload:smoke-postmortem-2026-05-20-v2.md]]');
   });
 
+  it('does NOT fire when the directive sits inside backticks or a fence — quoting the grammar is not a claim', async () => {
+    mockFindAgainst({});
+
+    await AgentMessageService.postMessage({
+      agentName: 'openclaw',
+      instanceId: 'aria',
+      podId: '6a0da39bae757028b39f87a6',
+      content: 'The manifest looks like `[[upload:abc.png|abc.png|12|image]]` and in a fence:\n```\n[[upload:def.md|def.md|3|document]]\n```',
+    });
+
+    expect(persistedDoc).toBeTruthy();
+    expect(persistedDoc.content).not.toContain('no matching attachment');
+    expect(persistedDoc.content).toContain('`[[upload:abc.png|abc.png|12|image]]`');
+  });
+
   it('does NOT append a footer when a File row matches the directive', async () => {
     // Real upload exists → no phantom.
     mockFindAgainst({

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -1061,7 +1061,12 @@ class AgentMessageService {
       // outcome as before for any message that never matched, and strictly
       // better than a service that can be stalled by a long one.
       const scanned = sanitizedContent.slice(0, ATTACH_CLAIM_SCAN_LIMIT);
-      const hasUploadDirective = /\[\[upload:/i.test(sanitizedContent);
+      // A directive quoted in backticks or a fence is a mention of the grammar,
+      // not an attachment — same escape the NO_REPLY sentinel has. Scan the
+      // body with code spans removed so documenting `[[upload:…]]` never
+      // trips the "check the agent's workspace" note.
+      const outsideCode = sanitizedContent.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]*`/g, '');
+      const hasUploadDirective = /\[\[upload:/i.test(outsideCode);
       const claimsAttachment = /(?:\b(?:i(?:'ve| have)?|done\s*[—-]?\s*i|i\s+just|i\s+already)\s+|(?:^|[.!?]\s+|[\r\n]+)(?:done\s*[—-]?\s*)?(?:just\s+)?)(?:attached|uploaded|posted)\b[^.\n]{0,80}\b(?:file|deck|attachment|runbook|pptx|docx|xlsx|pdf|csv|image|artifact)\b/i.test(scanned);
       if (claimsAttachment && !hasUploadDirective) {
         // Suppress the warning when THIS agent genuinely attached a file to
@@ -1124,7 +1129,7 @@ class AgentMessageService {
           const directivePattern = /\[\[upload:([^|\]]+)/gi;
           const referencedNames: string[] = [];
           let match;
-          while ((match = directivePattern.exec(sanitizedContent)) !== null) {
+          while ((match = directivePattern.exec(outsideCode)) !== null) {
             // Coerce + sanitize each captured name before it reaches the
             // Mongoose query — CodeQL doesn't trust regex output as a
             // SqlSanitizer for the NoSQL-injection query, so we apply the

--- a/frontend/src/components/ChatRoom.test.tsx
+++ b/frontend/src/components/ChatRoom.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import TestUtils from 'react-dom/test-utils';
-import ChatRoom from './ChatRoom';
+import ChatRoom, { uploadImageSrc } from './ChatRoom';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useSocket } from '../context/SocketContext';
@@ -218,4 +218,21 @@ test('renders system messages as lightweight notices', async () => {
 
   expect(container.textContent).toContain('[Encountered an issue - details sent to debug DM]');
   expect(container.querySelector('.system-message')).toBeTruthy();
+});
+
+// Pod Tools renders an image message by its src; since PR #1579 an image goes
+// out as the same `[[upload:…|image]]` manifest a file does, so the src must
+// be rebuilt from the manifest's key. Reverting to the bare content left the
+// whole suite green (sprint-review gate) — this pins it.
+describe('uploadImageSrc', () => {
+  test('a manifest resolves to the upload path of its key, never the directive text', () => {
+    const src = uploadImageSrc('[[upload:1788712076709-554286743.png|walk.png|351394|image]]');
+    expect(src).toContain('/api/uploads/1788712076709-554286743.png');
+    expect(src).not.toContain('[[');
+  });
+
+  test('a legacy bare reference is left to the URL normaliser unchanged', () => {
+    expect(uploadImageSrc('/api/uploads/old.png')).toContain('/api/uploads/old.png');
+    expect(uploadImageSrc('data:image/png;base64,AAAA')).toBe('data:image/png;base64,AAAA');
+  });
 });

--- a/frontend/src/components/ChatRoom.tsx
+++ b/frontend/src/components/ChatRoom.tsx
@@ -67,6 +67,14 @@ import {
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import './ChatRoom.css';
 
+// An image message carries either a bare upload reference (legacy) or the
+// same `[[upload:<key>|<name>|<size>|image]]` manifest a file does (direction
+// C, one attachment model). Both resolve to the instance's upload URL.
+export const uploadImageSrc = (content: string): string => {
+  const manifest = String(content || '').match(/^\s*\[\[upload:([^|\]]+)\|/);
+  return normalizeUploadUrl(manifest ? `/api/uploads/${manifest[1].trim()}` : content);
+};
+
 /**
  * Replace :shortcode: occurrences with the matching unicode emoji, but
  * leave code blocks (fenced ``` and inline `...`) untouched so colons
@@ -4740,10 +4748,10 @@ const ChatRoom = () => {
                                                     {messageType === 'image' && (
                                                         <div className={`message-image-container ${isCurrentUser ? 'sent' : 'received'}`}>
                                                             <img
-                                                                src={normalizeUploadUrl(messageContent)}
+                                                                src={uploadImageSrc(messageContent)}
                                                                 alt="Shared"
                                                                 className="message-image"
-                                                                onClick={() => window.open(normalizeUploadUrl(messageContent), '_blank')}
+                                                                onClick={() => window.open(uploadImageSrc(messageContent), '_blank')}
                                                             />
                                                         </div>
                                                     )}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -420,7 +420,8 @@
       "noMessagesTitle": "No messages yet",
       "agentDmText": "This is a private 1:1 conversation. Say hello to get started.",
       "quietTitle": "This pod is quiet",
-      "quietText": "Use @ to mention an agent or teammate—everyone in the member list can see and reply."
+      "quietText": "Use @ to mention an agent or teammate—everyone in the member list can see and reply.",
+      "noMessages": "no messages yet"
     },
     "newPod": {
       "label": "New Pod starter actions",
@@ -491,7 +492,10 @@
       "attachImage": "Attach image",
       "pasteImage": "Paste image from clipboard",
       "sendTooltip": "Send as {{name}} · Enter",
-      "clipboardEmpty": "No image on the clipboard."
+      "clipboardEmpty": "No image on the clipboard.",
+      "aimThread": "↳ replying in thread",
+      "aimReply": "↳ replying to {{author}}",
+      "replyPlaceholder": "Reply to {{author}}"
     },
     "errors": {
       "uploadFailed": "Failed to upload file. Please try again."

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -486,7 +486,12 @@
       "sendAria": "Send message",
       "postsAs": "posts as {{name}}",
       "mentionAgent": "mention an agent",
-      "toSend": "to send"
+      "toSend": "to send",
+      "more": "Add",
+      "attachImage": "Attach image",
+      "pasteImage": "Paste image from clipboard",
+      "sendTooltip": "Send as {{name}} · Enter",
+      "clipboardEmpty": "No image on the clipboard."
     },
     "errors": {
       "uploadFailed": "Failed to upload file. Please try again."
@@ -511,6 +516,23 @@
       "refresh": "Refresh",
       "working": "Summarizing…",
       "dismiss": "Dismiss"
+    },
+    "lightbox": {
+      "close": "Close",
+      "previous": "Previous image",
+      "next": "Next image"
+    },
+    "attachment": {
+      "open": "Open {{name}}",
+      "showMore": "Show {{count}} more lines",
+      "showLess": "Show less",
+      "image": "image"
+    },
+    "history": {
+      "loadingEarlier": "loading earlier…",
+      "loadEarlier": "load earlier",
+      "beginning": "beginning of the pod",
+      "jumpToLatest": "Jump to latest"
     }
   },
   "landing": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -420,7 +420,8 @@
       "noMessagesTitle": "暂无消息",
       "agentDmText": "这是一对一私信。打个招呼，开始对话。",
       "quietTitle": "这个 Pod 还很安静",
-      "quietText": "用 @ 提及智能体或队友，成员列表中的所有人都能看到并回复。"
+      "quietText": "用 @ 提及智能体或队友，成员列表中的所有人都能看到并回复。",
+      "noMessages": "还没有消息"
     },
     "newPod": {
       "label": "新 Pod 开始操作",
@@ -490,7 +491,10 @@
       "attachImage": "添加图片",
       "pasteImage": "粘贴剪贴板图片",
       "sendTooltip": "以 {{name}} 身份发送 · Enter",
-      "clipboardEmpty": "剪贴板中没有图片。"
+      "clipboardEmpty": "剪贴板中没有图片。",
+      "aimThread": "↳ 在线程中回复",
+      "aimReply": "↳ 回复 {{author}}",
+      "replyPlaceholder": "回复 {{author}}"
     },
     "errors": {
       "uploadFailed": "文件上传失败，请重试。"

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -485,7 +485,12 @@
       "sendAria": "发送消息",
       "postsAs": "发布身份：{{name}}",
       "mentionAgent": "提及智能体",
-      "toSend": "发送"
+      "toSend": "发送",
+      "more": "添加",
+      "attachImage": "添加图片",
+      "pasteImage": "粘贴剪贴板图片",
+      "sendTooltip": "以 {{name}} 身份发送 · Enter",
+      "clipboardEmpty": "剪贴板中没有图片。"
     },
     "errors": {
       "uploadFailed": "文件上传失败，请重试。"
@@ -510,6 +515,23 @@
       "refresh": "刷新",
       "working": "正在总结…",
       "dismiss": "关闭"
+    },
+    "lightbox": {
+      "close": "关闭",
+      "previous": "上一张",
+      "next": "下一张"
+    },
+    "attachment": {
+      "open": "打开 {{name}}",
+      "showMore": "展开另外 {{count}} 行",
+      "showLess": "收起",
+      "image": "图片"
+    },
+    "history": {
+      "loadingEarlier": "正在加载更早的消息…",
+      "loadEarlier": "加载更早的消息",
+      "beginning": "Pod 的开始",
+      "jumpToLatest": "跳到最新"
     }
   },
   "landing": {

--- a/frontend/src/v2/__tests__/V2Composer.test.tsx
+++ b/frontend/src/v2/__tests__/V2Composer.test.tsx
@@ -114,9 +114,11 @@ describe('V2Composer send button', () => {
     });
   });
 
-  test('send button is disabled while the draft is empty', () => {
+  test('there is no Send until the draft has text', () => {
     renderChat(makeDetail());
-    expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /send message/i })).not.toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), { target: { value: 'hello' } });
+    expect(screen.getByRole('button', { name: /send message/i })).toBeInTheDocument();
   });
 
   test('shows send failures by the composer and keeps the reply draft intact', async () => {
@@ -159,7 +161,7 @@ describe('V2Composer send button', () => {
     expect(sendError.closest('.v2-composer')).not.toBeNull();
     expect(sendError.closest('.v2-chat__messages')).toBeNull();
     expect(screen.getByPlaceholderText(/message my workspace/i)).toHaveValue('I am checking it now.');
-    expect(screen.getByRole('button', { name: /cancel reply/i }).closest('.v2-composer__target')).not.toBeNull();
+    expect(screen.getByRole('button', { name: /cancel reply/i }).closest('.v2-composer__tag')).not.toBeNull();
   });
 
   // W-T 4/4, constraint 4 (docs/design/threading-surface-ruling.md; ux-lead

--- a/frontend/src/v2/__tests__/V2Composer.test.tsx
+++ b/frontend/src/v2/__tests__/V2Composer.test.tsx
@@ -70,6 +70,10 @@ const makeDetail = (overrides = {}) => ({
   ...overrides,
 });
 
+// The placeholder changes once the composer is aimed (direction C), so tests
+// reach the field by its class rather than its placeholder.
+const composerInput = () => document.querySelector('.v2-composer textarea');
+
 const renderChat = (detail) => render(
   <AuthContext.Provider value={authValue}>
     <MemoryRouter>
@@ -101,7 +105,7 @@ describe('V2Composer send button', () => {
     const detail = makeDetail();
     renderChat(detail);
 
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'hello team' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
@@ -117,7 +121,7 @@ describe('V2Composer send button', () => {
   test('there is no Send until the draft has text', () => {
     renderChat(makeDetail());
     expect(screen.queryByRole('button', { name: /send message/i })).not.toBeInTheDocument();
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), { target: { value: 'hello' } });
+    fireEvent.change(composerInput(), { target: { value: 'hello' } });
     expect(screen.getByRole('button', { name: /send message/i })).toBeInTheDocument();
   });
 
@@ -137,7 +141,7 @@ describe('V2Composer send button', () => {
     const { rerender } = renderChat(detail);
 
     fireEvent.click(screen.getByRole('button', { name: /reply to teammate/i }));
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'I am checking it now.' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
@@ -160,7 +164,7 @@ describe('V2Composer send button', () => {
     const sendError = screen.getByText('Replies are temporarily unavailable. Please try again shortly.');
     expect(sendError.closest('.v2-composer')).not.toBeNull();
     expect(sendError.closest('.v2-chat__messages')).toBeNull();
-    expect(screen.getByPlaceholderText(/message my workspace/i)).toHaveValue('I am checking it now.');
+    expect(composerInput()).toHaveValue('I am checking it now.');
     expect(screen.getByRole('button', { name: /cancel reply/i }).closest('.v2-composer__tag')).not.toBeNull();
   });
 
@@ -202,7 +206,7 @@ describe('V2Composer send button', () => {
 
     fireEvent.click(replyFromExpandedThread());
     expect(screen.getByText(/replying in thread/i)).toBeInTheDocument();
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'Joining the thread.' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
@@ -219,7 +223,7 @@ describe('V2Composer send button', () => {
     // reply edge is gone.
     fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
     fireEvent.click(replyFromExpandedThread());
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'thread wins' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
@@ -231,12 +235,27 @@ describe('V2Composer send button', () => {
     // wins, the thread root is gone.
     fireEvent.click(replyFromExpandedThread());
     fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'reply wins' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
     await waitFor(() => {
       expect(detail.sendMessage).toHaveBeenLastCalledWith('reply wins', 'text', 'm2', undefined);
+    });
+  });
+
+  test('Escape in the field un-aims (reply or thread) and keeps the draft; the send goes out plain', async () => {
+    const detail = makeDetail({ messages: threadMessages() });
+    renderChat(detail);
+    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    expect(document.activeElement).toBe(composerInput());
+    fireEvent.change(composerInput(), { target: { value: 'kept draft' } });
+    fireEvent.keyDown(composerInput(), { key: 'Escape' });
+    expect(document.querySelector('.v2-composer__aim')).toBeNull();
+    expect(composerInput()).toHaveValue('kept draft');
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenLastCalledWith('kept draft', 'text', undefined, undefined);
     });
   });
 
@@ -283,6 +302,21 @@ describe('V2Composer send button', () => {
     fireEvent.change(input, { target: { files: [new File(['x'], 'x.png', { type: 'image/png' })] } });
   };
 
+  test('an image upload goes out as the upload manifest, not a bare URL, when the server returns a file key', async () => {
+    const axios = require('axios');
+    axios.post.mockImplementation((url) => (String(url).includes('/api/uploads')
+      ? Promise.resolve({ data: { kind: 'image', url: '/api/uploads/k1.png', fileName: 'k1.png', originalName: 'walk.png', size: 1234 } })
+      : Promise.resolve({ data: {} })));
+    const detail = makeDetail();
+    const { container } = renderChat(detail);
+    const input = container.querySelector('input[type=file]');
+    fireEvent.change(input, { target: { files: [new File(['x'], 'walk.png', { type: 'image/png' })] } });
+    await waitFor(() => {
+      expect(detail.sendMessage).toHaveBeenCalledWith('[[upload:k1.png|walk.png|1234|image]]', 'image', undefined, undefined);
+    });
+    axios.post.mockImplementation(() => Promise.resolve({ data: {} }));
+  });
+
   test('an image upload carries the REPLY edge when aimed at a person', async () => {
     // @ux-lead 57473. #1150 wired the thread root on this line and left the
     // reply edge hardcoded undefined, so the chip read "Replying to {name}"
@@ -316,7 +350,7 @@ describe('V2Composer send button', () => {
     await waitFor(() => {
       expect(screen.queryByText(/replying in thread/i)).not.toBeInTheDocument();
     });
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'unaimed' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
@@ -331,7 +365,7 @@ describe('V2Composer send button', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /thread from teammate/i }));
     expect(screen.getByText(/replying in thread/i)).toBeInTheDocument();
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'Starting a thread.' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
@@ -346,7 +380,7 @@ describe('V2Composer send button', () => {
     renderChat(detail);
 
     fireEvent.click(screen.getByRole('button', { name: /thread from other/i }));
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'Still in the first thread.' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
@@ -361,7 +395,7 @@ describe('V2Composer send button', () => {
     renderChat(detail);
 
     fireEvent.click(screen.getByRole('button', { name: /^reply in thread$/i }));
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'Joining through the card.' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
@@ -376,7 +410,7 @@ describe('V2Composer send button', () => {
     renderChat(detail);
 
     fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
-    fireEvent.change(screen.getByPlaceholderText(/message my workspace/i), {
+    fireEvent.change(composerInput(), {
       target: { value: 'Replying to a person.' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));

--- a/frontend/src/v2/__tests__/V2ComposerMenu.test.tsx
+++ b/frontend/src/v2/__tests__/V2ComposerMenu.test.tsx
@@ -1,0 +1,98 @@
+// @ts-nocheck
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import i18n, { i18nReady } from '../../i18n';
+import V2Composer from '../components/V2Composer';
+
+const renderComposer = (overrides = {}) => {
+  const props = {
+    podName: 'Sharpen',
+    authorName: 'lily',
+    draft: '',
+    sending: false,
+    uploading: false,
+    replyTarget: null,
+    threadTarget: null,
+    mentionOpen: false,
+    mentionIndex: 0,
+    mentions: [],
+    warnings: [],
+    inputRef: React.createRef(),
+    fileInputRef: React.createRef(),
+    mentionDropdownRef: React.createRef(),
+    onDraftChange: jest.fn(),
+    onDraftPointer: jest.fn(),
+    onKeyDown: jest.fn(),
+    onMentionSelect: jest.fn(),
+    onSend: jest.fn(),
+    onAttach: jest.fn(),
+    onPasteFromClipboard: jest.fn(),
+    onCancelReply: jest.fn(),
+    onCancelThread: jest.fn(),
+    ...overrides,
+  };
+  const view = render(<V2Composer {...props} />);
+  return { props, ...view };
+};
+
+describe('V2Composer (direction C)', () => {
+  beforeAll(async () => { await i18nReady; await act(async () => { await i18n.changeLanguage('en'); }); });
+
+  test('one row: a 24px plus, a one-line field, no identity line, and no Send until there is text', () => {
+    const { container } = renderComposer();
+    expect(container.querySelector('.v2-composer__row')).toBeTruthy();
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '1');
+    expect(screen.queryByText(/posts as/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Send message' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toHaveAttribute('aria-haspopup', 'menu');
+  });
+
+  test('Send appears with text, carries the identity and shortcut in its tooltip, and sends', () => {
+    const { props } = renderComposer({ draft: '@sprint-impl press #1573 when green' });
+    const send = screen.getByRole('button', { name: 'Send message' });
+    expect(send).toHaveAttribute('title', 'Send as lily · Enter');
+    fireEvent.click(send);
+    expect(props.onSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('the plus opens a three-row menu; attach file and attach image set the accept before opening the picker; paste reads the clipboard', () => {
+    jest.useFakeTimers();
+    const { props, container } = renderComposer();
+    const clickSpy = jest.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    const items = screen.getAllByRole('menuitem');
+    expect(items.map((item) => item.textContent)).toEqual(['Attach file', 'Attach image', 'Paste image from clipboard']);
+
+    fireEvent.click(items[1]);
+    act(() => { jest.runAllTimers(); });
+    expect(container.querySelector('input[type=file]')).toHaveAttribute('accept', 'image/*');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.click(screen.getAllByRole('menuitem')[0]);
+    act(() => { jest.runAllTimers(); });
+    expect(container.querySelector('input[type=file]').getAttribute('accept')).toContain('.pdf');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.click(screen.getAllByRole('menuitem')[2]);
+    expect(props.onPasteFromClipboard).toHaveBeenCalledTimes(1);
+    clickSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  test('a thread target is an inline tag inside the row with its own cancel', () => {
+    const { props } = renderComposer({ threadTarget: { id: '7', preview: 'Replacement is #1569' } });
+    const tag = screen.getByRole('status');
+    expect(tag).toHaveClass('v2-composer__tag');
+    expect(tag).toHaveTextContent('Replying in thread');
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel reply' }));
+    expect(props.onCancelThread).toHaveBeenCalledTimes(1);
+  });
+
+  test('uploading shows a mono status beside the field', () => {
+    renderComposer({ uploading: true });
+    expect(screen.getByRole('status')).toHaveTextContent('Uploading…');
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+  });
+});

--- a/frontend/src/v2/__tests__/V2ComposerMenu.test.tsx
+++ b/frontend/src/v2/__tests__/V2ComposerMenu.test.tsx
@@ -84,10 +84,17 @@ describe('V2Composer (direction C)', () => {
   test('a thread target is an inline tag inside the row with its own cancel', () => {
     const { props } = renderComposer({ threadTarget: { id: '7', preview: 'Replacement is #1569' } });
     const tag = screen.getByRole('status');
-    expect(tag).toHaveClass('v2-composer__tag');
-    expect(tag).toHaveTextContent('Replying in thread');
+    expect(tag).toHaveClass('v2-composer__aim');
+    expect(tag).toHaveTextContent('↳ replying in thread');
+    expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', 'Reply in thread');
     fireEvent.click(screen.getByRole('button', { name: 'Cancel reply' }));
     expect(props.onCancelThread).toHaveBeenCalledTimes(1);
+  });
+
+  test('aiming at a person reads ↳ replying to <author> and the placeholder follows', () => {
+    renderComposer({ replyTarget: { id: '3', content: 'hi', user: { username: 'vera' } } });
+    expect(screen.getByRole('status')).toHaveTextContent('↳ replying to vera');
+    expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', 'Reply to vera');
   });
 
   test('uploading shows a mono status beside the field', () => {

--- a/frontend/src/v2/__tests__/V2ComposerSurface.test.tsx
+++ b/frontend/src/v2/__tests__/V2ComposerSurface.test.tsx
@@ -34,12 +34,13 @@ const renderComposer = (overrides: Partial<React.ComponentProps<typeof V2Compose
 };
 
 describe('V2Composer', () => {
-  test('keeps the workspace’s single bordered input and posts-as line independent of the thread controller', () => {
+  test('keeps the workspace’s single bordered one-line input independent of the thread controller', () => {
     const { props, container } = renderComposer({ draft: 'Ready to ship' });
 
     expect(container.querySelector('.v2-composer')).toBeInTheDocument();
-    expect(screen.getByText('posts as lily · ⌘↵')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send message' })).toHaveTextContent('Send');
+    // Direction C: no identity line in the bar; it lives in the Send tooltip.
+    expect(screen.queryByText(/posts as/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send message' })).toHaveAttribute('title', 'Send as lily · Enter');
 
     fireEvent.change(screen.getByPlaceholderText('Message Sharpen…'), {
       target: { value: 'Next draft', selectionStart: 10 },

--- a/frontend/src/v2/__tests__/V2MessageRow.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageRow.test.tsx
@@ -33,14 +33,13 @@ describe('V2MessageRow', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('img', { name: 'Uploaded attachment' })).toHaveAttribute(
+    // Direction C: the image is a thumbnail that opens the lightbox, not a link.
+    expect(screen.getByRole('img', { name: 'image' })).toHaveAttribute(
       'src',
       'https://api.commonly.me/api/uploads/avatar.png',
     );
-    expect(screen.getByRole('link')).toHaveAttribute(
-      'href',
-      'https://api.commonly.me/api/uploads/avatar.png',
-    );
+    expect(screen.getByRole('button', { name: 'Open image' })).toHaveClass('v2-msg__thumb');
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   // A message with no reactions renders NO reactions row at all — the

--- a/frontend/src/v2/__tests__/V2MessageRowAttachments.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageRowAttachments.test.tsx
@@ -1,0 +1,88 @@
+// @ts-nocheck
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2MessageRow, { CollapsiblePre } from '../components/V2MessageRow';
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { username: 'viewer' } }),
+}));
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => ({ get: jest.fn(), post: jest.fn(), patch: jest.fn(), del: jest.fn() }),
+}));
+
+const message = (content, extra = {}) => ({
+  id: '1',
+  pod_id: 'pod-1',
+  user_id: 'sender-1',
+  content,
+  created_at: '2026-09-06T09:04:00.000Z',
+  user: { username: 'ux-lead' },
+  ...extra,
+});
+
+const renderRow = (msg, props = {}) => render(
+  <MemoryRouter><V2MessageRow message={msg} {...props} /></MemoryRouter>,
+);
+
+describe('V2MessageRow attachments (direction C)', () => {
+  const previousApiUrl = process.env.REACT_APP_API_URL;
+  beforeEach(() => { process.env.REACT_APP_API_URL = 'https://api.commonly.me'; });
+  afterEach(() => { process.env.REACT_APP_API_URL = previousApiUrl; });
+
+  test('uploaded images render as thumbnails in one gallery, and a click opens the lightbox that Esc closes', () => {
+    renderRow(message('Walk at 1440 and 390, both states. [[upload:1-walk.png|walk-1440.png|412000|image]] [[upload:2-walk.png|walk-390.png|188000|image]]'));
+    const thumbs = screen.getAllByRole('button', { name: /^Open walk-/ });
+    expect(thumbs).toHaveLength(2);
+    expect(thumbs[0].querySelector('img')).toHaveAttribute('src', 'https://api.commonly.me/api/uploads/1-walk.png');
+    expect(thumbs[0].closest('.v2-msg__thumbs')).toBeTruthy();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    fireEvent.click(thumbs[1]);
+    const dialog = screen.getByRole('dialog', { name: 'walk-390.png' });
+    expect(dialog).toHaveTextContent('walk-390.png · 2/2');
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+    expect(screen.getByRole('dialog')).toHaveTextContent('walk-1440.png · 1/2');
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('non-image uploads render as chips with a text type badge, name and size — no colour square', () => {
+    const onOpenFile = jest.fn();
+    renderRow(message('PR 2 plan attached. [[upload:9-plan.pdf|channel-reply-resolution.pdf|319488|document]] [[upload:8-plan.md|plan.md|4096|document]]'), { onOpenFile });
+    const chip = screen.getByRole('button', { name: 'Open channel-reply-resolution.pdf' });
+    expect(chip).toHaveClass('v2-msg__chip');
+    expect(chip.querySelector('.v2-msg__chip-ext')).toHaveTextContent('pdf');
+    expect(chip.querySelector('.v2-msg__chip-ext')).not.toHaveAttribute('style');
+    expect(chip.querySelector('.v2-msg__chip-size')).toHaveTextContent('312 KB');
+    expect(document.querySelector('.v2-msg__file-icon')).toBeNull();
+    fireEvent.click(chip);
+    expect(onOpenFile).toHaveBeenCalledWith('9-plan.pdf');
+    expect(screen.queryByRole('button', { name: /^Open .*\.png/ })).not.toBeInTheDocument();
+  });
+
+  test('a legacy image message becomes one thumbnail, not a bare link', () => {
+    renderRow(message('/api/uploads/avatar.png', { message_type: 'image' }));
+    const thumb = screen.getByRole('button', { name: 'Open image' });
+    expect(thumb.querySelector('img')).toHaveAttribute('src', 'https://api.commonly.me/api/uploads/avatar.png');
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  // react-markdown is mocked in jsdom, so the collapse is tested at the
+  // component the markdown `pre` override renders.
+  test('fenced code past six lines collapses with Show N more lines and expands in place', () => {
+    const code = Array.from({ length: 12 }, (_, i) => `line ${i + 1}`).join('\n');
+    render(<CollapsiblePre><code>{`${code}\n`}</code></CollapsiblePre>);
+    const more = screen.getByRole('button', { name: 'Show 6 more lines' });
+    expect(more.closest('.v2-msg__collapse')).toHaveClass('v2-msg__collapse--closed');
+    fireEvent.click(more);
+    expect(screen.getByRole('button', { name: 'Show less' }).closest('.v2-msg__collapse')).toHaveClass('v2-msg__collapse--open');
+  });
+
+  test('short code does not collapse', () => {
+    const { container } = render(<CollapsiblePre><code>{'one\ntwo\nthree\n'}</code></CollapsiblePre>);
+    expect(screen.queryByRole('button', { name: /Show/ })).not.toBeInTheDocument();
+    expect(container.querySelector('.v2-msg__collapse')).toBeNull();
+    expect(container.querySelector('pre')).toBeTruthy();
+  });
+});

--- a/frontend/src/v2/__tests__/V2MessageRowAttachments.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageRowAttachments.test.tsx
@@ -61,6 +61,13 @@ describe('V2MessageRow attachments (direction C)', () => {
     expect(screen.queryByRole('button', { name: /^Open .*\.png/ })).not.toBeInTheDocument();
   });
 
+  test('a directive quoted in backticks or a fence stays text — no chip, no thumbnail', () => {
+    renderRow(message('The grammar is `[[upload:abc.png|abc.png|12|image]]` and fenced:\n```\n[[upload:def.md|def.md|3|document]]\n```'));
+    expect(document.querySelector('.v2-msg__thumb')).toBeNull();
+    expect(document.querySelector('.v2-msg__chip')).toBeNull();
+    expect(document.querySelector('.v2-msg__content')).toHaveTextContent('[[upload:abc.png|abc.png|12|image]]');
+  });
+
   test('a legacy image message becomes one thumbnail, not a bare link', () => {
     renderRow(message('/api/uploads/avatar.png', { message_type: 'image' }));
     const thumb = screen.getByRole('button', { name: 'Open image' });

--- a/frontend/src/v2/__tests__/V2ThreadHistory.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadHistory.test.tsx
@@ -69,8 +69,12 @@ describe('V2ThreadMessages history edge and jump pill (direction C)', () => {
 
   test('the jump pill appears only with arrivals while scrolled up and carries the count', () => {
     const onJump = jest.fn();
-    const { rerender } = renderThread({ jumpCount: 0, onJump });
+    renderThread({ jumpCount: 0, onJump });
     expect(screen.queryByRole('button', { name: /Jump to latest/ })).not.toBeInTheDocument();
+    // A viewport up with no arrivals: the pill mounts without a count.
+    const { unmount } = renderThread({ jumpCount: 0, showJump: true, onJump });
+    expect(screen.getByRole('button', { name: /Jump to latest/ })).not.toHaveTextContent('·');
+    unmount();
     renderThread({ jumpCount: 3, onJump });
     const pill = screen.getByRole('button', { name: /Jump to latest/ });
     expect(pill).toHaveTextContent('· 3');

--- a/frontend/src/v2/__tests__/V2ThreadHistory.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadHistory.test.tsx
@@ -1,0 +1,80 @@
+// @ts-nocheck
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2ThreadMessages from '../components/V2ThreadMessages';
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { username: 'viewer' } }),
+}));
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => ({ get: jest.fn(), post: jest.fn(), patch: jest.fn(), del: jest.fn() }),
+}));
+
+const msg = (id) => ({
+  id, pod_id: 'p', user_id: 'u', content: `m${id}`, created_at: '2026-09-06T09:00:00.000Z', user: { username: 'a' },
+});
+
+const renderThread = (props = {}) => {
+  const messages = props.messages || [msg('1'), msg('2')];
+  return render(
+    <MemoryRouter>
+      <V2ThreadMessages
+        messages={messages}
+        threadView={messages.map((message) => ({ kind: 'message', message }))}
+        threadState={{ byRoot: new Map(), toggleCollapsed: jest.fn(), toggleFollowing: jest.fn() }}
+        decisionByMessageId={new Map()}
+        settledDecisionByMessageId={new Map()}
+        agentDisplayNames={new Map()}
+        agentAuthorKeys={new Set()}
+        onAimAtThread={jest.fn()}
+        hasMore={false}
+        loadingOlder={false}
+        onLoadOlder={jest.fn()}
+        loading={false}
+        error={null}
+        messagesContainerRef={React.createRef()}
+        messagesEndRef={React.createRef()}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+};
+
+describe('V2ThreadMessages history edge and jump pill (direction C)', () => {
+  test('with more history the edge is a mono "load earlier" control; loading shows "loading earlier…"', () => {
+    const onLoadOlder = jest.fn();
+    const { rerender, container } = renderThread({ hasMore: true, onLoadOlder });
+    expect(container.querySelector('.v2-thread__edge')).toHaveAttribute('data-state', 'more');
+    fireEvent.click(screen.getByRole('button', { name: 'load earlier' }));
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('.v2-chat__older-btn')).toBeNull();
+  });
+
+  test('loading and beginning states are one mono line each, never a dead button', () => {
+    const { container } = renderThread({ hasMore: true, loadingOlder: true });
+    expect(container.querySelector('.v2-thread__edge')).toHaveAttribute('data-state', 'loading');
+    expect(screen.getByRole('status')).toHaveTextContent('loading earlier…');
+    expect(screen.queryByRole('button', { name: /earlier/ })).not.toBeInTheDocument();
+    const { container: c2 } = renderThread({ hasMore: false });
+    expect(c2.querySelector('.v2-thread__edge')).toHaveAttribute('data-state', 'beginning');
+    expect(screen.getByText('beginning of the pod')).toBeInTheDocument();
+  });
+
+  test('an empty pod shows no edge line at all', () => {
+    const { container } = renderThread({ messages: [], hasMore: false });
+    expect(container.querySelector('.v2-thread__edge')).toHaveAttribute('data-state', 'empty');
+    expect(container.querySelector('.v2-thread__edge').textContent).toBe('');
+  });
+
+  test('the jump pill appears only with arrivals while scrolled up and carries the count', () => {
+    const onJump = jest.fn();
+    const { rerender } = renderThread({ jumpCount: 0, onJump });
+    expect(screen.queryByRole('button', { name: /Jump to latest/ })).not.toBeInTheDocument();
+    renderThread({ jumpCount: 3, onJump });
+    const pill = screen.getByRole('button', { name: /Jump to latest/ });
+    expect(pill).toHaveTextContent('· 3');
+    fireEvent.click(pill);
+    expect(onJump).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/v2/__tests__/V2ThreadStarter.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadStarter.test.tsx
@@ -100,9 +100,10 @@ describe('V2Thread teaching empty states', () => {
   test('regular empty pods teach visible membership and @-mentions', () => {
     renderChat(makeDetail());
 
-    expect(screen.getByText('This pod is quiet')).toBeInTheDocument();
-    expect(screen.getByText(/use @ to mention an agent or teammate/i)).toBeInTheDocument();
-    expect(screen.getByText(/everyone in the member list can see and reply/i)).toBeInTheDocument();
+    expect(screen.getByText('no messages yet')).toBeInTheDocument();
+    // Direction C: the empty pod is one mono line; the composer (focused) carries the teaching.
+    expect(screen.queryByText(/use @ to mention an agent or teammate/i)).not.toBeInTheDocument();
+    expect(document.querySelector('.v2-thread__empty-line')).toHaveTextContent('no messages yet');
   });
 
   test('multi-member regular pods use the same teaching state', () => {
@@ -113,7 +114,7 @@ describe('V2Thread teaching empty states', () => {
       ],
     }));
 
-    expect(screen.getByText('This pod is quiet')).toBeInTheDocument();
+    expect(screen.getByText('no messages yet')).toBeInTheDocument();
   });
 
   test('keeps the agent-to-agent empty state unchanged', () => {
@@ -319,7 +320,7 @@ describe('V2Thread just-created Pod starter panel', () => {
   test('stays absent without the flag or after messages arrive', async () => {
     const noFlag = renderChat(makeDetail());
     expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
-    expect(screen.getByText('This pod is quiet')).toBeInTheDocument();
+    expect(screen.getByText('no messages yet')).toBeInTheDocument();
     noFlag.unmount();
 
     sessionStorage.setItem('v2.justCreated.p1', '1');
@@ -343,7 +344,7 @@ describe('V2Thread just-created Pod starter panel', () => {
     renderChat(makeDetail());
 
     expect(screen.queryByText('Your Pod is ready')).not.toBeInTheDocument();
-    expect(screen.getByText('This pod is quiet')).toBeInTheDocument();
+    expect(screen.getByText('no messages yet')).toBeInTheDocument();
     expect(axios.post).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -839,7 +839,13 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(threadMessages).not.toContain('v2-chat__older-btn');
     expect(thread).toContain('new IntersectionObserver');
     expect(thread).toContain('atBottomRef');
-    expect(ruleBody(v2, '.v2-root button.v2-thread__jump')).toContain('border-radius: 999px');
+    // ux-lead gate on #1579: the pill is a 28px r14 white chip on #dde0e6, sans
+    // 600 13px — the same family as the aim chip, not a 999px capsule.
+    const jump = ruleBody(v2, '.v2-root button.v2-thread__jump');
+    expect(jump).toContain('height: 28px');
+    expect(jump).toContain('border-radius: 14px');
+    expect(jump).toContain('border: 1px solid #dde0e6');
+    expect(jump).toContain('font: 600 13px/26px var(--v2-font)');
     expect(lastRuleBody(v2, '.v2-thread__edge-line')).toContain('var(--v2-font-mono)');
   });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -520,7 +520,8 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('width: 100%');
     expect(ruleBody(v2, '.v2-chat__messages > *')).toContain('margin-inline: 0');
     expect(ruleBody(v2, '.v2-composer')).toContain('border: 1px solid var(--v2-border)');
-    expect(ruleBody(v2, '.v2-composer__posts-as')).toContain('font: 500 11px/16px var(--v2-font-mono)');
+    // Direction C: the identity line is gone; the plus and Send sit inside the one bordered row.
+    expect(ruleBody(v2, '.v2-root button.v2-composer__plus')).toContain('border: 1px solid var(--v2-border)');
     // Nothing in the column may escape the shared edge (Sam, 2026-08-23:
     // mentions and threads sat off-grid while messages aligned).
     // Mentions: the wash bleed must equal the padding (the old -12px against
@@ -805,6 +806,41 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(podBoard).toContain('<AddIcon fontSize="small" aria-hidden="true" />');
     expect(podBoard).not.toContain('← {t(\'board.backToChat\')}');
     expect(podBoard).not.toContain('+ {t(\'board.newTask\')}');
+  });
+
+  test('the composer is one line with a 24px plus menu and a 28px ink Send that exists only with text (direction C PR 2a)', () => {
+    expect(lastRuleBody(v2, '.v2-composer__row')).toContain('min-height: 42px');
+    expect(ruleBody(v2, '.v2-root button.v2-composer__plus')).toContain('width: 24px');
+    expect(ruleBody(v2, '.v2-root button.v2-composer__plus')).toContain('border-radius: 4px');
+    expect(lastRuleBody(v2, '.v2-root .v2-composer__field > textarea')).toContain('max-height: 112px');
+    expect(lastRuleBody(v2, '.v2-root .v2-composer__field > textarea')).toContain('resize: none');
+    expect(lastRuleBody(v2, '.v2-root button.v2-composer__send')).toContain('width: 28px');
+    expect(lastRuleBody(v2, '.v2-root button.v2-composer__send')).toContain('background: var(--v2-ink)');
+    expect(composer).toContain('{hasText && (');
+    expect(composer).toContain("role=\"menu\"");
+    expect(composer).not.toContain('postsAs');
+    expect(v2).not.toContain('.v2-composer__posts-as');
+  });
+
+  test('attachments: 156×104 thumbnails with a lightbox, text-badge chips, code collapsed past six lines', () => {
+    expect(ruleBody(v2, '.v2-root button.v2-msg__thumb')).toContain('width: 156px');
+    expect(ruleBody(v2, '.v2-root button.v2-msg__thumb')).toContain('height: 104px');
+    expect(ruleBody(v2, '.v2-msg__chip-ext')).toContain('background: var(--v2-surface-tint)');
+    expect(ruleBody(v2, '.v2-msg__chip-ext')).not.toContain('#');
+    expect(v2).toContain('.v2-msg__collapse--closed pre');
+    expect(ruleBody(v2, '.v2-lightbox')).toContain('rgba(16, 24, 40, 0.9)');
+    expect(messageRow).not.toContain('FILE_EXT_COLORS');
+    expect(messageRow).toContain('COLLAPSE_AFTER_LINES = 6');
+    expect(messageRow).toContain('<V2Lightbox');
+  });
+
+  test('history: a mono edge line that loads on scroll and a Jump-to-latest pill', () => {
+    expect(threadMessages).toContain('v2-thread__edge');
+    expect(threadMessages).not.toContain('v2-chat__older-btn');
+    expect(thread).toContain('new IntersectionObserver');
+    expect(thread).toContain('atBottomRef');
+    expect(ruleBody(v2, '.v2-root button.v2-thread__jump')).toContain('border-radius: 999px');
+    expect(lastRuleBody(v2, '.v2-thread__edge-line')).toContain('var(--v2-font-mono)');
   });
 
   test('the pod header is 50px: sans 15/600 name, inline description, mono meta — the working count moved to the inspector', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -841,7 +841,17 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(thread).toContain('atBottomRef');
     // ux-lead gate on #1579: the pill is a 28px r14 white chip on #dde0e6, sans
     // 600 13px — the same family as the aim chip, not a 999px capsule.
+    // The wrap sticks to the scroller's bottom edge with real height; the
+    // pill centres by flow. An absolute pill inside a 0-height last child
+    // sat ~1100px below the viewport (ux-lead gate on #1579). Rect
+    // containment is a browser-tier check (setupTests stubs
+    // getBoundingClientRect to zeros), so it lives in the walk, not here.
+    const wrap = ruleBody(v2, '.v2-thread__jump-wrap');
+    expect(wrap).toContain('position: sticky');
+    expect(wrap).toContain('bottom: 12px');
+    expect(wrap).not.toContain('height: 0');
     const jump = ruleBody(v2, '.v2-root button.v2-thread__jump');
+    expect(jump).not.toContain('position: absolute');
     expect(jump).toContain('height: 28px');
     expect(jump).toContain('border-radius: 14px');
     expect(jump).toContain('border: 1px solid #dde0e6');

--- a/frontend/src/v2/components/V2Composer.tsx
+++ b/frontend/src/v2/components/V2Composer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import V2Avatar from './V2Avatar';
 import type { V2Message } from '../hooks/useV2PodDetail';
@@ -40,11 +40,22 @@ interface V2ComposerProps {
   onMentionSelect: (item: V2ComposerMention) => void;
   onSend: () => void;
   onAttach: (file: File | null) => void;
+  // Direction C plus menu: attach any file, attach an image, or paste an image
+  // from the clipboard. The first two open the file input with the right
+  // accept; the third reads the clipboard (falls back to the file input when
+  // the browser refuses).
+  onPasteFromClipboard?: () => void;
   onCancelReply: () => void;
   onCancelThread: () => void;
 }
 
-/** The one bounded input surface for a workspace thread. */
+// One line at rest, five lines at most; past that the textarea scrolls.
+const LINE_HEIGHT = 20;
+const MAX_LINES = 5;
+const VERTICAL_PADDING = 12;
+const FILE_ACCEPT = 'image/*,.pdf,.md,.txt,.csv,.json,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.zip';
+
+/** The one bounded input surface for a workspace thread (direction C). */
 const V2Composer: React.FC<V2ComposerProps> = ({
   podName,
   authorName,
@@ -68,93 +79,148 @@ const V2Composer: React.FC<V2ComposerProps> = ({
   onMentionSelect,
   onSend,
   onAttach,
+  onPasteFromClipboard,
   onCancelReply,
   onCancelThread,
 }) => {
   const { t } = useTranslation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [accept, setAccept] = useState(FILE_ACCEPT);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const hasText = draft.trim().length > 0;
+
+  // Grow with the draft up to five lines, then scroll inside the field.
+  useLayoutEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const max = LINE_HEIGHT * MAX_LINES + VERTICAL_PADDING;
+    const next = Math.min(el.scrollHeight, max);
+    el.style.height = `${Math.max(next, LINE_HEIGHT + VERTICAL_PADDING)}px`;
+    el.style.overflowY = el.scrollHeight > max ? 'auto' : 'hidden';
+  }, [draft, inputRef]);
+
+  useEffect(() => {
+    if (!menuOpen) return undefined;
+    const close = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) setMenuOpen(false);
+    };
+    const onEsc = (event: KeyboardEvent) => { if (event.key === 'Escape') setMenuOpen(false); };
+    document.addEventListener('mousedown', close);
+    document.addEventListener('keydown', onEsc);
+    return () => {
+      document.removeEventListener('mousedown', close);
+      document.removeEventListener('keydown', onEsc);
+    };
+  }, [menuOpen]);
+
+  const openFileInput = (nextAccept: string) => {
+    setAccept(nextAccept);
+    setMenuOpen(false);
+    // The accept attribute must be on the input before the picker opens.
+    window.setTimeout(() => fileInputRef.current?.click(), 0);
+  };
+
+  const pasteFromClipboard = () => {
+    setMenuOpen(false);
+    if (onPasteFromClipboard) onPasteFromClipboard();
+    else openFileInput('image/*');
+  };
+
+  const target = threadTarget
+    ? { label: `↳ ${t('podChat.thread.replyingInThread')} ${threadTarget.preview.replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 32)}`, cancel: onCancelThread }
+    : replyTarget
+      ? { label: null, cancel: onCancelReply }
+      : null;
+
   return (
-    <div className="v2-composer">
-      {threadTarget && (
-        <div className="v2-composer__target" role="status">
-          <span>{t('podChat.thread.replyingInThread')} {threadTarget.preview.replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 40)}</span>
-          <button type="button" aria-label={t('podChat.cancelReply')} onClick={onCancelThread}>×</button>
-        </div>
-      )}
-      {replyTarget && (
-        <div className="v2-composer__target" role="status">
-          <span>
-            <Trans
-              i18nKey="podChat.replyingTo"
-              values={{ author: replyTarget.user?.username || t('podChat.messageFallback') }}
-              components={{ author: <strong /> }}
-            />{' '}
-            {String(replyTarget.content || '').replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 80)}
-          </span>
-          <button type="button" aria-label={t('podChat.cancelReply')} onClick={onCancelReply}>×</button>
-        </div>
-      )}
-      <div className="v2-composer__field">
-        <textarea
-          ref={inputRef}
-          placeholder={t('podChat.composer.placeholder', { podName })}
-          value={draft}
-          rows={2}
-          onChange={(event) => onDraftChange(event.target.value, event.target.selectionStart)}
-          onClick={(event) => onDraftPointer(event.currentTarget.value, event.currentTarget.selectionStart)}
-          onKeyUp={(event) => onDraftPointer(event.currentTarget.value, event.currentTarget.selectionStart)}
-          onKeyDown={onKeyDown}
-        />
-        {mentionOpen && mentions.length > 0 && (
-          <div className="v2-mention-dropdown" ref={mentionDropdownRef} role="listbox">
-            {mentions.map((item, index) => (
-              <button
-                type="button"
-                key={item.id}
-                className={`v2-mention-item${index === mentionIndex ? ' v2-mention-item--active' : ''}`}
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => onMentionSelect(item)}
-                role="option"
-                aria-selected={index === mentionIndex}
-              >
-                <V2Avatar name={item.label} src={item.avatar || undefined} size="sm" />
-                <span className="v2-mention-item__text">
-                  <span className="v2-mention-item__label">@{item.value || item.label}</span>
-                  <span className="v2-mention-item__sub">{item.subtitle}</span>
-                </span>
-              </button>
-            ))}
-          </div>
-        )}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*,.pdf,.md,.txt,.csv,.json,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.zip"
-          className="v2-composer__file"
-          onChange={(event) => onAttach(event.target.files?.[0] || null)}
-        />
-        <div className="v2-composer__actions">
+    <div className={`v2-composer${hasText ? ' v2-composer--typing' : ''}${uploading ? ' v2-composer--uploading' : ''}`}>
+      <div className="v2-composer__row">
+        <div className="v2-composer__plus-wrap" ref={menuRef}>
           <button
             type="button"
-            className="v2-composer__attach"
-            title={uploading ? t('podChat.composer.uploading') : t('podChat.composer.attachFile')}
-            aria-label={t('podChat.composer.attachFile')}
-            onClick={() => fileInputRef.current?.click()}
+            className="v2-composer__plus"
+            aria-label={t('podChat.composer.more')}
+            title={t('podChat.composer.more')}
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen((open) => !open)}
             disabled={uploading}
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 11l-9 9a5 5 0 01-7-7l9-9a3 3 0 014 4l-9 9a1 1 0 01-2-2l8-8" /></svg>
-          </button>
-          <span className="v2-composer__posts-as">{t('podChat.composer.postsAs', { name: authorName })} · ⌘↵</span>
+          />
+          {menuOpen && (
+            <div className="v2-composer__menu" role="menu" aria-label={t('podChat.composer.more')}>
+              <button type="button" role="menuitem" onClick={() => openFileInput(FILE_ACCEPT)}>{t('podChat.composer.attachFile')}</button>
+              <button type="button" role="menuitem" onClick={() => openFileInput('image/*')}>{t('podChat.composer.attachImage')}</button>
+              <button type="button" role="menuitem" onClick={pasteFromClipboard}>{t('podChat.composer.pasteImage')}</button>
+            </div>
+          )}
+        </div>
+        {target && (
+          <span className="v2-composer__tag" role="status">
+            {target.label ? target.label : (
+              <Trans
+                i18nKey="podChat.replyingTo"
+                values={{ author: replyTarget?.user?.username || t('podChat.messageFallback') }}
+                components={{ author: <strong /> }}
+              />
+            )}
+            <button type="button" className="v2-composer__tag-cancel" aria-label={t('podChat.cancelReply')} onClick={target.cancel}>×</button>
+          </span>
+        )}
+        <div className="v2-composer__field">
+          <textarea
+            ref={inputRef}
+            placeholder={t('podChat.composer.placeholder', { podName })}
+            value={draft}
+            rows={1}
+            onChange={(event) => onDraftChange(event.target.value, event.target.selectionStart)}
+            onClick={(event) => onDraftPointer(event.currentTarget.value, event.currentTarget.selectionStart)}
+            onKeyUp={(event) => onDraftPointer(event.currentTarget.value, event.currentTarget.selectionStart)}
+            onKeyDown={onKeyDown}
+          />
+          {mentionOpen && mentions.length > 0 && (
+            <div className="v2-mention-dropdown" ref={mentionDropdownRef} role="listbox">
+              {mentions.map((item, index) => (
+                <button
+                  type="button"
+                  key={item.id}
+                  className={`v2-mention-item${index === mentionIndex ? ' v2-mention-item--active' : ''}`}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => onMentionSelect(item)}
+                  role="option"
+                  aria-selected={index === mentionIndex}
+                >
+                  <V2Avatar name={item.label} src={item.avatar || undefined} size="sm" />
+                  <span className="v2-mention-item__text">
+                    <span className="v2-mention-item__label">@{item.value || item.label}</span>
+                    <span className="v2-mention-item__sub">{item.subtitle}</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        {uploading && <span className="v2-composer__uploading" role="status">{t('podChat.composer.uploading')}</span>}
+        {hasText && (
           <button
             type="button"
             className="v2-composer__send"
             onClick={onSend}
-            disabled={sending || !draft.trim()}
+            disabled={sending}
             aria-label={sending ? t('podChat.composer.sending') : t('podChat.composer.sendAria')}
+            title={t('podChat.composer.sendTooltip', { name: authorName })}
           >
-            {sending ? t('podChat.composer.sending') : t('podChat.composer.send')}
+            <span aria-hidden="true">↵</span>
           </button>
-        </div>
+        )}
       </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={accept}
+        className="v2-composer__file"
+        onChange={(event) => onAttach(event.target.files?.[0] || null)}
+      />
       {(composerError || sendError) && <p className="v2-composer__error">{composerError || sendError}</p>}
       {warnings.length > 0 && (
         <div className="v2-composer__warnings" data-testid="mention-state-warning">

--- a/frontend/src/v2/components/V2Composer.tsx
+++ b/frontend/src/v2/components/V2Composer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import V2Avatar from './V2Avatar';
 import type { V2Message } from '../hooks/useV2PodDetail';
 
@@ -127,10 +127,12 @@ const V2Composer: React.FC<V2ComposerProps> = ({
     else openFileInput('image/*');
   };
 
+  // The aim chip (direction C): `↳ replying in thread` / `↳ replying to <author>`,
+  // mono lowercase, inside the row before the placeholder.
   const target = threadTarget
-    ? { label: `↳ ${t('podChat.thread.replyingInThread')} ${threadTarget.preview.replace(/\[\[upload:[^\]]*\]\]/g, '📎').slice(0, 32)}`, cancel: onCancelThread }
+    ? { label: t('podChat.composer.aimThread'), cancel: onCancelThread }
     : replyTarget
-      ? { label: null, cancel: onCancelReply }
+      ? { label: t('podChat.composer.aimReply', { author: replyTarget.user?.username || t('podChat.messageFallback') }), cancel: onCancelReply }
       : null;
 
   return (
@@ -156,21 +158,15 @@ const V2Composer: React.FC<V2ComposerProps> = ({
           )}
         </div>
         {target && (
-          <span className="v2-composer__tag" role="status">
-            {target.label ? target.label : (
-              <Trans
-                i18nKey="podChat.replyingTo"
-                values={{ author: replyTarget?.user?.username || t('podChat.messageFallback') }}
-                components={{ author: <strong /> }}
-              />
-            )}
-            <button type="button" className="v2-composer__tag-cancel" aria-label={t('podChat.cancelReply')} onClick={target.cancel}>×</button>
+          <span className="v2-composer__aim v2-composer__tag" role="status">
+            {target.label}
+            <button type="button" className="v2-composer__aim-cancel v2-composer__tag-cancel" aria-label={t('podChat.cancelReply')} onClick={target.cancel}>×</button>
           </span>
         )}
         <div className="v2-composer__field">
           <textarea
             ref={inputRef}
-            placeholder={t('podChat.composer.placeholder', { podName })}
+            placeholder={threadTarget ? t('podChat.thread.replyInThread') : replyTarget ? t('podChat.composer.replyPlaceholder', { author: replyTarget.user?.username || t('podChat.messageFallback') }) : t('podChat.composer.placeholder', { podName })}
             value={draft}
             rows={1}
             onChange={(event) => onDraftChange(event.target.value, event.target.selectionStart)}

--- a/frontend/src/v2/components/V2Lightbox.tsx
+++ b/frontend/src/v2/components/V2Lightbox.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getSignedAttachmentUrl } from '../../utils/signedAttachmentUrl';
+
+export interface V2LightboxImage {
+  src: string;
+  name: string;
+}
+
+interface V2LightboxProps {
+  images: V2LightboxImage[];
+  index: number;
+  onClose: () => void;
+}
+
+/**
+ * Direction C lightbox: ink ground at 90%, the image contained, the filename
+ * top-left, a 28px close square top-right, ←/→ across the images of the same
+ * message, Esc closes. Rendered by the message row that owns the thumbnails.
+ */
+const V2Lightbox: React.FC<V2LightboxProps> = ({ images, index, onClose }) => {
+  const { t } = useTranslation();
+  const [current, setCurrent] = useState(index);
+  const count = images.length;
+  const image = images[Math.min(current, count - 1)];
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') { event.preventDefault(); onClose(); }
+      if (event.key === 'ArrowRight' && count > 1) setCurrent((i) => (i + 1) % count);
+      if (event.key === 'ArrowLeft' && count > 1) setCurrent((i) => (i - 1 + count) % count);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [count, onClose]);
+
+  // Same signed-URL bridge as the thumbnails: the full image needs it too.
+  const [resolved, setResolved] = useState<string | null>(null);
+  useEffect(() => {
+    let active = true;
+    setResolved(null);
+    if (!image || !/\/api\/uploads\//.test(image.src)) return undefined;
+    void getSignedAttachmentUrl(image.src).then((signed) => { if (active && signed) setResolved(signed); });
+    return () => { active = false; };
+  }, [image]);
+
+  if (!image) return null;
+
+  return (
+    <div className="v2-lightbox" role="dialog" aria-modal="true" aria-label={image.name} onClick={onClose}>
+      <span className="v2-lightbox__name">{image.name}{count > 1 ? ` · ${current + 1}/${count}` : ''}</span>
+      <button type="button" className="v2-lightbox__close" aria-label={t('podChat.lightbox.close')} onClick={onClose}>×</button>
+      {count > 1 && (
+        <>
+          <button type="button" className="v2-lightbox__nav v2-lightbox__nav--prev" aria-label={t('podChat.lightbox.previous')} onClick={(event) => { event.stopPropagation(); setCurrent((i) => (i - 1 + count) % count); }}>←</button>
+          <button type="button" className="v2-lightbox__nav v2-lightbox__nav--next" aria-label={t('podChat.lightbox.next')} onClick={(event) => { event.stopPropagation(); setCurrent((i) => (i + 1) % count); }}>→</button>
+        </>
+      )}
+      <img className="v2-lightbox__image" src={resolved || image.src} alt={image.name} onClick={(event) => event.stopPropagation()} />
+    </div>
+  );
+};
+
+export default V2Lightbox;

--- a/frontend/src/v2/components/V2MessageRow.tsx
+++ b/frontend/src/v2/components/V2MessageRow.tsx
@@ -175,11 +175,21 @@ const MARKDOWN_IMAGE_RE = /^!\[[^\]]*\]\(([^)]+)\)$/;
 // image send posted as bare content (`/api/uploads/<key>.png`).
 const IMAGE_URL_RE = /^(?:https?:\/\/.+|\/api\/uploads\/[^\s]+)\.(png|jpe?g|gif|webp|svg)(\?.*)?$/i;
 
+// Code spans and fences are quoted grammar, not attachments: mask them while
+// the directives are pulled out, then put them back verbatim.
+const CODE_RE = /```[\s\S]*?```|`[^`\n]*`/g;
+const maskCode = (content: string): { masked: string; restore: (s: string) => string } => {
+  const spans: string[] = [];
+  const masked = content.replace(CODE_RE, (span) => { spans.push(span); return `\u0000${spans.length - 1}\u0000`; });
+  return { masked, restore: (s) => s.replace(/\u0000(\d+)\u0000/g, (_m, i) => spans[Number(i)]) };
+};
+
 const parseFiles = (content: string): { stripped: string; files: ParsedFile[] } => {
   const files: ParsedFile[] = [];
+  const { masked, restore } = maskCode(content);
   // Real uploads first — they carry a fileName and resolve to a signed URL on
   // click. Then static file tokens (demo fixtures, no backend reference).
-  let working = content.replace(UPLOAD_TOKEN_RE, (_match, rawFileName, rawOriginal, rawSize, rawKind) => {
+  let working = masked.replace(UPLOAD_TOKEN_RE, (_match, rawFileName, rawOriginal, rawSize, rawKind) => {
     const fileName = String(rawFileName).trim();
     const name = String(rawOriginal).trim();
     const dot = name.lastIndexOf('.');
@@ -195,7 +205,7 @@ const parseFiles = (content: string): { stripped: string; files: ParsedFile[] } 
     files.push({ name, ext, size: rawSize ? String(rawSize).trim() : undefined });
     return '';
   });
-  return { stripped: working.trim(), files };
+  return { stripped: restore(working).trim(), files };
 };
 
 const parseReactions = (content: string): { stripped: string; reactions: ParsedReaction[] } => {

--- a/frontend/src/v2/components/V2MessageRow.tsx
+++ b/frontend/src/v2/components/V2MessageRow.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import V2Lightbox, { type V2LightboxImage } from './V2Lightbox';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
@@ -70,6 +71,8 @@ const messageMarkdownComponents = {
   // Inline code vs fenced code share `<code>`; only fenced code is wrapped in
   // `<pre>`. Both fall through to v2.css selectors `.v2-msg__content code`
   // and `.v2-msg__content pre`. Mentions inside code are NOT transformed.
+  // Fenced code past six lines collapses (direction C).
+  pre: (props: React.HTMLAttributes<HTMLPreElement>) => <CollapsiblePre {...props} />,
 };
 
 interface V2MessageRowProps {
@@ -129,6 +132,9 @@ interface ParsedFile {
   name: string;
   ext: string;
   size?: string;
+  // Upload kind from the directive (image / document / data / office / archive);
+  // images render as thumbnails, everything else as a chip.
+  kind?: string;
   // Set when the pill came from an [[upload:...]] directive backed by a real
   // ObjectStore record. Click → mint signed URL → open. Plain [[file:...]]
   // pills (used by demo fixtures) leave this undefined and render as static.
@@ -140,26 +146,6 @@ interface ParsedReaction {
   count: number;
 }
 
-const FILE_EXT_COLORS: Record<string, string> = {
-  md: '#60a5fa',
-  txt: '#94a3b8',
-  pdf: '#ef4444',
-  docx: '#3b82f6',
-  doc: '#3b82f6',
-  xlsx: '#10b981',
-  xls: '#10b981',
-  csv: '#10b981',
-  pptx: '#f97316',
-  ppt: '#f97316',
-  odt: '#3b82f6',
-  ods: '#10b981',
-  odp: '#f97316',
-  json: '#f59e0b',
-  zip: '#a78bfa',
-  png: '#f472b6',
-  jpg: '#f472b6',
-  jpeg: '#f472b6',
-};
 
 // Match a markdown-ish file token: [[file:Name.ext]] or [[file:Name.ext|2.4 KB]].
 // This is a v2-only convention so we can preview file pills until the backend
@@ -185,18 +171,21 @@ const formatBytes = (raw: string | number): string => {
 // Real reactions backend ships post-YC.
 const REACTION_TOKEN_RE = /\[\[reactions:([^\]]+)\]\]/g;
 const MARKDOWN_IMAGE_RE = /^!\[[^\]]*\]\(([^)]+)\)$/;
-const IMAGE_URL_RE = /^https?:\/\/.+\.(png|jpe?g|gif|webp)(\?.*)?$/i;
+// Absolute image URLs and the instance-relative upload reference the legacy
+// image send posted as bare content (`/api/uploads/<key>.png`).
+const IMAGE_URL_RE = /^(?:https?:\/\/.+|\/api\/uploads\/[^\s]+)\.(png|jpe?g|gif|webp|svg)(\?.*)?$/i;
 
 const parseFiles = (content: string): { stripped: string; files: ParsedFile[] } => {
   const files: ParsedFile[] = [];
   // Real uploads first — they carry a fileName and resolve to a signed URL on
   // click. Then static file tokens (demo fixtures, no backend reference).
-  let working = content.replace(UPLOAD_TOKEN_RE, (_match, rawFileName, rawOriginal, rawSize) => {
+  let working = content.replace(UPLOAD_TOKEN_RE, (_match, rawFileName, rawOriginal, rawSize, rawKind) => {
     const fileName = String(rawFileName).trim();
     const name = String(rawOriginal).trim();
     const dot = name.lastIndexOf('.');
     const ext = dot >= 0 ? name.slice(dot + 1).toLowerCase() : 'file';
-    files.push({ fileName, name, ext, size: formatBytes(String(rawSize).trim()) || undefined });
+    const kind = rawKind ? String(rawKind).trim() : undefined;
+    files.push({ fileName, name, ext, kind, size: formatBytes(String(rawSize).trim()) || undefined });
     return '';
   });
   working = working.replace(FILE_TOKEN_RE, (_match, rawName, rawSize) => {
@@ -229,73 +218,78 @@ const parseReactions = (content: string): { stripped: string; reactions: ParsedR
   return { stripped, reactions };
 };
 
-const FilePill: React.FC<{
+const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg']);
+
+// A browser cannot send the bearer header on `<img src>`, so each thumbnail
+// asks for the short-TTL signed URL (ADR-002 1b, cached per file) and falls
+// back to the plain reference while the public-read GET still exists.
+const SignedImage: React.FC<{ src: string; alt: string }> = ({ src, alt }) => {
+  const [resolved, setResolved] = useState<string>(src);
+  useEffect(() => {
+    let active = true;
+    if (!/\/api\/uploads\//.test(src)) return undefined;
+    void getSignedAttachmentUrl(src).then((signed) => { if (active && signed) setResolved(signed); });
+    return () => { active = false; };
+  }, [src]);
+  return <img src={resolved} alt={alt} loading="lazy" />;
+};
+const isImageFile = (file: ParsedFile): boolean => file.kind === 'image' || IMAGE_EXTS.has(file.ext);
+
+// Direction C file chip: type badge as text on tint (never a colour), name, size.
+// Click opens through the inspector when a handler is in scope, else mints the
+// signed URL and opens in a tab.
+const FileChip: React.FC<{
   file: ParsedFile;
   onOpenFile?: (fileName: string) => void;
 }> = ({ file, onOpenFile }) => {
-  const color = FILE_EXT_COLORS[file.ext] || '#94a3b8';
+  const { t } = useTranslation();
   const inner = (
     <>
-      <span className="v2-msg__file-icon" style={{ background: color }}>
-        {file.ext.slice(0, 4).toUpperCase()}
-      </span>
-      <span className="v2-msg__file-meta">
-        <span className="v2-msg__file-name">{file.name}</span>
-        {file.size && <span className="v2-msg__file-size">{file.size}</span>}
-      </span>
+      <span className="v2-msg__chip-ext">{file.ext.slice(0, 4)}</span>
+      <span className="v2-msg__chip-name">{file.name}</span>
+      {file.size && <span className="v2-msg__chip-size">{file.size}</span>}
     </>
   );
-  // Static demo file with no backend reference — but we can still try to
-  // resolve it via the inspector's pod-files index by `originalName`. The
-  // inspector's `openByFileName` callback (threaded down from V2Layout) is
-  // tolerant of either the ObjectStore key or a originalName lookup, so a
-  // chat author can post a `[[file:foo.md]]` static token and clicking it
-  // opens the corresponding pod-file artifact preview if a file with that
-  // originalName exists. Falls back to a non-clickable pill if there's no
-  // handler in scope.
-  if (!file.fileName) {
+  const handleClick = async (event: React.MouseEvent) => {
+    event.preventDefault();
     if (onOpenFile) {
-      const handleStaticClick = (e: React.MouseEvent) => {
-        e.preventDefault();
-        onOpenFile(file.name); // resolved by originalName
-      };
-      return (
-        <button
-          type="button"
-          className="v2-msg__file v2-msg__file--clickable"
-          onClick={handleStaticClick}
-          aria-label={`Open ${file.name}`}
-        >
-          {inner}
-        </button>
-      );
-    }
-    return <span className="v2-msg__file">{inner}</span>;
-  }
-  // Real upload — prefer the inspector route when a handler is in scope so
-  // the preview lands inline (markdown rendered, csv tabular, etc.) instead
-  // of dumping raw bytes into a new tab. Fall back to the legacy signed-URL
-  // open-in-tab when no handler is provided (older surfaces).
-  const handleClick = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    if (onOpenFile && file.fileName) {
-      onOpenFile(file.fileName);
+      onOpenFile(file.fileName || file.name);
       return;
     }
+    if (!file.fileName) return;
     const signed = await getSignedAttachmentUrl(`/api/uploads/${file.fileName}`);
-    if (signed) {
-      window.open(signed, '_blank', 'noopener,noreferrer');
-    }
+    if (signed) window.open(signed, '_blank', 'noopener,noreferrer');
   };
+  if (!file.fileName && !onOpenFile) return <span className="v2-msg__chip">{inner}</span>;
   return (
-    <button
-      type="button"
-      className="v2-msg__file v2-msg__file--clickable"
-      onClick={handleClick}
-      aria-label={`Open ${file.name}`}
-    >
+    <button type="button" className="v2-msg__chip" onClick={handleClick} aria-label={t('podChat.attachment.open', { name: file.name })}>
       {inner}
     </button>
+  );
+};
+
+// Code past six lines collapses in place; Show more expands it, Show less folds it.
+const COLLAPSE_AFTER_LINES = 6;
+export const CollapsiblePre: React.FC<React.HTMLAttributes<HTMLPreElement>> = ({ children, ...props }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const text = React.Children.toArray(children).map((child) => {
+    if (typeof child === 'string') return child;
+    if (React.isValidElement(child)) {
+      const inner = (child.props as { children?: React.ReactNode }).children;
+      return React.Children.toArray(inner).filter((c) => typeof c === 'string').join('');
+    }
+    return '';
+  }).join('');
+  const lines = text.replace(/\n$/, '').split('\n').length;
+  if (lines <= COLLAPSE_AFTER_LINES) return <pre {...props}>{children}</pre>;
+  return (
+    <div className={`v2-msg__collapse${open ? ' v2-msg__collapse--open' : ' v2-msg__collapse--closed'}`}>
+      <pre {...props}>{children}</pre>
+      <button type="button" className="v2-msg__more" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
+        {open ? t('podChat.attachment.showLess') : t('podChat.attachment.showMore', { count: lines - COLLAPSE_AFTER_LINES })}
+      </button>
+    </div>
   );
 };
 
@@ -344,6 +338,8 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
   // nothing visible — which made the ❤️-validation bug read as "reactions
   // don't work / can't add more than one" (2026-07-24).
   const [reactionError, setReactionError] = useState<string | null>(null);
+  // Thumbnail → lightbox, per row; the index is into this row's own images.
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const rawUsername = message.user?.username || 'Unknown';
   const overriddenDisplay = agentDisplayNames?.get(rawUsername);
   const author = overriddenDisplay || rawUsername;
@@ -417,6 +413,15 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
   // Resolve them against the configured API origin at render time so the
   // browser never requests image bytes from the frontend host.
   const imageUrl = rawImageUrl ? normalizeUploadUrl(rawImageUrl) : undefined;
+  // Direction C: every image attached to the message is a 156×104 thumbnail in
+  // one gallery row; other uploads are chips. Uploaded images resolve to the
+  // same `/api/uploads/<key>` reference the legacy image path already uses.
+  const imageFiles = files.filter(isImageFile);
+  const otherFiles = files.filter((file) => !isImageFile(file));
+  const galleryImages: V2LightboxImage[] = [
+    ...(imageUrl ? [{ src: imageUrl, name: t('podChat.attachment.image') }] : []),
+    ...imageFiles.filter((file) => file.fileName).map((file) => ({ src: normalizeUploadUrl(`/api/uploads/${file.fileName}`), name: file.name })),
+  ];
 
   // GitHub PR URL detection — if the message body contains a `pull/<n>` URL,
   // we render an inline preview card below the text. Card fetch is lazy +
@@ -581,20 +586,37 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
             </div>
           );
         })()}
-        {imageUrl ? (
-          <a href={imageUrl} target="_blank" rel="noreferrer" className="v2-msg__image-link">
-            <img src={imageUrl} alt="Uploaded attachment" className="v2-msg__image" />
-          </a>
-        ) : (
-          stripped && (
-            <div className="v2-msg__content">
-              <ReactMarkdown components={messageMarkdownComponents}>{stripped}</ReactMarkdown>
-            </div>
-          )
+        {!imageUrl && stripped && (
+          <div className="v2-msg__content">
+            <ReactMarkdown components={messageMarkdownComponents}>{stripped}</ReactMarkdown>
+          </div>
         )}
-        {files.map((file, idx) => (
-          <FilePill key={`${file.name}-${idx}`} file={file} onOpenFile={onOpenFile} />
-        ))}
+        {galleryImages.length > 0 && (
+          <div className="v2-msg__thumbs">
+            {galleryImages.map((image, idx) => (
+              <button
+                key={`${image.src}-${idx}`}
+                type="button"
+                className="v2-msg__thumb"
+                onClick={(event) => { event.stopPropagation(); setLightboxIndex(idx); }}
+                aria-label={t('podChat.attachment.open', { name: image.name })}
+              >
+                <SignedImage src={image.src} alt={image.name} />
+                <span className="v2-msg__thumb-name" aria-hidden="true">{image.name}</span>
+              </button>
+            ))}
+          </div>
+        )}
+        {lightboxIndex !== null && galleryImages.length > 0 && (
+          <V2Lightbox images={galleryImages} index={lightboxIndex} onClose={() => setLightboxIndex(null)} />
+        )}
+        {otherFiles.length > 0 && (
+          <div className="v2-msg__chips">
+            {otherFiles.map((file, idx) => (
+              <FileChip key={`${file.name}-${idx}`} file={file} onOpenFile={onOpenFile} />
+            ))}
+          </div>
+        )}
         {prRefs.map((pr) => (
           <V2GithubPrCard
             key={`${pr.owner}/${pr.repo}#${pr.number}`}

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -502,8 +502,39 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // which reads as "load older is broken". Key on the newest message's id so
   // prepends are ignored.
   const newestMessageId = messages.length > 0 ? messages[messages.length - 1].id : null;
-  useEffect(() => {
+  // Direction C history: the reader's position is respected. New messages
+  // pull the view down only when it was already at the bottom (or the message
+  // is mine); otherwise they count up in the Jump-to-latest pill.
+  const atBottomRef = useRef(true);
+  const [jumpCount, setJumpCount] = useState(0);
+  const edgeRef = useRef<HTMLDivElement | null>(null);
+  const jumpToLatest = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    atBottomRef.current = true;
+    setJumpCount(0);
+  }, []);
+  useEffect(() => {
+    const el = messagesContainerRef.current;
+    if (!el) return undefined;
+    const onScroll = () => {
+      const near = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+      atBottomRef.current = near;
+      if (near) setJumpCount(0);
+    };
+    onScroll();
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [pod?._id]);
+  const newestIsMine = messages.length > 0 && String(messages[messages.length - 1]?.user_id || '') === String(currentUser?._id || '');
+  useEffect(() => {
+    if (!newestMessageId) return;
+    if (atBottomRef.current || newestIsMine) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      setJumpCount(0);
+    } else {
+      setJumpCount((count) => count + 1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [newestMessageId]);
 
   // Prepending changes scrollHeight, so without this the viewport jumps. Hold
@@ -523,6 +554,37 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     el.scrollTop = el.scrollHeight - anchor;
     scrollAnchorRef.current = null;
   }, [messages]);
+
+  // Pasting an image into the field attaches it. The handler is defined
+  // later (it needs the upload plumbing), so the effect reads it through a ref
+  // and stays above the early return with the other hooks.
+  const attachFileRef = useRef<((file: File | null) => Promise<void>) | null>(null);
+  useEffect(() => {
+    const el = composerInputRef.current;
+    if (!el) return undefined;
+    const onPaste = (event: ClipboardEvent) => {
+      const file = Array.from(event.clipboardData?.files || []).find((candidate) => candidate.type.startsWith('image/'));
+      if (!file) return;
+      event.preventDefault();
+      void attachFileRef.current?.(file);
+    };
+    el.addEventListener('paste', onPaste);
+    return () => el.removeEventListener('paste', onPaste);
+  }, [pod?._id]);
+
+  // Reaching the top loads the previous page; the edge line is the sentinel.
+  useEffect(() => {
+    const edge = edgeRef.current;
+    const root = messagesContainerRef.current;
+    if (!edge || !root || typeof IntersectionObserver === 'undefined') return undefined;
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      if (!hasMore || loadingOlder || loading) return;
+      void handleLoadOlder();
+    }, { root, rootMargin: '120px 0px 0px 0px' });
+    observer.observe(edge);
+    return () => observer.disconnect();
+  }, [hasMore, loadingOlder, loading, handleLoadOlder, pod?._id]);
 
   // Removed: Lead-pill computation. The "Lead" label was just `idx === 0`,
   // which made whichever agent installed first (usually auto-installed
@@ -861,6 +923,25 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // draft so the user can add accompanying text and send when ready). Both
   // paths POST to /api/uploads with the active podId so the file shows up in
   // the inspector's Artifacts section.
+  // Paste an image straight into the thread: from the plus menu (clipboard
+  // read) or by pasting into the field.
+  const attachFromClipboard = async () => {
+    try {
+      const items = await navigator.clipboard.read();
+      for (const item of items) {
+        const type = item.types.find((candidate) => candidate.startsWith('image/'));
+        if (type) {
+          const blob = await item.getType(type);
+          const ext = type.split('/')[1] || 'png';
+          await handleAttachFile(new File([blob], `pasted-${Date.now()}.${ext}`, { type }));
+          return;
+        }
+      }
+      setComposerError(t('podChat.composer.clipboardEmpty'));
+    } catch {
+      fileInputRef.current?.click();
+    }
+  };
   const handleAttachFile = async (file: File | null) => {
     if (!file || uploading) return;
     setUploading(true);
@@ -894,8 +975,15 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
         // The rule the ruling states is "a send consumes the target on EVERY
         // path" — written that way precisely because per-path wiring is what
         // keeps going wrong here.
+        // One attachment model (direction C): the image goes out as the same
+        // `[[upload:…|image]]` manifest a file does, so the row renders a
+        // thumbnail and an agent reads it through the attachment tool. The
+        // bare URL remains only for a server that returned no file key.
+        const imageContent = uploaded.fileName
+          ? `[[upload:${uploaded.fileName}|${uploaded.originalName || file.name}|${uploaded.size || file.size}|image]]`
+          : uploaded.url;
         const created = await sendMessage(
-          uploaded.url,
+          imageContent,
           'image',
           replyTarget?.id || undefined,
           threadTarget?.id || undefined,
@@ -918,6 +1006,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
       if (fileInputRef.current) fileInputRef.current.value = '';
     }
   };
+  attachFileRef.current = handleAttachFile;
 
   const starterPrompts = STARTER_PROMPT_KEYS.map((key) => t(key));
   // Header meta (direction C): members · agents · board N open · bound
@@ -995,6 +1084,9 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           hasMore={hasMore}
           loadingOlder={loadingOlder}
           onLoadOlder={() => { void handleLoadOlder(); }}
+          edgeRef={edgeRef}
+          jumpCount={jumpCount}
+          onJump={jumpToLatest}
           loading={loading}
           error={error}
           starterPanel={starterPanelVisible ? (
@@ -1164,6 +1256,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
                 onMentionSelect={selectMention}
                 onSend={() => { void handleSend(); }}
                 onAttach={(file) => { void handleAttachFile(file); }}
+                onPasteFromClipboard={() => { void attachFromClipboard(); }}
                 onCancelReply={() => setReplyTarget(null)}
                 onCancelThread={() => setThreadTarget(null)}
               />

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -209,13 +209,16 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
 
   // Setting one composer target clears the other. Two chips would be two
   // meanings for one send, and the resolver rejects a message carrying both.
+  // Aiming puts the cursor in the field so Esc (un-aim) and typing both land.
   const aimAtThread = useCallback((rootId: string, preview: string) => {
     setReplyTarget(null);
     setThreadTarget({ id: rootId, preview });
+    composerInputRef.current?.focus();
   }, []);
   const aimAtMessage = useCallback((m: import('../hooks/useV2PodDetail').V2Message) => {
     setThreadTarget(null);
     setReplyTarget(m);
+    composerInputRef.current?.focus();
   }, []);
   const aimAtMessageThread = useCallback((m: import('../hooks/useV2PodDetail').V2Message) => {
     // The action is available on every visible message, including replies.
@@ -507,18 +510,23 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // is mine); otherwise they count up in the Jump-to-latest pill.
   const atBottomRef = useRef(true);
   const [jumpCount, setJumpCount] = useState(0);
+  // The pill mounts once the reader is a viewport up; `· N` only with arrivals.
+  const [scrolledUp, setScrolledUp] = useState(false);
   const edgeRef = useRef<HTMLDivElement | null>(null);
   const jumpToLatest = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     atBottomRef.current = true;
     setJumpCount(0);
+    setScrolledUp(false);
   }, []);
   useEffect(() => {
     const el = messagesContainerRef.current;
     if (!el) return undefined;
     const onScroll = () => {
-      const near = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      const near = distance < 80;
       atBottomRef.current = near;
+      setScrolledUp(distance > el.clientHeight);
       if (near) setJumpCount(0);
     };
     onScroll();
@@ -571,6 +579,10 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     el.addEventListener('paste', onPaste);
     return () => el.removeEventListener('paste', onPaste);
   }, [pod?._id]);
+
+  useEffect(() => {
+    if (!loading && pod && messages.length === 0) composerInputRef.current?.focus();
+  }, [loading, pod?._id, messages.length]);
 
   // Reaching the top loads the previous page; the edge line is the sentinel.
   useEffect(() => {
@@ -1086,6 +1098,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           onLoadOlder={() => { void handleLoadOlder(); }}
           edgeRef={edgeRef}
           jumpCount={jumpCount}
+          showJump={scrolledUp}
           onJump={jumpToLatest}
           loading={loading}
           error={error}
@@ -1130,12 +1143,8 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
                       <div className="v2-empty__text">{t('podChat.empty.agentDmText')}</div>
                     </>
                   ) : (
-                    <>
-                      <div className="v2-empty__title">{t('podChat.empty.quietTitle')}</div>
-                      <div className="v2-empty__text">
-                        {t('podChat.empty.quietText')}
-                      </div>
-                    </>
+                    // Direction C: an empty pod is one mono line and a focused composer.
+                    <span className="v2-thread__empty-line">{t('podChat.empty.noMessages')}</span>
                   )}
                 </div>
           ) : undefined}
@@ -1247,6 +1256,14 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
                       if (selection) selectMention(selection);
                       return;
                     }
+                  }
+                  // Esc with no mention menu open un-aims the composer (the aim
+                  // chip's keyboard cancel); the draft itself is kept.
+                  if (event.key === 'Escape' && (replyTarget || threadTarget)) {
+                    event.preventDefault();
+                    setReplyTarget(null);
+                    setThreadTarget(null);
+                    return;
                   }
                   if (event.key === 'Enter' && !event.shiftKey) {
                     event.preventDefault();

--- a/frontend/src/v2/components/V2ThreadMessages.tsx
+++ b/frontend/src/v2/components/V2ThreadMessages.tsx
@@ -25,6 +25,12 @@ interface V2ThreadMessagesProps {
   hasMore: boolean;
   loadingOlder: boolean;
   onLoadOlder: () => void;
+  // Direction C history edge: the sentinel V2Thread observes to auto-load the
+  // previous page when the reader reaches the top.
+  edgeRef?: React.RefObject<HTMLDivElement | null>;
+  // Jump-to-latest pill: messages that arrived while the reader was scrolled up.
+  jumpCount?: number;
+  onJump?: () => void;
   loading: boolean;
   error: string | null;
   starterPanel?: React.ReactNode;
@@ -56,6 +62,9 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
   hasMore,
   loadingOlder,
   onLoadOlder,
+  edgeRef,
+  jumpCount = 0,
+  onJump,
   loading,
   error,
   starterPanel,
@@ -96,18 +105,17 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
 
   return (
     <div className="v2-chat__messages" ref={messagesContainerRef}>
-      {hasMore && (
-        <div className="v2-chat__older">
-          <button
-            type="button"
-            className="v2-chat__older-btn"
-            onClick={onLoadOlder}
-            disabled={loadingOlder}
-          >
-            {loadingOlder ? t('podChat.loadingOlder') : t('podChat.loadOlder')}
-          </button>
-        </div>
-      )}
+      {/* History edge: one mono line. Loads on scroll (observer in V2Thread);
+          the button form stays reachable by keyboard. */}
+      <div className="v2-thread__edge" ref={edgeRef} data-state={loadingOlder ? 'loading' : hasMore ? 'more' : messages.length > 0 ? 'beginning' : 'empty'}>
+        {loadingOlder ? (
+          <span className="v2-thread__edge-line" role="status">{t('podChat.history.loadingEarlier')}</span>
+        ) : hasMore ? (
+          <button type="button" className="v2-thread__edge-line" onClick={onLoadOlder}>{t('podChat.history.loadEarlier')}</button>
+        ) : messages.length > 0 ? (
+          <span className="v2-thread__edge-line">{t('podChat.history.beginning')}</span>
+        ) : null}
+      </div>
       {error && <div className="v2-chat__error">{error}</div>}
       {loading && messages.length === 0 && <div className="v2-empty"><span className="v2-spinner" /></div>}
       {starterPanel}
@@ -201,6 +209,14 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
         );
       })}
       <div ref={messagesEndRef} />
+      {onJump && jumpCount > 0 && (
+        <div className="v2-thread__jump-wrap">
+          <button type="button" className="v2-thread__jump" onClick={onJump}>
+            {t('podChat.history.jumpToLatest')}
+            <span className="v2-thread__jump-count">· {jumpCount}</span>
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/v2/components/V2ThreadMessages.tsx
+++ b/frontend/src/v2/components/V2ThreadMessages.tsx
@@ -30,6 +30,8 @@ interface V2ThreadMessagesProps {
   edgeRef?: React.RefObject<HTMLDivElement | null>;
   // Jump-to-latest pill: messages that arrived while the reader was scrolled up.
   jumpCount?: number;
+  // Mount the pill once the reader is a viewport up, even before arrivals.
+  showJump?: boolean;
   onJump?: () => void;
   loading: boolean;
   error: string | null;
@@ -64,6 +66,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
   onLoadOlder,
   edgeRef,
   jumpCount = 0,
+  showJump = false,
   onJump,
   loading,
   error,
@@ -209,11 +212,11 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
         );
       })}
       <div ref={messagesEndRef} />
-      {onJump && jumpCount > 0 && (
+      {onJump && (showJump || jumpCount > 0) && (
         <div className="v2-thread__jump-wrap">
           <button type="button" className="v2-thread__jump" onClick={onJump}>
             {t('podChat.history.jumpToLatest')}
-            <span className="v2-thread__jump-count">· {jumpCount}</span>
+            {jumpCount > 0 && <span className="v2-thread__jump-count">· {jumpCount}</span>}
           </button>
         </div>
       )}

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -10849,6 +10849,13 @@ body.modern-ui.v2-canvas {
 .v2-root .v2-composer__menu > button:hover,
 .v2-root .v2-composer__menu > button:focus-visible { background: var(--v2-surface-hover); outline: none; }
 
+.v2-thread__empty-line {
+  display: block;
+  padding: 12px 0;
+  color: var(--v2-text-muted);
+  font: 400 11px/16px var(--v2-font-mono);
+}
+
 .v2-composer__tag {
   display: inline-flex;
   flex: 0 0 auto;
@@ -10861,6 +10868,7 @@ body.modern-ui.v2-canvas {
   background: var(--v2-accent-soft, #e8ecfb);
   color: var(--v2-accent-text);
   font: 500 11px/16px var(--v2-font-mono);
+  text-transform: lowercase;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -10880,6 +10888,8 @@ body.modern-ui.v2-canvas {
 .v2-composer__field { position: relative; min-width: 0; flex: 1; }
 
 .v2-composer__file { display: none; }
+
+.v2-root .v2-composer__field > textarea::placeholder { color: var(--v2-text-placeholder); }
 
 /* The row carries the focus state on its border; the field itself draws none. */
 .v2-root .v2-composer__field > textarea:focus,
@@ -11130,13 +11140,14 @@ body.modern-ui.v2-canvas {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
+  height: 28px;
+  padding: 0 12px;
   transform: translateX(-50%);
-  border: 1px solid var(--v2-border);
-  border-radius: 999px;
+  border: 1px solid #dde0e6;
+  border-radius: 14px;
   background: var(--v2-surface);
   color: var(--v2-text-primary);
-  font: 500 12px/16px var(--v2-font);
+  font: 600 13px/26px var(--v2-font);
   white-space: nowrap;
 }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -10238,101 +10238,6 @@ body.modern-ui.v2-canvas {
 
 .v2-message-row--decision { padding: 8px 0; }
 
-.v2-composer {
-  flex: 0 0 auto;
-  margin: 10px 14px 14px;
-  border: 1px solid var(--v2-border);
-  border-radius: 6px;
-  background: var(--v2-surface);
-}
-
-.v2-composer__target {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 7px 10px;
-  border-bottom: 1px solid var(--v2-border-soft);
-  color: var(--v2-text-secondary);
-  font: 400 12px/16px var(--v2-font);
-}
-
-.v2-root button.v2-composer__target button {
-  min-width: 24px;
-  min-height: 24px;
-  padding: 0;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--v2-text-muted);
-  font-size: 18px;
-  line-height: 1;
-}
-
-.v2-composer__field { position: relative; }
-
-.v2-root .v2-composer__field > textarea {
-  display: block;
-  box-sizing: border-box;
-  width: 100%;
-  min-height: 68px;
-  padding: 10px 12px 6px;
-  resize: vertical;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  color: var(--v2-text-primary);
-  font: 400 14px/20px var(--v2-font);
-}
-
-.v2-composer__file { display: none; }
-
-.v2-composer__actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 38px;
-  padding: 6px 8px 6px 10px;
-  border-top: 1px solid var(--v2-border-soft);
-}
-
-.v2-root button.v2-composer__attach {
-  display: inline-grid;
-  width: 28px;
-  height: 28px;
-  place-items: center;
-  padding: 0;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--v2-text-secondary);
-}
-
-.v2-root button.v2-composer__attach:hover { background: var(--v2-surface-hover); color: var(--v2-text-primary); }
-
-.v2-composer__posts-as {
-  min-width: 0;
-  flex: 1;
-  overflow: hidden;
-  color: var(--v2-text-muted);
-  font: 500 11px/16px var(--v2-font-mono);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.v2-root button.v2-composer__send {
-  min-height: 28px;
-  padding: 4px 12px;
-  border: 1px solid var(--v2-ink);
-  border-radius: 4px;
-  background: var(--v2-ink);
-  color: var(--v2-on-ink);
-  font: 600 12px/18px var(--v2-font);
-}
-
-.v2-root button.v2-composer__send:hover:not(:disabled) { background: var(--v2-ink-hover); }
-.v2-root button.v2-composer__send:disabled { cursor: not-allowed; opacity: 0.45; }
-
 .v2-composer__error {
   margin: 0;
   padding: 0 10px 8px;
@@ -10372,30 +10277,6 @@ body.modern-ui.v2-canvas {
   .v2-decision-card__option { width: 100%; }
   .v2-root button.v2-decision-card__choice { width: 100%; min-height: 44px; font-size: 15px; }
   .v2-root button.v2-decision-card__other { align-self: center; min-height: 30px; }
-
-  .v2-composer { margin: 8px 16px 62px; border: 0; background: transparent; }
-  .v2-composer__field { display: flex; align-items: stretch; gap: 12px; }
-  .v2-root .v2-composer__field > textarea {
-    min-height: 44px;
-    height: 44px;
-    flex: 1;
-    padding: 11px 12px;
-    resize: none;
-    border: 1px solid var(--v2-border);
-    border-radius: 4px;
-    background: var(--v2-surface);
-    line-height: 20px;
-  }
-  .v2-composer__actions { min-height: 0; padding: 0; border: 0; }
-  .v2-root button.v2-composer__attach,
-  .v2-composer__posts-as { display: none; }
-  .v2-root button.v2-composer__send {
-    width: 44px;
-    min-height: 44px;
-    padding: 0;
-    border-radius: 4px;
-    font-size: 11px;
-  }
 
   /* The workspace is edge-to-edge on a phone. Rail and pod list are drawers,
      while the transcript, composer, and tab bar share the white canvas. */
@@ -10892,4 +10773,380 @@ body.modern-ui.v2-canvas {
   }
 
   .v2-root button.v2-mobile-tabs__item--active .v2-mobile-tabs__label { font-weight: 700; }
+}
+
+/* ---------- Workspace at scale · direction C · PR 2a (composer, attachments, history) ----------
+   One-line composer with a plus menu, Send only with text, no identity line;
+   images as 156×104 thumbnails with a lightbox, files as chips with a text type
+   badge, code past six lines collapsed; older messages load on scroll with a
+   mono edge line and a Jump-to-latest pill. */
+
+.v2-composer {
+  flex: 0 0 auto;
+  margin: 0 16px 14px;
+  border: 1px solid var(--v2-border);
+  border-radius: 6px;
+  background: var(--v2-surface);
+}
+
+.v2-composer--typing,
+.v2-composer:focus-within { border-color: var(--v2-border-strong); }
+
+.v2-composer__row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  min-height: 42px;
+  padding: 7px 8px 7px 10px;
+}
+
+.v2-composer__plus-wrap { position: relative; flex: 0 0 auto; align-self: flex-end; padding-bottom: 2px; }
+
+.v2-root button.v2-composer__plus {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+}
+
+.v2-root button.v2-composer__plus::before { content: '+'; font: 500 16px/1 var(--v2-font); }
+.v2-root button.v2-composer__plus:hover:not(:disabled),
+.v2-root button.v2-composer__plus[aria-expanded="true"] { background: var(--v2-surface-hover); color: var(--v2-text-primary); }
+
+.v2-composer__menu {
+  position: absolute;
+  left: 0;
+  bottom: 32px;
+  z-index: 4;
+  display: flex;
+  min-width: 220px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px;
+  border: 1px solid var(--v2-border);
+  border-radius: 6px;
+  background: var(--v2-surface);
+}
+
+.v2-root .v2-composer__menu > button {
+  display: block;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--v2-text-primary);
+  font: 400 13px/18px var(--v2-font);
+  text-align: left;
+}
+
+.v2-root .v2-composer__menu > button:hover,
+.v2-root .v2-composer__menu > button:focus-visible { background: var(--v2-surface-hover); outline: none; }
+
+.v2-composer__tag {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  max-width: 220px;
+  padding: 2px 4px 2px 6px;
+  margin-bottom: 4px;
+  border-radius: 3px;
+  background: var(--v2-accent-soft, #e8ecfb);
+  color: var(--v2-accent-text);
+  font: 500 11px/16px var(--v2-font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v2-root button.v2-composer__tag-cancel {
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.v2-composer__field { position: relative; min-width: 0; flex: 1; }
+
+.v2-composer__file { display: none; }
+
+/* The row carries the focus state on its border; the field itself draws none. */
+.v2-root .v2-composer__field > textarea:focus,
+.v2-root .v2-composer__field > textarea:focus-visible {
+  outline: none;
+  box-shadow: none;
+  border: 0;
+}
+
+.v2-root .v2-composer__field > textarea {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 32px;
+  max-height: 112px;
+  padding: 6px 4px;
+  resize: none;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--v2-text-primary);
+  font: 400 14px/20px var(--v2-font);
+}
+
+.v2-composer__uploading {
+  flex: 0 0 auto;
+  align-self: center;
+  color: var(--v2-text-muted);
+  font: 400 11px/16px var(--v2-font-mono);
+}
+
+.v2-root button.v2-composer__send {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  place-items: center;
+  padding: 0;
+  margin-bottom: 0;
+  border: 1px solid var(--v2-ink);
+  border-radius: 4px;
+  background: var(--v2-ink);
+  color: var(--v2-on-ink);
+  font: 500 14px/1 var(--v2-font-mono);
+}
+
+.v2-root button.v2-composer__send:hover:not(:disabled) { background: var(--v2-ink-hover); }
+.v2-root button.v2-composer__send:disabled { cursor: progress; opacity: 0.6; }
+
+.v2-composer__error,
+.v2-composer__warnings { padding: 0 10px 8px; }
+
+/* Attachments */
+.v2-msg__thumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.v2-root button.v2-msg__thumb {
+  display: block;
+  width: 156px;
+  height: 104px;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: 4px;
+  background: var(--v2-surface-tint);
+  position: relative;
+}
+
+.v2-root button.v2-msg__thumb:hover { border-color: var(--v2-border-strong); }
+
+.v2-msg__thumb img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.v2-msg__thumb-name {
+  position: absolute;
+  left: 6px;
+  bottom: 6px;
+  max-width: calc(100% - 12px);
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font: 500 11px/14px var(--v2-font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v2-msg__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.v2-root button.v2-msg__chip,
+.v2-msg__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  min-height: 30px;
+  padding: 5px 8px;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: 400 12.5px/18px var(--v2-font);
+  text-align: left;
+}
+
+.v2-root button.v2-msg__chip:hover { background: var(--v2-surface-hover); }
+
+.v2-msg__chip-ext {
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--v2-surface-tint);
+  color: var(--v2-text-secondary);
+  font: 500 11px/14px var(--v2-font-mono);
+  text-transform: uppercase;
+}
+
+.v2-msg__chip-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2-msg__chip-size {
+  flex: 0 0 auto;
+  color: var(--v2-text-muted);
+  font: 400 11px/16px var(--v2-font-mono);
+}
+
+/* Long code collapses after six lines; expands in place. */
+.v2-msg__collapse { position: relative; }
+.v2-msg__collapse--closed pre { max-height: calc(6 * 1.5 * 12.5px + 20px); overflow: hidden; }
+
+.v2-root button.v2-msg__more {
+  display: inline-block;
+  margin: 2px 0 6px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--v2-accent-text);
+  font: 500 12.5px/18px var(--v2-font);
+}
+
+.v2-root button.v2-msg__more:hover { text-decoration: underline; }
+
+/* Lightbox */
+.v2-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: grid;
+  place-items: center;
+  background: rgba(16, 24, 40, 0.9);
+  cursor: zoom-out;
+}
+
+.v2-lightbox__image {
+  max-width: min(92vw, 1400px);
+  max-height: 88vh;
+  object-fit: contain;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.v2-lightbox__name {
+  position: absolute;
+  top: 14px;
+  left: 16px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font: 500 11px/16px var(--v2-font-mono);
+}
+
+.v2-root button.v2-lightbox__close,
+.v2-root button.v2-lightbox__nav {
+  position: absolute;
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: 500 16px/1 var(--v2-font);
+  cursor: pointer;
+}
+
+.v2-root button.v2-lightbox__close { top: 12px; right: 12px; }
+.v2-root button.v2-lightbox__nav--prev { left: 12px; top: 50%; transform: translateY(-50%); }
+.v2-root button.v2-lightbox__nav--next { right: 12px; top: 50%; transform: translateY(-50%); }
+
+/* History edge + jump pill */
+.v2-thread__edge {
+  display: flex;
+  justify-content: center;
+  padding: 6px 0 10px;
+}
+
+.v2-thread__edge-line {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--v2-text-muted);
+  font: 400 11px/16px var(--v2-font-mono);
+}
+
+.v2-root button.v2-thread__edge-line {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--v2-text-muted);
+  font: 400 11px/16px var(--v2-font-mono);
+}
+
+.v2-root button.v2-thread__edge-line { cursor: pointer; }
+.v2-root button.v2-thread__edge-line:hover { color: var(--v2-text-primary); }
+
+.v2-thread__jump-wrap {
+  position: relative;
+  height: 0;
+  overflow: visible;
+}
+
+.v2-root button.v2-thread__jump {
+  position: absolute;
+  left: 50%;
+  bottom: 12px;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  transform: translateX(-50%);
+  border: 1px solid var(--v2-border);
+  border-radius: 999px;
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: 500 12px/16px var(--v2-font);
+  white-space: nowrap;
+}
+
+.v2-root button.v2-thread__jump:hover { background: var(--v2-surface-hover); }
+.v2-thread__jump-count { color: var(--v2-accent-text); font: 700 11px/16px var(--v2-font-mono); }
+
+@media (max-width: 760px) {
+  /* Sits above the 56px tab bar; the row itself keeps its desktop shape. */
+  .v2-composer { margin: 0 12px 64px; }
+  .v2-composer__menu { min-width: 200px; }
+  .v2-root button.v2-msg__thumb { width: calc(50% - 3px); height: 84px; }
+  .v2-composer__tag { max-width: 120px; }
 }

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -11126,23 +11126,27 @@ body.modern-ui.v2-canvas {
 .v2-root button.v2-thread__edge-line { cursor: pointer; }
 .v2-root button.v2-thread__edge-line:hover { color: var(--v2-text-primary); }
 
+/* The wrap is the scroller's last child and STICKS to its bottom edge: a
+   0-height wrap with an absolute pill resolved `bottom: 12px` against a box
+   at the end of the transcript, ~1100px below the viewport when the pill
+   mounts a viewport up (ux-lead gate on #1579). Sticky needs real height. */
 .v2-thread__jump-wrap {
-  position: relative;
-  height: 0;
-  overflow: visible;
+  position: sticky;
+  bottom: 12px;
+  z-index: 3;
+  display: flex;
+  justify-content: center;
+  height: 28px;
+  pointer-events: none;
 }
 
 .v2-root button.v2-thread__jump {
-  position: absolute;
-  left: 50%;
-  bottom: 12px;
-  z-index: 3;
   display: inline-flex;
   align-items: center;
   gap: 8px;
   height: 28px;
   padding: 0 12px;
-  transform: translateX(-50%);
+  pointer-events: auto;
   border: 1px solid #dde0e6;
   border-radius: 14px;
   background: var(--v2-surface);


### PR DESCRIPTION
## Direction C · PR 2a of 5 — composer, attachments, collapse, scroll-to-load

Spec: canvas page 5 (Workspace clickable + Thread states) + walk-1 rulings (Sharpen 64326) + Sam's two mid-build asks (older messages load on scroll; attachments for UX and AX). PR 2b (threading restyle: action strip, quoted replies, agent runtime tag, reactions chips) follows separately so this stays reviewable.

### What changed
- **Composer** (`V2Composer`): one 42px row — a 24px r4 `+` opening a three-row menu (Attach file · Attach image · Paste image from clipboard, `role=menu`), a field that starts at one line and grows to five (112px) then scrolls, and a 28px ink `↵` Send that exists only when there is text. The `posts as … · ⌘↵` line is gone (ruling d); identity and shortcut live in Send's tooltip (`Send as lily · Enter`). Reply / thread targets are an inline tag in the row. Enter sends, Shift+Enter newlines (unchanged). Pasting an image into the field attaches it.
- **One attachment model** (`V2Thread`): an uploaded image now goes out as the same `[[upload:<key>|<name>|<size>|image]]` manifest a file does, so the row renders a thumbnail and an agent reads it through the attachment tool — the bare-URL image send remains only for a server that returns no file key. The agent path (`[[upload:]]` + read on demand) is unchanged.
- **Attachments** (`V2MessageRow`, `V2Lightbox`): images render as 156×104 thumbnails in one gallery row (filename chip, signed-URL bridge, lazy), click → lightbox (ink 90%, filename · n/N, ×, ←/→ across the message's images, Esc); non-image uploads are chips with a text type badge on tint, name and size — the per-type colour palette is deleted; legacy bare-URL image messages become thumbnails too. Fenced code past six lines collapses with `Show N more lines` / `Show less`.
- **History** (`V2ThreadMessages`, `V2Thread`): the top of the thread is a mono edge line — `load earlier` (keyboard fallback, auto-loads via IntersectionObserver when the reader reaches it), `loading earlier…`, `beginning of the pod`, or nothing for an empty pod — the position is held across the prepend; new messages pull the view down only when the reader was at the bottom (or it is their own message), otherwise a `Jump to latest · N` pill counts them.
- CSS: the pre-C composer rules (target row, actions row, attach icon, posts-as, 44px phone field) and the file-pill colours are retired; 15 i18n keys in en + zh-CN.

### Not in this PR
Threading restyle (PR 2b); `after` cursor + `(created_at, id)` tiebreak (kernel row k4 — until it lands, "open a message from Activity" pages back with `before` as today); Other… on decision cards (already present in `V2DecisionCard`, verified in the smoke as PR 3's surface).

### Proof
- `tsc --noEmit` clean; eslint 0 errors on the touched files.
- Tests: `V2ComposerMenu` (row shape, Send-on-text + tooltip, three-row menu with accept switching and clipboard, inline tag, uploading status), `V2MessageRowAttachments` (thumbnails + lightbox with arrows and Esc, chips with text badge and open handler, legacy image → thumbnail, collapse at 6 lines), `V2ThreadHistory` (edge states, no dead button, jump pill), plus the existing `V2Composer`, `V2ComposerSurface`, `V2MessageRow`, `V2MessageRowQuote`, `V2ThreadDeliveryHint` and `v2-layout-invariants` (composer/attachments/history guards) — 142 tests.
- Real-browser walk of the built bundle against the live API (local proxy), posting only into my private pod: composer 48px at rest, `+` 24×24 r4, menu `Attach file · Attach image · Paste image from clipboard`, Send 28×28 appears with text, field 112px at 8 lines with `overflowY: auto`; image upload → thumbnail 156×104 → lightbox opens and Esc closes, images load (naturalWidth 1440); `.md` upload → chip `MD walk-note.md 12 B` with a tint badge, zero colour icons; 12-line code → `Show 6 more lines`; Sharpen: scrolling to the top loaded the previous page (42 → 79 rows) with the position held (scrollTop 6641, not 0) and the edge still `more`; 390: composer 48px sitting above the tab bar, thumbnails half-width.

### Gates
@sprint-review code; @ux-lead walk against the Workspace and Thread states boards at 1440 and 390. Presses only on both + green; branch kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX
