### PR TITLE
fix(v2): close #1582 UX follow-ups

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -511,7 +511,10 @@
       "collapse": "Collapse",
       "replyOne": "reply",
       "replyOther": "replies",
-      "moreReplies": "{{count}} more replies"
+      "moreReplies": "{{count}} more replies",
+      "follow": "Follow",
+      "following": "Following",
+      "muted": "Muted"
     },
     "leadBadge": "Lead",
     "catchup": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -506,7 +506,12 @@
       "startThread": "Thread",
       "replyInThread": "Reply in thread",
       "replyFromExpandedThread": "Reply from expanded thread",
-      "replyingInThread": "Replying in thread ·"
+      "replyingInThread": "Replying in thread ·",
+      "last": "last",
+      "collapse": "Collapse",
+      "replyOne": "reply",
+      "replyOther": "replies",
+      "moreReplies": "{{count}} more replies"
     },
     "leadBadge": "Lead",
     "catchup": {
@@ -537,6 +542,19 @@
       "loadEarlier": "load earlier",
       "beginning": "beginning of the pod",
       "jumpToLatest": "Jump to latest"
+    },
+    "strip": {
+      "label": "Message actions",
+      "react": "Add reaction",
+      "more": "More",
+      "copyLink": "Copy link",
+      "copyText": "Copy text"
+    },
+    "quote": {
+      "earlier": "earlier message"
+    },
+    "reactions": {
+      "more": "{{count}} more reactions"
     }
   },
   "landing": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -510,7 +510,10 @@
       "collapse": "收起",
       "replyOne": "条回复",
       "replyOther": "条回复",
-      "moreReplies": "还有 {{count}} 条回复"
+      "moreReplies": "还有 {{count}} 条回复",
+      "follow": "关注",
+      "following": "已关注",
+      "muted": "已静音"
     },
     "leadBadge": "负责人",
     "catchup": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -505,7 +505,12 @@
       "startThread": "话题",
       "replyInThread": "在话题中回复",
       "replyFromExpandedThread": "在已展开的话题中回复",
-      "replyingInThread": "正在话题中回复："
+      "replyingInThread": "正在话题中回复：",
+      "last": "最近",
+      "collapse": "收起",
+      "replyOne": "条回复",
+      "replyOther": "条回复",
+      "moreReplies": "还有 {{count}} 条回复"
     },
     "leadBadge": "负责人",
     "catchup": {
@@ -536,6 +541,19 @@
       "loadEarlier": "加载更早的消息",
       "beginning": "Pod 的开始",
       "jumpToLatest": "跳到最新"
+    },
+    "strip": {
+      "label": "消息操作",
+      "react": "添加表情回应",
+      "more": "更多",
+      "copyLink": "复制链接",
+      "copyText": "复制文本"
+    },
+    "quote": {
+      "earlier": "更早的消息"
+    },
+    "reactions": {
+      "more": "还有 {{count}} 个回应"
     }
   },
   "landing": {

--- a/frontend/src/v2/__tests__/V2Composer.test.tsx
+++ b/frontend/src/v2/__tests__/V2Composer.test.tsx
@@ -198,7 +198,19 @@ describe('V2Composer send button', () => {
     },
   ]);
 
-  const replyFromExpandedThread = () => screen.getByRole('button', { name: /reply from expanded thread/i });
+  // Threads rest as a chip (ux-lead 64476); Reply in thread lives in the
+  // open band's foot, so every path through it opens the thread first.
+  // The reply row (m2) lives inside the thread, which rests as a chip: open
+  // it before reaching for a button on that row.
+  const openThread = () => {
+    const chip = screen.queryByRole('button', { name: /expand thread/i });
+    if (chip) fireEvent.click(chip);
+  };
+  const replyFromExpandedThread = () => {
+    const chip = screen.queryByRole('button', { name: /expand thread/i });
+    if (chip) fireEvent.click(chip);
+    return screen.getByRole('button', { name: /reply from expanded thread/i });
+  };
 
   test('"Reply in thread" from the expanded rail sends threadRootId and no reply edge', async () => {
     const detail = makeDetail({ messages: threadMessages() });
@@ -221,7 +233,7 @@ describe('V2Composer send button', () => {
 
     // Reply-to-person first, then "Reply in thread": the thread wins, the
     // reply edge is gone.
-    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    openThread(); fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
     fireEvent.click(replyFromExpandedThread());
     fireEvent.change(composerInput(), {
       target: { value: 'thread wins' },
@@ -234,7 +246,7 @@ describe('V2Composer send button', () => {
     // The other order: thread first, then reply-to-person. The reply edge
     // wins, the thread root is gone.
     fireEvent.click(replyFromExpandedThread());
-    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    openThread(); fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
     fireEvent.change(composerInput(), {
       target: { value: 'reply wins' },
     });
@@ -247,7 +259,7 @@ describe('V2Composer send button', () => {
   test('Escape in the field un-aims (reply or thread) and keeps the draft; the send goes out plain', async () => {
     const detail = makeDetail({ messages: threadMessages() });
     renderChat(detail);
-    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    openThread(); fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
     expect(document.activeElement).toBe(composerInput());
     fireEvent.change(composerInput(), { target: { value: 'kept draft' } });
     fireEvent.keyDown(composerInput(), { key: 'Escape' });
@@ -325,7 +337,7 @@ describe('V2Composer send button', () => {
     const detail = makeDetail({ messages: threadMessages() });
     const { container } = renderChat(detail);
 
-    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    openThread(); fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
     upload(container);
 
     await waitFor(() => {
@@ -379,7 +391,7 @@ describe('V2Composer send button', () => {
     const detail = makeDetail({ messages: threadMessages() });
     renderChat(detail);
 
-    fireEvent.click(screen.getByRole('button', { name: /thread from other/i }));
+    openThread(); fireEvent.click(screen.getByRole('button', { name: /thread from other/i }));
     fireEvent.change(composerInput(), {
       target: { value: 'Still in the first thread.' },
     });
@@ -390,11 +402,13 @@ describe('V2Composer send button', () => {
     });
   });
 
-  test('the headline card aims the same root without requiring an expand', async () => {
+  test('the chip opens the thread and the foot aims the same root', async () => {
     const detail = makeDetail({ messages: threadMessages() });
     renderChat(detail);
 
-    fireEvent.click(screen.getByRole('button', { name: /^reply in thread$/i }));
+    expect(screen.queryByRole('button', { name: /^reply in thread$/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /expand thread/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reply from expanded thread/i }));
     fireEvent.change(composerInput(), {
       target: { value: 'Joining through the card.' },
     });
@@ -409,7 +423,7 @@ describe('V2Composer send button', () => {
     const detail = makeDetail({ messages: threadMessages() });
     renderChat(detail);
 
-    fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
+    openThread(); fireEvent.click(screen.getByRole('button', { name: /reply to other/i }));
     fireEvent.change(composerInput(), {
       target: { value: 'Replying to a person.' },
     });

--- a/frontend/src/v2/__tests__/V2ThreadCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadCard.test.tsx
@@ -1,8 +1,6 @@
-// The thread headline card (W-T 4/4) against @ux-lead's render brief.
-//
-// Checklist items 1 and 5 are asserted here; the geometry half of item 2 is a
-// real-browser check, because jsdom has no layout engine and a rail offset
-// asserted in jsdom would be a test of my own CSS string.
+// The thread chip (direction C, ux-lead 64476 (3)): faces + count + last —
+// and nothing else. Reply in thread and Follow live in the expanded band's
+// foot (V2ThreadRestyle.test), the chevron is gone.
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import V2ThreadCard from '../components/V2ThreadCard';
@@ -18,29 +16,25 @@ const people = [
 
 const setup = (over: Partial<React.ComponentProps<typeof V2ThreadCard>> = {}) => {
   const onToggleCollapsed = jest.fn();
-  const onToggleFollowing = jest.fn();
-  const onReplyInThread = over.onReplyInThread || jest.fn();
   const utils = render(
     <V2ThreadCard
       replyCount={3}
       participants={people.slice(0, 2)}
       lastActivityAt={new Date(NOW.getTime() - 2 * 60000).toISOString()}
       collapsed
-      following={null}
       onToggleCollapsed={onToggleCollapsed}
-      onToggleFollowing={onToggleFollowing}
-      onReplyInThread={onReplyInThread}
       now={NOW}
       {...over}
     />,
   );
-  return { ...utils, onToggleCollapsed, onToggleFollowing, onReplyInThread };
+  return { ...utils, onToggleCollapsed };
 };
 
-describe('content is a count, faces and a time — and nothing else', () => {
-  test('renders the count, pluralised', () => {
+describe('content is faces, a count and a time — and nothing else', () => {
+  test('renders the count, pluralised, and the `· last` stamp', () => {
     setup();
     expect(screen.getByText('3 replies')).toBeInTheDocument();
+    expect(screen.getByText(/^· last 2m$/)).toBeInTheDocument();
   });
 
   test('one reply is singular', () => {
@@ -48,27 +42,27 @@ describe('content is a count, faces and a time — and nothing else', () => {
     expect(screen.getByText('1 reply')).toBeInTheDocument();
   });
 
-  test('the short activity stamp is shown', () => {
-    setup();
-    expect(screen.getByText(/2m$/)).toBeInTheDocument();
-  });
-
-  test('at most three avatars, however many participants', () => {
+  test('at most three faces, flat two-tone, however many participants', () => {
     const { container } = setup({ participants: people });
-    expect(container.querySelectorAll('.v2-thread-card__faces .v2-avatar')).toHaveLength(3);
+    const faces = container.querySelectorAll('.v2-thread-card__faces .v2-avatar');
+    expect(faces).toHaveLength(3);
+    expect(faces[0]).toHaveClass('v2-avatar--flat-human');
+    expect(faces[2]).toHaveClass('v2-avatar--flat-agent');
   });
 
-  test('no reply bodies and no participant names leak into the card', () => {
-    // The brief is explicit: the card is a door, not a preview. Names are the
-    // easy thing to add later "for context" and the reason it is written down.
-    setup({ participants: people });
+  test('no reply bodies, no names, no chevron, no reply or follow controls', () => {
+    const { container } = setup({ participants: people });
     expect(screen.queryByText('Ada')).not.toBeInTheDocument();
     expect(screen.queryByText('Grace')).not.toBeInTheDocument();
+    expect(container.querySelector('.v2-thread-card__chevron')).toBeNull();
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: /reply in thread/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /follow/i })).not.toBeInTheDocument();
   });
 });
 
 describe('accent is reserved for being addressed', () => {
-  test('a resting card carries no accent modifier', () => {
+  test('a resting chip carries no accent modifier', () => {
     const { container } = setup();
     expect(container.querySelector('.v2-thread-card--addressed')).toBeNull();
     expect(container.querySelector('.v2-thread-card__dot')).toBeNull();
@@ -81,78 +75,13 @@ describe('accent is reserved for being addressed', () => {
   });
 });
 
-describe('collapse is driven by the prop and reported to the caller', () => {
-  test('collapsed hides the chevron and reads as not expanded', () => {
-    const { container } = setup({ collapsed: true });
-    expect(container.querySelector('.v2-thread-card__chevron')).toBeNull();
-    expect(screen.getByRole('button', { name: /Expand thread/ })).toHaveAttribute('aria-expanded', 'false');
-  });
-
-  test('expanded shows the chevron and says so', () => {
-    const { container } = setup({ collapsed: false });
-    expect(container.querySelector('.v2-thread-card__chevron')).not.toBeNull();
-    expect(screen.getByRole('button', { name: /Collapse thread/ })).toHaveAttribute('aria-expanded', 'true');
-  });
-
-  test('clicking asks the caller to toggle — the card holds no state', () => {
-    // If the card owned `collapsed` it would drift from the server value the
-    // moment a write failed, and the persistence in constraint 2 would be a
-    // local illusion.
+describe('the chip is a door', () => {
+  test('its accessible name carries the state and a click asks the caller to open', () => {
     const { onToggleCollapsed } = setup();
-    fireEvent.click(screen.getByRole('button', { name: /Expand thread/ }));
+    const chip = screen.getByRole('button', { name: 'Expand thread, 3 replies' });
+    expect(chip).toHaveAttribute('aria-expanded', 'false');
+    expect(chip).toHaveClass('v2-msg__thread-chip');
+    fireEvent.click(chip);
     expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
-  });
-
-  test('Reply in thread is a sibling action that does not need an expand', () => {
-    const { container, onReplyInThread, onToggleCollapsed } = setup({ collapsed: true });
-    const main = container.querySelector('.v2-thread-card__main');
-    const reply = screen.getByRole('button', { name: /^reply in thread$/i });
-
-    expect(main?.contains(reply)).toBe(false);
-    fireEvent.click(reply);
-    expect(onReplyInThread).toHaveBeenCalledTimes(1);
-    expect(onToggleCollapsed).not.toHaveBeenCalled();
-  });
-});
-
-describe('the follow toggle renders three states from the raw value', () => {
-  test('null reads Follow — an invitation, not a state', () => {
-    setup({ collapsed: false, following: null });
-    expect(screen.getByRole('button', { name: 'Follow' })).toBeInTheDocument();
-  });
-
-  test('true reads Following and is pressed', () => {
-    setup({ collapsed: false, following: true });
-    expect(screen.getByRole('button', { name: 'Following' })).toHaveAttribute('aria-pressed', 'true');
-  });
-
-  test('false reads Muted, and is NOT the same rendering as null', () => {
-    // Boolean(null) is false, and false is a mute. The whole tri-state exists
-    // so these two do not collapse into one another.
-    setup({ collapsed: false, following: false });
-    const muted = screen.getByRole('button', { name: 'Muted' });
-    expect(muted).toHaveAttribute('aria-pressed', 'false');
-    expect(screen.queryByRole('button', { name: 'Follow' })).not.toBeInTheDocument();
-  });
-
-  test('the toggle is absent while collapsed, per the brief', () => {
-    setup({ collapsed: true, following: true });
-    expect(screen.queryByRole('button', { name: 'Following' })).not.toBeInTheDocument();
-  });
-
-  test('follow is a sibling of the expand control, not nested inside it', () => {
-    // A button inside a button is invalid HTML and, here, a mis-hit that
-    // silently mutes a thread — the expensive direction.
-    const { container } = setup({ collapsed: false });
-    const main = container.querySelector('.v2-thread-card__main');
-    expect(main?.querySelector('.v2-thread-card__follow')).toBeNull();
-    expect(container.querySelector('.v2-thread-card__follow')).not.toBeNull();
-  });
-
-  test('clicking follow does not also toggle collapse', () => {
-    const { onToggleCollapsed, onToggleFollowing } = setup({ collapsed: false });
-    fireEvent.click(screen.getByRole('button', { name: 'Follow' }));
-    expect(onToggleFollowing).toHaveBeenCalledTimes(1);
-    expect(onToggleCollapsed).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/v2/__tests__/V2ThreadCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadCard.test.tsx
@@ -50,7 +50,7 @@ describe('content is a count, faces and a time — and nothing else', () => {
 
   test('the short activity stamp is shown', () => {
     setup();
-    expect(screen.getByText('2m')).toBeInTheDocument();
+    expect(screen.getByText(/2m$/)).toBeInTheDocument();
   });
 
   test('at most three avatars, however many participants', () => {

--- a/frontend/src/v2/__tests__/V2ThreadRestyle.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadRestyle.test.tsx
@@ -110,21 +110,23 @@ describe('direction C threading restyle (PR 2b)', () => {
     expect(within(strip).getAllByRole('menuitem').map((m) => m.textContent)).toEqual(['Copy link', 'Copy text']);
   });
 
-  test('an expanded thread is one band with the newest eight, a more line, and a Collapse foot', () => {
+  const renderThread = (props = {}) => {
     const root = msg(20);
     const replies = Array.from({ length: 11 }, (_, i) => msg(21 + i, { thread_root_id: '20' }));
-    const toggleCollapsed = jest.fn();
-    const { container } = render(
+    const setCollapsed = jest.fn();
+    const toggleFollowing = jest.fn();
+    const utils = render(
       <MemoryRouter>
         <V2ThreadMessages
           messages={[root, ...replies]}
           threadView={[{ kind: 'message', message: root }, { kind: 'card', rootId: '20', replyCount: 11, participants: [], lastActivityAt: null, replies }]}
-          threadState={{ byRoot: new Map([['20', { collapsed: false, following: null }]]), toggleCollapsed, toggleFollowing: jest.fn() }}
+          threadState={{ byRoot: new Map([['20', { collapsed: false, following: null }]]), toggleCollapsed: jest.fn(), setCollapsed, toggleFollowing }}
           decisionByMessageId={new Map()}
           settledDecisionByMessageId={new Map()}
           agentDisplayNames={new Map()}
           agentAuthorKeys={new Set()}
           onAimAtThread={jest.fn()}
+          onReply={jest.fn()}
           hasMore={false}
           loadingOlder={false}
           onLoadOlder={jest.fn()}
@@ -132,17 +134,94 @@ describe('direction C threading restyle (PR 2b)', () => {
           error={null}
           messagesContainerRef={React.createRef()}
           messagesEndRef={React.createRef()}
+          {...props}
         />
       </MemoryRouter>,
     );
+    return { ...utils, setCollapsed, toggleFollowing };
+  };
+
+  test('a thread rests as a chip under its root even when the server row says open; the chip opens it and the server is told', () => {
+    const { container, setCollapsed } = renderThread();
+    const block = container.querySelector('.v2-thread-block');
+    expect(block).not.toHaveClass('v2-thread-block--open');
+    // The root renders INSIDE the block — one surface once it opens.
+    expect(block.querySelector('#message-20')).toBeTruthy();
+    expect(container.querySelectorAll('.v2-chat__messages > #message-20')).toHaveLength(0);
+    expect(within(block).getByRole('button', { name: 'Expand thread, 11 replies' })).toBeInTheDocument();
+    expect(block.querySelector('.v2-thread-replies')).toBeNull();
+    fireEvent.click(within(block).getByRole('button', { name: 'Expand thread, 11 replies' }));
+    expect(block).toHaveClass('v2-thread-block--open');
+    expect(setCollapsed).toHaveBeenCalledWith('20', false);
+    expect(within(block).queryByRole('button', { name: /Expand thread/ })).not.toBeInTheDocument();
+  });
+
+  test('open: one band with the root, the newest eight, a more line, and a foot with Collapse · count · Reply in thread · Follow', () => {
+    const { container, setCollapsed, toggleFollowing } = renderThread();
+    fireEvent.click(screen.getByRole('button', { name: 'Expand thread, 11 replies' }));
     const block = container.querySelector('.v2-thread-block--open');
-    expect(block).toBeTruthy();
+    expect(block.querySelector('#message-20')).toBeTruthy();
     expect(block.querySelectorAll('.v2-thread-replies .v2-msg')).toHaveLength(8);
     fireEvent.click(within(block).getByRole('button', { name: '3 more replies' }));
     expect(block.querySelectorAll('.v2-thread-replies .v2-msg')).toHaveLength(11);
     const foot = block.querySelector('.v2-thread-replies__foot');
     expect(foot).toHaveTextContent('11 replies');
+    expect(within(foot).getByRole('button', { name: /reply from expanded thread/i })).toBeInTheDocument();
+    const follow = within(foot).getByRole('button', { name: 'Follow' });
+    expect(follow).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(follow);
+    expect(toggleFollowing).toHaveBeenCalledWith('20');
     fireEvent.click(within(foot).getByRole('button', { name: 'Collapse' }));
-    expect(toggleCollapsed).toHaveBeenCalledWith('20');
+    expect(setCollapsed).toHaveBeenLastCalledWith('20', true);
+    expect(container.querySelector('.v2-thread-block--open')).toBeNull();
+  });
+
+  test('landing on a reply folded behind the chip reveals the whole thread instead of fetching history', () => {
+    const onRevealed = jest.fn();
+    const { container, rerender } = renderThread({ revealMessageId: '22', onRevealed });
+    expect(onRevealed).toHaveBeenCalledWith('22', true);
+    const block = container.querySelector('.v2-thread-block--open');
+    expect(block).toBeTruthy();
+    // 22 is the second-oldest reply — outside the newest-eight window, so the fold must be gone too.
+    expect(block.querySelector('#message-22')).toBeTruthy();
+    expect(block.querySelectorAll('.v2-thread-replies .v2-msg')).toHaveLength(11);
+    onRevealed.mockClear();
+    renderThread({ revealMessageId: '999', onRevealed });
+    expect(onRevealed).toHaveBeenCalledWith('999', false);
+  });
+
+  test('the strip keeps react as its first icon, disabled, when the row cannot take a reaction', () => {
+    render(
+      <V2MessageActions
+        message={msg(6)}
+        author="Vera"
+        onReply={jest.fn()}
+        onThread={jest.fn()}
+        canInteract={false}
+        pickerOpen={false}
+        reactions={[]}
+        onTogglePicker={jest.fn()}
+        onToggleReaction={jest.fn()}
+      />,
+    );
+    const strip = screen.getByRole('toolbar', { name: 'Message actions' });
+    const buttons = within(strip).getAllByRole('button');
+    expect(buttons.map((b) => b.getAttribute('aria-label'))).toEqual(['Add reaction', 'Reply to Vera', 'Thread from Vera', 'More']);
+    expect(buttons[0]).toBeDisabled();
+  });
+
+  test('transcript avatars are flat two-tone squares: agent cobalt, human tint, no illustration', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <V2MessageRow message={msg(30, { user: { username: 'sprint-impl', isBot: true } })} />
+        <V2MessageRow message={msg(31, { user: { username: 'sam', isBot: false } })} />
+      </MemoryRouter>,
+    );
+    const agent = container.querySelector('#message-30 .v2-avatar');
+    const human = container.querySelector('#message-31 .v2-avatar');
+    expect(agent).toHaveClass('v2-avatar--flat', 'v2-avatar--flat-agent');
+    expect(human).toHaveClass('v2-avatar--flat', 'v2-avatar--flat-human');
+    expect(agent.querySelector('img')).toBeNull();
+    expect(agent.textContent).toBe('SI');
   });
 });

--- a/frontend/src/v2/__tests__/V2ThreadRestyle.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadRestyle.test.tsx
@@ -1,0 +1,148 @@
+// @ts-nocheck
+import React from 'react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2MessageRow, { landOnMessage } from '../components/V2MessageRow';
+import V2MessageActions from '../components/V2MessageActions';
+import V2ThreadMessages from '../components/V2ThreadMessages';
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ currentUser: { username: 'viewer', _id: 'me' } }),
+}));
+jest.mock('../hooks/useV2Api', () => ({
+  useV2Api: () => ({ get: jest.fn(), post: jest.fn(), patch: jest.fn(), del: jest.fn() }),
+}));
+
+const msg = (id, extra = {}) => ({
+  id: String(id), pod_id: 'p', user_id: `u${id}`, content: `message ${id}`, created_at: '2026-09-06T09:00:00.000Z', user: { username: `author${id}` }, ...extra,
+});
+
+describe('direction C threading restyle (PR 2b)', () => {
+  test('an agent row carries the runtime tag after the time and the agent modifier; a human row carries neither', () => {
+    const tags = new Map([['sprint-impl', 'codex']]);
+    const { container } = render(
+      <MemoryRouter>
+        <V2MessageRow message={msg(1, { user: { username: 'sprint-impl', isBot: true } })} agentTags={tags} />
+        <V2MessageRow message={msg(2, { user: { username: 'sam', isBot: false } })} agentTags={tags} />
+      </MemoryRouter>,
+    );
+    const agent = container.querySelector('#message-1');
+    expect(agent).toHaveClass('v2-msg--agent');
+    expect(agent.querySelector('.v2-msg__tag')).toHaveTextContent('codex');
+    const human = container.querySelector('#message-2');
+    expect(human).not.toHaveClass('v2-msg--agent');
+    expect(human.querySelector('.v2-msg__tag')).toBeNull();
+  });
+
+  test('reactions past six collapse into a +N chip that expands the row', () => {
+    const reactions = ['👍', '❤️', '🔥', '🤔', '👀', '🚀', '✅', '🎉'].map((emoji, i) => ({ emoji, count: i + 1, mine: false }));
+    render(<MemoryRouter><V2MessageRow message={msg(3, { reactions })} /></MemoryRouter>);
+    // Six emoji chips (emoji + count as text) and one +N chip whose accessible name carries the count.
+    const chips = document.querySelectorAll('.v2-msg__reaction:not(.v2-msg__reaction--more)');
+    expect(chips).toHaveLength(6);
+    const more = screen.getByRole('button', { name: '2 more reactions' });
+    expect(more).toHaveTextContent('+2');
+    fireEvent.click(more);
+    expect(document.querySelectorAll('.v2-msg__reaction:not(.v2-msg__reaction--more)')).toHaveLength(8);
+    expect(screen.queryByRole('button', { name: /more reactions/ })).not.toBeInTheDocument();
+  });
+
+  test('at 390 a long-press reveals the strip, the click that ends the press keeps it, and the next tap hides it', () => {
+    jest.useFakeTimers();
+    const orig = window.matchMedia;
+    window.matchMedia = (q) => ({ matches: q.includes('hover: none'), media: q, addEventListener() {}, removeEventListener() {}, addListener() {}, removeListener() {} });
+    const { container } = render(<MemoryRouter><V2MessageRow message={msg(5)} /></MemoryRouter>);
+    const row = container.querySelector('#message-5');
+    fireEvent.pointerDown(row);
+    act(() => { jest.advanceTimersByTime(600); });
+    fireEvent.pointerUp(row);
+    fireEvent.click(row);
+    expect(row).toHaveClass('v2-msg--reveal');
+    fireEvent.click(row);
+    expect(row).not.toHaveClass('v2-msg--reveal');
+    // A short tap never reveals.
+    fireEvent.pointerDown(row);
+    act(() => { jest.advanceTimersByTime(200); });
+    fireEvent.pointerUp(row);
+    fireEvent.click(row);
+    expect(row).not.toHaveClass('v2-msg--reveal');
+    window.matchMedia = orig;
+    jest.useRealTimers();
+  });
+
+  test('a quoted reply is a link that lands on its source when loaded, else sets the hash', () => {
+    window.location.hash = '';
+    const { container } = render(
+      <MemoryRouter>
+        <V2MessageRow message={msg(10)} />
+        <V2MessageRow message={msg(11, { replyTo: { id: '10', username: 'author10', content: 'message 10' } })} />
+        <V2MessageRow message={msg(12, { replyTo: { id: '99', username: 'gone', content: 'paged out' } })} />
+      </MemoryRouter>,
+    );
+    Element.prototype.scrollIntoView = jest.fn();
+    const quotes = container.querySelectorAll('.v2-msg__quote');
+    expect(quotes[0]).toHaveAttribute('role', 'link');
+    fireEvent.click(quotes[0]);
+    expect(container.querySelector('#message-10')).toHaveClass('v2-msg--landed');
+    fireEvent.click(quotes[1]);
+    expect(window.location.hash).toBe('#message-99');
+    expect(landOnMessage(null)).toBe(false);
+  });
+
+  test('the strip is react · reply · thread · more, and more offers copy link / copy text', () => {
+    render(
+      <V2MessageActions
+        message={msg(5)}
+        author="Vera"
+        onReply={jest.fn()}
+        onThread={jest.fn()}
+        canInteract
+        pickerOpen={false}
+        reactions={[]}
+        onTogglePicker={jest.fn()}
+        onToggleReaction={jest.fn()}
+      />,
+    );
+    const strip = screen.getByRole('toolbar', { name: 'Message actions' });
+    expect(strip).toHaveClass('v2-msg__strip');
+    expect(within(strip).getAllByRole('button').map((b) => b.getAttribute('aria-label'))).toEqual(['Add reaction', 'Reply to Vera', 'Thread from Vera', 'More']);
+    fireEvent.click(within(strip).getByRole('button', { name: 'More' }));
+    expect(within(strip).getAllByRole('menuitem').map((m) => m.textContent)).toEqual(['Copy link', 'Copy text']);
+  });
+
+  test('an expanded thread is one band with the newest eight, a more line, and a Collapse foot', () => {
+    const root = msg(20);
+    const replies = Array.from({ length: 11 }, (_, i) => msg(21 + i, { thread_root_id: '20' }));
+    const toggleCollapsed = jest.fn();
+    const { container } = render(
+      <MemoryRouter>
+        <V2ThreadMessages
+          messages={[root, ...replies]}
+          threadView={[{ kind: 'message', message: root }, { kind: 'card', rootId: '20', replyCount: 11, participants: [], lastActivityAt: null, replies }]}
+          threadState={{ byRoot: new Map([['20', { collapsed: false, following: null }]]), toggleCollapsed, toggleFollowing: jest.fn() }}
+          decisionByMessageId={new Map()}
+          settledDecisionByMessageId={new Map()}
+          agentDisplayNames={new Map()}
+          agentAuthorKeys={new Set()}
+          onAimAtThread={jest.fn()}
+          hasMore={false}
+          loadingOlder={false}
+          onLoadOlder={jest.fn()}
+          loading={false}
+          error={null}
+          messagesContainerRef={React.createRef()}
+          messagesEndRef={React.createRef()}
+        />
+      </MemoryRouter>,
+    );
+    const block = container.querySelector('.v2-thread-block--open');
+    expect(block).toBeTruthy();
+    expect(block.querySelectorAll('.v2-thread-replies .v2-msg')).toHaveLength(8);
+    fireEvent.click(within(block).getByRole('button', { name: '3 more replies' }));
+    expect(block.querySelectorAll('.v2-thread-replies .v2-msg')).toHaveLength(11);
+    const foot = block.querySelector('.v2-thread-replies__foot');
+    expect(foot).toHaveTextContent('11 replies');
+    fireEvent.click(within(foot).getByRole('button', { name: 'Collapse' }));
+    expect(toggleCollapsed).toHaveBeenCalledWith('20');
+  });
+});

--- a/frontend/src/v2/__tests__/V2ThreadReveal.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadReveal.test.tsx
@@ -1,0 +1,149 @@
+// @ts-nocheck
+// The PRODUCER halves of the two changes @sprint-review found bare (64500,
+// 64501): the landing effect that decides reveal-vs-fetch from the hash, and
+// the write that persists a thread's open/closed state. The consumers were
+// covered (V2ThreadRestyle hands `revealMessageId` straight to the
+// transcript); nothing exercised the code that computes either.
+import React from 'react';
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import V2Thread from '../components/V2Thread';
+import { AuthContext } from '../../context/AuthContext';
+import { useV2ThreadState } from '../hooks/useV2ThreadState';
+
+jest.mock('../../context/SocketContext', () => ({ useSocket: () => ({ socket: null, connected: false }) }));
+jest.mock('../components/V2Avatar', () => {
+  const MockAvatar = () => <span data-testid="avatar" />;
+  MockAvatar.displayName = 'MockAvatar';
+  return MockAvatar;
+});
+jest.mock('../utils/avatars', () => ({ initialsFor: (name: string) => name.slice(0, 2) }));
+beforeAll(() => { Element.prototype.scrollIntoView = jest.fn(); });
+
+// `mock`-prefixed so the factory may close over them (jest hoists the mock).
+const THREAD_ROW = { threadRootId: 7, collapsed: true, following: null };
+const mockPut = jest.fn(() => Promise.resolve({}));
+const mockGet = jest.fn(() => Promise.resolve({ podId: 'p1', defaults: { following: null }, threads: [THREAD_ROW] }));
+// ONE object for every render: the hook's fetch effect depends on `api`, so a
+// factory that builds a fresh object per call re-fetches on every render (66
+// calls in 50ms when I got this wrong).
+const mockApi = {
+  get: (...args) => mockGet(...args),
+  post: jest.fn(() => Promise.resolve({})),
+  put: (...args) => mockPut(...args),
+  patch: jest.fn(() => Promise.resolve({})),
+  del: jest.fn(() => Promise.resolve({})),
+};
+jest.mock('../hooks/useV2Api', () => ({ useV2Api: () => mockApi }));
+
+const authValue = {
+  currentUser: { _id: 'u1', username: 'solo-user' },
+  user: { _id: 'u1', username: 'solo-user' },
+  token: 't',
+  loading: false,
+  isAuthenticated: true,
+  error: null,
+  register: jest.fn(), login: jest.fn(), logout: jest.fn(), updateProfile: jest.fn(),
+};
+
+const threadMessages = () => ([
+  {
+    id: 'm1', pod_id: 'p1', user_id: 'u2', content: 'Root of the thread', message_type: 'text', created_at: '2026-08-22T13:00:00Z', user: { username: 'teammate' },
+  },
+  ...Array.from({ length: 10 }, (_, i) => ({
+    id: `r${i}`, pod_id: 'p1', user_id: 'u3', thread_root_id: 'm1', content: `reply ${i}`, message_type: 'text', created_at: `2026-08-22T13:0${i}:00Z`, user: { username: 'other' },
+  })),
+]);
+
+const makeDetail = (overrides = {}) => ({
+  pod: { _id: 'p1', name: 'My Workspace', type: 'chat' },
+  members: [{ _id: 'u1', username: 'solo-user', isBot: false }],
+  messages: threadMessages(),
+  agents: [],
+  sendMessage: jest.fn(() => Promise.resolve({ _id: 'm1' })),
+  loading: false,
+  error: null,
+  sendError: null,
+  hasMore: true,
+  loadingOlder: false,
+  loadOlder: jest.fn(() => Promise.resolve()),
+  refresh: jest.fn(),
+  ...overrides,
+});
+
+const renderAt = (hash, detail) => render(
+  <AuthContext.Provider value={authValue}>
+    <MemoryRouter initialEntries={[`/v2/pods/p1${hash}`]}>
+      <V2Thread detail={detail} />
+    </MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+describe('landing on a message decides reveal vs fetch (producer)', () => {
+  test('a target folded inside a collapsed thread is revealed — the thread opens and NO history is fetched', async () => {
+    const detail = makeDetail();
+    const { container } = renderAt('#message-r2', detail);
+    await waitFor(() => {
+      expect(container.querySelector('.v2-thread-block--open')).toBeTruthy();
+    });
+    // r2 is outside the newest-eight window, so the fold must be cleared too.
+    expect(container.querySelector('#message-r2')).toBeTruthy();
+    expect(detail.loadOlder).not.toHaveBeenCalled();
+  });
+
+  test('a target that is nowhere in the loaded window pages older history instead', async () => {
+    // Call count is deliberately not asserted: this fixture pins
+    // `loadingOlder: false`, while the real hook flips it for the duration of
+    // the fetch. What matters is that the fetch path is chosen at all.
+    const detail = makeDetail();
+    const { container } = renderAt('#message-999', detail);
+    await waitFor(() => { expect(detail.loadOlder).toHaveBeenCalled(); });
+    expect(container.querySelector('.v2-thread-block--open')).toBeNull();
+  });
+
+  test('a target already on screen neither reveals nor fetches', async () => {
+    const detail = makeDetail();
+    const { container } = renderAt('#message-m1', detail);
+    await waitFor(() => {
+      expect(container.querySelector('#message-m1')).toHaveClass('v2-msg--landed');
+    });
+    expect(detail.loadOlder).not.toHaveBeenCalled();
+    expect(container.querySelector('.v2-thread-block--open')).toBeNull();
+  });
+});
+
+describe('opening or closing a thread persists (producer)', () => {
+  const wrapper = ({ children }) => <>{children}</>;
+
+  beforeEach(() => { mockPut.mockClear(); });
+
+  test('setCollapsed writes the new value to the collapsed route', async () => {
+    const { result } = renderHook(() => useV2ThreadState('p1'), { wrapper });
+    await waitFor(() => { expect(result.current.byRoot.size).toBe(1); });
+
+    act(() => { result.current.setCollapsed('7', false); });
+    expect(mockPut).toHaveBeenCalledWith('/api/messages/7/collapsed', { collapsed: false });
+    await waitFor(() => { expect(result.current.byRoot.get('7').collapsed).toBe(false); });
+
+    act(() => { result.current.setCollapsed('7', true); });
+    expect(mockPut).toHaveBeenLastCalledWith('/api/messages/7/collapsed', { collapsed: true });
+  });
+
+  test('a no-op and an unknown root write nothing — a 10-chip first load must not issue a bulk write', async () => {
+    const { result } = renderHook(() => useV2ThreadState('p1'), { wrapper });
+    await waitFor(() => { expect(result.current.byRoot.size).toBe(1); });
+
+    act(() => { result.current.setCollapsed('7', true); });
+    act(() => { result.current.setCollapsed('nope', false); });
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  test('a failed write reverts the optimistic state', async () => {
+    mockPut.mockRejectedValueOnce(new Error('offline'));
+    const { result } = renderHook(() => useV2ThreadState('p1'), { wrapper });
+    await waitFor(() => { expect(result.current.byRoot.size).toBe(1); });
+
+    act(() => { result.current.setCollapsed('7', false); });
+    await waitFor(() => { expect(result.current.byRoot.get('7').collapsed).toBe(true); });
+  });
+});

--- a/frontend/src/v2/__tests__/V2ThreadReveal.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadReveal.test.tsx
@@ -5,7 +5,7 @@
 // covered (V2ThreadRestyle hands `revealMessageId` straight to the
 // transcript); nothing exercised the code that computes either.
 import React from 'react';
-import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import V2Thread from '../components/V2Thread';
 import { AuthContext } from '../../context/AuthContext';
@@ -71,13 +71,14 @@ const makeDetail = (overrides = {}) => ({
   ...overrides,
 });
 
-const renderAt = (hash, detail) => render(
+const threadNode = (hash, detail) => (
   <AuthContext.Provider value={authValue}>
     <MemoryRouter initialEntries={[`/v2/pods/p1${hash}`]}>
       <V2Thread detail={detail} />
     </MemoryRouter>
-  </AuthContext.Provider>,
+  </AuthContext.Provider>
 );
+const renderAt = (hash, detail) => render(threadNode(hash, detail));
 
 describe('landing on a message decides reveal vs fetch (producer)', () => {
   test('a target folded inside a collapsed thread is revealed — the thread opens and NO history is fetched', async () => {
@@ -109,6 +110,57 @@ describe('landing on a message decides reveal vs fetch (producer)', () => {
     });
     expect(detail.loadOlder).not.toHaveBeenCalled();
     expect(container.querySelector('.v2-thread-block--open')).toBeNull();
+  });
+
+  test('quoting the same folded reply again after collapse reopens it without fetching history', async () => {
+    const detail = makeDetail({
+      messages: [
+        ...threadMessages(),
+        {
+          id: 'q', pod_id: 'p1', user_id: 'u4', content: 'follow-up', message_type: 'text',
+          created_at: '2026-08-22T14:00:00Z', user: { username: 'quoter' },
+          replyTo: { id: 'r2', username: 'other', content: 'reply 2' },
+        },
+      ],
+    });
+    const { container } = renderAt('#message-r2', detail);
+    await waitFor(() => {
+      expect(container.querySelector('.v2-thread-block--open')).toBeTruthy();
+      expect(container.querySelector('#message-r2')).toBeTruthy();
+    });
+
+    fireEvent.click(container.querySelector('.v2-thread-replies__collapse'));
+    await waitFor(() => {
+      expect(container.querySelector('.v2-thread-block--open')).toBeNull();
+    });
+
+    fireEvent.click(container.querySelector('#message-q .v2-msg__quote'));
+    await waitFor(() => {
+      expect(container.querySelector('.v2-thread-block--open')).toBeTruthy();
+      expect(container.querySelector('#message-r2')).toBeTruthy();
+    });
+    expect(detail.loadOlder).not.toHaveBeenCalled();
+  });
+
+  test('a reply visible before its older root loads remains flat after the prepend', async () => {
+    const orphan = {
+      id: 'orphan', pod_id: 'p1', user_id: 'u3', thread_root_id: 'old-root', content: 'orphan reply',
+      message_type: 'text', created_at: '2026-08-22T12:00:00Z', user: { username: 'other' },
+    };
+    const initial = makeDetail({ messages: [orphan] });
+    const view = renderAt('', initial);
+    await waitFor(() => { expect(view.container.querySelector('#message-orphan')).toBeTruthy(); });
+
+    const loaded = {
+      ...initial,
+      messages: [
+        { id: 'old-root', pod_id: 'p1', user_id: 'u2', content: 'older root', message_type: 'text', created_at: '2026-08-22T11:00:00Z', user: { username: 'teammate' } },
+        orphan,
+      ],
+    };
+    view.rerender(threadNode('', loaded));
+    await waitFor(() => { expect(view.container.querySelector('#message-orphan')).toBeTruthy(); });
+    expect(view.container.querySelector('.v2-thread-block')).toBeNull();
   });
 });
 

--- a/frontend/src/v2/__tests__/threadView.test.ts
+++ b/frontend/src/v2/__tests__/threadView.test.ts
@@ -1,4 +1,4 @@
-import { buildThreadView } from '../utils/threadView';
+import { buildThreadView, freezeOrphanReplyIds } from '../utils/threadView';
 import { V2ThreadState } from '../hooks/useV2ThreadState';
 
 const msg = (id: number, opts: Partial<any> = {}) => ({
@@ -54,6 +54,38 @@ describe('a reply whose root is not in the page is not lost', () => {
     const items = buildThreadView([msg(5, { thread_root_id: 999 })], state([]));
     expect(items).toHaveLength(1);
     expect(items[0]).toMatchObject({ kind: 'message', message: { id: '5' } });
+  });
+
+  test('an orphan stays flat when its root arrives on a later page', () => {
+    const orphan = msg(5, { thread_root_id: 999 });
+    const frozen = freezeOrphanReplyIds([orphan]);
+    const items = buildThreadView(
+      [msg(999), orphan],
+      state([999]),
+      frozen,
+    );
+    expect(items.filter((i) => i.kind === 'message').map((i: any) => i.message.id)).toEqual(['999', '5']);
+    expect(items.find((i) => i.kind === 'card')).toBeUndefined();
+  });
+
+  test('a frozen orphan stays visible beside an unfrozen reply under the same root', () => {
+    const orphan = msg(5, { thread_root_id: 999 });
+    const liveReply = msg(6, { thread_root_id: 999 });
+    const frozen = freezeOrphanReplyIds([orphan]);
+    const items = buildThreadView(
+      [msg(999), orphan, liveReply],
+      state([999]),
+      frozen,
+    );
+    expect(items.filter((i) => i.kind === 'message').map((i: any) => i.message.id)).toEqual(['999', '5']);
+    expect((items.find((i) => i.kind === 'card') as any).replies.map((reply: any) => reply.id)).toEqual(['6']);
+  });
+
+  test('freezeOrphanReplyIds retains prior freezes and adds new orphans', () => {
+    const prior = new Set(['5']);
+    const next = freezeOrphanReplyIds([msg(5, { thread_root_id: 999 }), msg(6, { thread_root_id: 1000 })], prior);
+    expect([...next]).toEqual(['5', '6']);
+    expect(prior).toEqual(new Set(['5']));
   });
 });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -846,6 +846,12 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-thread .v2-thread-replies')).toContain('border-left: 2px solid var(--v2-border)');
     expect(ruleBody(v2, '.v2-thread .v2-msg__strip')).toContain('border-radius: 4px');
     expect(ruleBody(v2, '.v2-thread .v2-msg__strip')).toContain('box-shadow: none');
+    expect(ruleBody(v2, '.v2-thread .v2-msg__strip')).toContain('padding: 1px');
+    expect(ruleBody(v2, '.v2-thread .v2-avatar--flat')).toContain('font: 650 12px/1 var(--v2-font)');
+    expect(ruleBody(v2, '.v2-thread .v2-thread-replies .v2-msg .v2-avatar')).toContain('font-size: 12px');
+    expect(ruleBody(v2, '.v2-thread .v2-thread-card__faces .v2-avatar')).toContain('font: 650 11px/1 var(--v2-font-mono)');
+    expect(ruleBody(v2, '.v2-thread .v2-thread-card__faces .v2-avatar--flat')).toContain('font: 650 11px/1 var(--v2-font-mono)');
+    expect(v2).toMatch(/@media \(max-width: 760px\)[\s\S]*?\.v2-root \.v2-thread button\.v2-msg__action \{ width: 24px; height: 24px; \}/);
     expect(lastRuleBody(v2, '.v2-root button.v2-thread__jump')).toContain('border: 1px solid #dde0e6');
     expect(lastRuleBody(v2, '.v2-root button.v2-thread__jump')).toContain('border-radius: 14px');
     expect(messageRow).toContain('v2-msg__tag');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -834,6 +834,30 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(messageRow).toContain('<V2Lightbox');
   });
 
+  test('threading restyle (PR 2b): runtime tag, 20px reaction chips, two-line quote, thread chip, band, strip, white jump pill', () => {
+    expect(ruleBody(v2, '.v2-msg__tag')).toContain('font: 500 11px/16px var(--v2-font-mono)');
+    expect(ruleBody(v2, '.v2-thread .v2-msg__reaction')).toContain('height: 20px');
+    expect(ruleBody(v2, '.v2-thread .v2-msg__quote')).toContain('border-left: 2px solid var(--v2-border)');
+    expect(ruleBody(v2, '.v2-thread .v2-msg__quote-text')).toContain('-webkit-line-clamp: 2');
+    expect(ruleBody(v2, '.v2-root .v2-thread button.v2-msg__thread-chip')).toContain('min-height: 28px');
+    expect(ruleBody(v2, '.v2-thread .v2-thread-block--open')).toContain('background: #f9fafb');
+    expect(ruleBody(v2, '.v2-thread .v2-thread-replies')).toContain('border-left: 2px solid var(--v2-border)');
+    expect(ruleBody(v2, '.v2-thread .v2-msg__strip')).toContain('border-radius: 4px');
+    expect(ruleBody(v2, '.v2-thread .v2-msg__strip')).toContain('box-shadow: none');
+    expect(lastRuleBody(v2, '.v2-root button.v2-thread__jump')).toContain('border: 1px solid #dde0e6');
+    expect(lastRuleBody(v2, '.v2-root button.v2-thread__jump')).toContain('border-radius: 14px');
+    expect(messageRow).toContain('v2-msg__tag');
+    expect(messageRow).toContain('MAX_REACTION_CHIPS = 6');
+    expect(threadMessages).toContain('MAX_EXPANDED_REPLIES = 8');
+    expect(threadMessages).toContain('v2-thread-replies__foot');
+    // The revealed strip must be pinned to the body column: the row is a
+    // 38px | 1fr grid and auto-placement would drop the body into the avatar
+    // column (390 walk, one word per line).
+    const revealed = ruleBody(v2, '.v2-thread .v2-msg--reveal .v2-msg__strip');
+    expect(revealed).toContain('grid-column: 2');
+    expect(revealed).toContain('grid-row: 2');
+  });
+
   test('history: a mono edge line that loads on scroll and a Jump-to-latest pill', () => {
     expect(threadMessages).toContain('v2-thread__edge');
     expect(threadMessages).not.toContain('v2-chat__older-btn');
@@ -1183,6 +1207,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
         '.v2-rail__brand-icon',
         '.v2-root button.v2-decision-card__choice--primary',
         '.v2-root button.v2-pods__row--selected',
+        // Direction C (walk-3 miss 62): an agent's transcript avatar is a cobalt
+        // square with white initials — the mark that says "agent" on a row.
+        '.v2-thread .v2-msg--agent .v2-avatar:not(.v2-avatar--photo)',
         '.v2-thread-card__dot',
         '.v2-workspace-inspector__state--needs-you',
         '.v2-workspace-inspector__state--working',

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -531,17 +531,19 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       .toContain('margin-inline: -10px');
     expect(ruleBody(v2, '.v2-chat__messages > .v2-msg--mention'))
       .toContain('width: calc(100% + 20px)');
-    // Threads: card + rail travel inside one block-level child, indented
-    // to the message TEXT column like an attachment (38px avatar + 12px
-    // gap), whose bottom margin terminates the rail before the next
-    // outer message.
-    expect(ruleBody(v2, '.v2-thread-block')).toContain('margin-left: 50px');
-    // Indent + width must sum to 100%: the column's `> *` width:100% plus
-    // the 50px indent pushed every thread 50px past the pane's right edge,
-    // making the transcript horizontally swipeable — worst on phones
-    // (Sam, 2026-08-24; measured 350 vs 326 scrollWidth at 390px).
-    expect(ruleBody(v2, '.v2-thread-block')).toContain('width: calc(100% - 50px)');
-    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-block \{[\s\S]*?width: calc\(100% - 24px\)/);
+    // Threads (ux-lead 64476 (2)): the ROOT now renders inside the block, so
+    // the block itself is a full-width child like any message and the INDENT
+    // moved to the inner wrap (chip + rail at the text column, 28px avatar +
+    // 8px gap).
+    const block = ruleBody(v2, '.v2-thread-block');
+    expect(block).toContain('width: 100%');
+    expect(ruleBody(v2, '.v2-thread .v2-thread-block__inner')).toContain('margin-left: 36px');
+    // Indent + width must still sum to 100%: an indented child that ALSO
+    // carried width:100% pushed every thread past the pane's right edge and
+    // made the transcript horizontally swipeable (Sam, 2026-08-24; 350 vs
+    // 326 scrollWidth at 390). The inner wrap must never take a width.
+    expect(ruleBody(v2, '.v2-thread .v2-thread-block__inner')).not.toContain('width');
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-block__inner \{[\s\S]*?margin-left: 24px/);
     // Belt-and-braces: the transcript itself never scrolls sideways.
     expect(ruleBody(v2, '.v2-chat__messages')).toContain('overflow-x: hidden');
     expect(ruleBody(v2, '.v2-thread-block')).toContain('margin-bottom');
@@ -856,6 +858,22 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     const revealed = ruleBody(v2, '.v2-thread .v2-msg--reveal .v2-msg__strip');
     expect(revealed).toContain('grid-column: 2');
     expect(revealed).toContain('grid-row: 2');
+    // The reveal is gated on capability, so its placement is too — and the
+    // query must MATCH `matchMedia('(hover: none)')` exactly: a comma'd
+    // `(pointer: coarse)` or width term styles machines where the reveal never
+    // fires (sprint-review 64468 + 64485). It must also come after the strip
+    // rules it overrides, since they win on order at equal specificity.
+    const capability = v2.indexOf('@media (hover: none) {');
+    expect(capability).toBeGreaterThan(v2.indexOf('.v2-thread .v2-msg__strip {'));
+    expect(v2.slice(capability, capability + 600)).toContain('.v2-thread .v2-msg--reveal .v2-msg__strip');
+    // ux-lead 64476: root inside the band at the text column; chip-only rest state;
+    // mention wash; flat two-tone transcript avatars.
+    expect(threadMessages).toContain('v2-thread-block__inner');
+    expect(threadMessages).toContain('const collapsed = !openRoots.has(item.rootId)');
+    expect(v2).not.toContain('.v2-thread-card__reply');
+    expect(ruleBody(v2, '.v2-thread .v2-msg__mention')).toContain('background: #e8ecfb');
+    expect(ruleBody(v2, '.v2-thread .v2-avatar--flat-agent')).toContain('var(--v2-accent)');
+    expect(ruleBody(v2, '.v2-thread .v2-avatar--flat-human')).toContain('#f2f4f7');
   });
 
   test('history: a mono edge line that loads on scroll and a Jump-to-latest pill', () => {
@@ -1207,9 +1225,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
         '.v2-rail__brand-icon',
         '.v2-root button.v2-decision-card__choice--primary',
         '.v2-root button.v2-pods__row--selected',
-        // Direction C (walk-3 miss 62): an agent's transcript avatar is a cobalt
-        // square with white initials — the mark that says "agent" on a row.
-        '.v2-thread .v2-msg--agent .v2-avatar:not(.v2-avatar--photo)',
+        // Direction C (walk-3 miss 62, ux-lead 64476 (1)): an agent's transcript
+        // avatar is a flat cobalt square with white initials — the mark that
+        // says "agent" on a row. A photo never gets the class.
+        '.v2-thread .v2-avatar--flat-agent',
         '.v2-thread-card__dot',
         '.v2-workspace-inspector__state--needs-you',
         '.v2-workspace-inspector__state--working',
@@ -1325,9 +1344,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(railRow).toContain('grid-template-columns: 24px minmax(0, 1fr)');
     expect(railRow).toContain('gap: 8px');
 
-    // 390 (rev 3): the block's 50px attachment indent tightens to 24px,
-    // the rail stays on the block edge, and the inner padding tightens.
-    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-block\s*\{[\s\S]*?margin-left: 24px/);
+    // 390 (rev 4): the inner wrap's text-column indent tightens to 24px,
+    // the rail stays on its edge, and the inner padding tightens.
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-block__inner\s*\{[\s\S]*?margin-left: 24px/);
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-replies\s*\{[\s\S]*?margin-left: 0[\s\S]*?padding-left: 8px/);
   });
 
@@ -1362,8 +1381,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // message by default (Sam's report, 2026-08-23).
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-msg--reveal \.v2-msg__actions[\s\S]*?opacity: 1/);
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root button\.v2-msg__action[\s\S]*?height: 44px/);
-    const cardAction = ruleBody(v2, '.v2-root button.v2-thread-card__reply');
-    expect(cardAction).toContain('min-height: 44px');
+    // Reply in thread / Follow / Collapse moved from the chip to the band's
+    // foot (ux-lead 64476 (3)) — the 44px floor moved with them.
+    expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-replies__foot button[\s\S]*?min-height: 44px/);
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-thread-card\s*\{[\s\S]*?flex-wrap: wrap/);
   });
 

--- a/frontend/src/v2/components/V2Avatar.tsx
+++ b/frontend/src/v2/components/V2Avatar.tsx
@@ -28,6 +28,14 @@ interface V2AvatarProps {
    * `name` when absent.
    */
   seed?: string | null;
+  /**
+   * `flat` is the transcript tier (direction C, ux-lead 64476): a photo still
+   * wins, otherwise a two-tone square with initials — human tint, agent
+   * cobalt — instead of the illustrated character. Presentation only; the
+   * species still comes from `kind`, so an unknown kind reads as human tint
+   * rather than guessing agent.
+   */
+  tone?: 'flat';
 }
 
 const sizeClass = (size: V2AvatarSize): string => {
@@ -41,7 +49,7 @@ const sizeClass = (size: V2AvatarSize): string => {
 };
 
 const V2Avatar: React.FC<V2AvatarProps> = ({
-  name, src, size = 'md', className, online, title, kind, seed: seedProp,
+  name, src, size = 'md', className, online, title, kind, seed: seedProp, tone,
 }) => {
   const seed = String(name || '');
   const bg = gradientFor(seed);
@@ -59,15 +67,20 @@ const V2Avatar: React.FC<V2AvatarProps> = ({
   // right tier.
   const cleanSrc = getAvatarSrc(rawSrc) || null;
   const [imgFailed, setImgFailed] = React.useState(false);
-  const classes = [sizeClass(size), className].filter(Boolean).join(' ');
+  const flat = tone === 'flat';
+  const classes = [
+    sizeClass(size),
+    flat ? `v2-avatar--flat v2-avatar--flat-${kind === 'agent' ? 'agent' : 'human'}` : null,
+    className,
+  ].filter(Boolean).join(' ');
 
   // Character tier (photo still wins, below). Memoized because the SVG build
   // runs per identity per render otherwise, and chat re-renders per message.
   // Falls back to gradient+initials on any generation failure — the character
   // is presentation, never load-bearing.
   const characterSrc = React.useMemo(
-    () => (kind ? characterAvatarFor(seedProp || seed, kind) : null),
-    [kind, seedProp, seed],
+    () => (kind && !flat ? characterAvatarFor(seedProp || seed, kind) : null),
+    [kind, seedProp, seed, flat],
   );
 
   React.useEffect(() => {
@@ -116,7 +129,7 @@ const V2Avatar: React.FC<V2AvatarProps> = ({
   return (
     <span
       className={classes}
-      style={{ background: bg }}
+      style={flat ? undefined : { background: bg }}
       title={display}
     >
       {initials}

--- a/frontend/src/v2/components/V2MessageActions.tsx
+++ b/frontend/src/v2/components/V2MessageActions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { V2Message } from '../hooks/useV2PodDetail';
 
@@ -23,7 +23,20 @@ interface V2MessageActionsProps {
 
 const REACTION_PALETTE = ['👍', '❤️', '🔥', '🤔', '👀', '🚀'];
 
-/** The row-level action affordances, kept out of the message content flow. */
+const Icon = ({ d, extra }: { d: string; extra?: React.ReactNode }) => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d={d} />
+    {extra}
+  </svg>
+);
+
+/**
+ * The row's action strip (direction C, walk-3 miss 56): react · reply · thread
+ * · more, in one 28px white box at the row's top-right on hover or focus at
+ * desktop widths, inline under the body on long-press at 390. Kept out of the
+ * message content flow. `v2-msg__actions` stays for the existing invariants;
+ * `v2-msg__strip` is the direction-C contract name.
+ */
 const V2MessageActions: React.FC<V2MessageActionsProps> = ({
   message,
   author,
@@ -36,57 +49,41 @@ const V2MessageActions: React.FC<V2MessageActionsProps> = ({
   onToggleReaction,
 }) => {
   const { t } = useTranslation();
+  const [moreOpen, setMoreOpen] = useState(false);
+  const moreRef = useRef<HTMLSpanElement | null>(null);
+  useEffect(() => {
+    if (!moreOpen) return undefined;
+    const close = (event: MouseEvent) => { if (moreRef.current && !moreRef.current.contains(event.target as Node)) setMoreOpen(false); };
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [moreOpen]);
   if (!onReply && !onThread && !canInteract) return null;
+
+  const copy = async (text: string) => {
+    try { await navigator.clipboard.writeText(text); } catch { /* clipboard unavailable: nothing to show */ }
+    setMoreOpen(false);
+  };
+  const link = typeof window !== 'undefined'
+    ? `${window.location.origin}${window.location.pathname}#message-${message.id}`
+    : `#message-${message.id}`;
 
   return (
     <div
-      className="v2-msg__actions"
+      className="v2-msg__actions v2-msg__strip"
       role="toolbar"
-      aria-label="Message actions"
+      aria-label={t('podChat.strip.label')}
       onClick={(event) => event.stopPropagation()}
     >
-      {onReply && (
-        <button
-          type="button"
-          className="v2-msg__action"
-          aria-label={`Reply to ${author}`}
-          title={`Reply to ${author}`}
-          onClick={() => onReply(message)}
-        >
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <polyline points="9 17 4 12 9 7" />
-            <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
-          </svg>
-        </button>
-      )}
-      {onThread && (
-        <button
-          type="button"
-          className="v2-msg__action"
-          aria-label={`${t('podChat.thread.startThread')} from ${author}`}
-          title={t('podChat.thread.startThread')}
-          onClick={() => onThread(message)}
-        >
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-          </svg>
-        </button>
-      )}
       {canInteract && (
         <span className="v2-msg__action-wrap">
           <button
             type="button"
             className="v2-msg__action"
-            aria-label="Add reaction"
-            title="Add reaction"
+            aria-label={t('podChat.strip.react')}
+            title={t('podChat.strip.react')}
             onClick={onTogglePicker}
           >
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <circle cx="12" cy="12" r="10" />
-              <path d="M8 14s1.5 2 4 2 4-2 4-2" />
-              <line x1="9" y1="9" x2="9.01" y2="9" />
-              <line x1="15" y1="9" x2="15.01" y2="9" />
-            </svg>
+            <Icon d="M8 14s1.5 2 4 2 4-2 4-2" extra={<><circle cx="12" cy="12" r="10" /><line x1="9" y1="9" x2="9.01" y2="9" /><line x1="15" y1="9" x2="15.01" y2="9" /></>} />
           </button>
           {pickerOpen && (
             <span className="v2-msg__reaction-picker" role="menu">
@@ -109,6 +106,47 @@ const V2MessageActions: React.FC<V2MessageActionsProps> = ({
           )}
         </span>
       )}
+      {onReply && (
+        <button
+          type="button"
+          className="v2-msg__action"
+          aria-label={`Reply to ${author}`}
+          title={`Reply to ${author}`}
+          onClick={() => onReply(message)}
+        >
+          <Icon d="M20 18v-2a4 4 0 0 0-4-4H4" extra={<polyline points="9 17 4 12 9 7" />} />
+        </button>
+      )}
+      {onThread && (
+        <button
+          type="button"
+          className="v2-msg__action"
+          aria-label={`${t('podChat.thread.startThread')} from ${author}`}
+          title={t('podChat.thread.startThread')}
+          onClick={() => onThread(message)}
+        >
+          <Icon d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </button>
+      )}
+      <span className="v2-msg__action-wrap" ref={moreRef}>
+        <button
+          type="button"
+          className="v2-msg__action"
+          aria-label={t('podChat.strip.more')}
+          title={t('podChat.strip.more')}
+          aria-haspopup="menu"
+          aria-expanded={moreOpen}
+          onClick={() => setMoreOpen((open) => !open)}
+        >
+          <Icon d="M5 12h.01M12 12h.01M19 12h.01" />
+        </button>
+        {moreOpen && (
+          <span className="v2-msg__more-menu" role="menu">
+            <button type="button" role="menuitem" onClick={() => copy(link)}>{t('podChat.strip.copyLink')}</button>
+            <button type="button" role="menuitem" onClick={() => copy(String(message.content || ''))}>{t('podChat.strip.copyText')}</button>
+          </span>
+        )}
+      </span>
     </div>
   );
 };

--- a/frontend/src/v2/components/V2MessageActions.tsx
+++ b/frontend/src/v2/components/V2MessageActions.tsx
@@ -74,14 +74,17 @@ const V2MessageActions: React.FC<V2MessageActionsProps> = ({
       aria-label={t('podChat.strip.label')}
       onClick={(event) => event.stopPropagation()}
     >
-      {canInteract && (
-        <span className="v2-msg__action-wrap">
+      {/* React is the first of the four icons whenever the strip renders; it
+          is disabled, not absent, when this row cannot take a reaction yet
+          (no live reactions, or a non-numeric id) — ux-lead 64476 (5). */}
+      <span className="v2-msg__action-wrap">
           <button
             type="button"
             className="v2-msg__action"
             aria-label={t('podChat.strip.react')}
             title={t('podChat.strip.react')}
             onClick={onTogglePicker}
+            disabled={!canInteract}
           >
             <Icon d="M8 14s1.5 2 4 2 4-2 4-2" extra={<><circle cx="12" cy="12" r="10" /><line x1="9" y1="9" x2="9.01" y2="9" /><line x1="15" y1="9" x2="15.01" y2="9" /></>} />
           </button>
@@ -104,8 +107,7 @@ const V2MessageActions: React.FC<V2MessageActionsProps> = ({
               })}
             </span>
           )}
-        </span>
-      )}
+      </span>
       {onReply && (
         <button
           type="button"

--- a/frontend/src/v2/components/V2MessageRow.tsx
+++ b/frontend/src/v2/components/V2MessageRow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import V2Lightbox, { type V2LightboxImage } from './V2Lightbox';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -92,6 +92,9 @@ interface V2MessageRowProps {
   // raw User row username "openclaw-nova". Frontend-only display layer; the
   // underlying User row is unchanged.
   agentDisplayNames?: Map<string, string>;
+  // Lowercased author key → runtime short name (`codex`, `claude`, …), the
+  // mono tag after the time on agent rows (direction C). Absent = no tag.
+  agentTags?: Map<string, string>;
   // Lowercased set of strings we treat as agent author bylines (both raw
   // usernames and displayNames). The backend may serve either shape on
   // `message.user.username`, so we gate click behavior on a known set.
@@ -318,7 +321,21 @@ const parseAgentDmEvent = (content: string | undefined): { headline: string; tar
   return { headline: match[1], targetPodId: match[2] };
 };
 
-const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisionRuled, isDecisionRuling = false, isLead, agentDisplayNames, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, grouped, insideThreadRoot }) => {
+const MAX_REACTION_CHIPS = 6;
+const LONG_PRESS_MS = 500;
+
+// Jump to a message already in the transcript and mark it landed for a beat.
+export const landOnMessage = (id: string | number | null | undefined): boolean => {
+  if (id === null || id === undefined) return false;
+  const el = typeof document !== 'undefined' ? document.getElementById(`message-${id}`) : null;
+  if (!el) return false;
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  el.classList.add('v2-msg--landed');
+  window.setTimeout(() => el.classList.remove('v2-msg--landed'), 2000);
+  return true;
+};
+
+const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisionRuled, isDecisionRuling = false, isLead, agentDisplayNames, agentTags, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, grouped, insideThreadRoot }) => {
   const { currentUser } = useAuth();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -333,15 +350,31 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
   // it again. Desktop hover behavior is untouched — the class is inert
   // wherever hover exists.
   const [actionsRevealed, setActionsRevealed] = useState(false);
+  const [reactionsExpanded, setReactionsExpanded] = useState(false);
+  const pressTimer = useRef<number | null>(null);
+  const isHoverless = () => typeof window !== 'undefined' && !!window.matchMedia && window.matchMedia('(hover: none)').matches;
+  // Direction C at 390: a long-press (~500ms) reveals the strip inline under
+  // the body; a tap elsewhere dismisses it. Desktop hover is untouched.
+  // The pointer-up that ends a long-press still delivers a click on most
+  // touch stacks; without this latch that click would hide the strip the
+  // same instant the press revealed it (walk-2b, 390).
+  const pressRevealedRef = useRef(false);
+  const onPressStart = () => {
+    if (!isHoverless()) return;
+    pressRevealedRef.current = false;
+    pressTimer.current = window.setTimeout(() => {
+      setActionsRevealed(true);
+      pressRevealedRef.current = true;
+      pressTimer.current = null;
+    }, LONG_PRESS_MS);
+  };
+  const onPressEnd = () => {
+    if (pressTimer.current !== null) { window.clearTimeout(pressTimer.current); pressTimer.current = null; }
+  };
   const onBubbleTap = () => {
-    if (typeof window !== 'undefined'
-      && window.matchMedia
-      && window.matchMedia('(hover: none)').matches) {
-      setActionsRevealed((v) => {
-        if (v) setPickerOpen(false);
-        return !v;
-      });
-    }
+    if (!isHoverless()) return;
+    if (pressRevealedRef.current) { pressRevealedRef.current = false; return; }
+    if (actionsRevealed) { setActionsRevealed(false); setPickerOpen(false); }
   };
   // Surface why a reaction failed instead of swallowing it. Before this, a
   // rejected reaction (bad emoji 400, non-member 403, rate-limit 429) did
@@ -356,6 +389,7 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
   // Click is gated by agentAuthorKeys — backend may serve either raw username
   // or displayName on `message.user.username`, and the v2 set covers both.
   const isClickable = !!onAuthorClick && !!agentAuthorKeys?.has(rawUsername.toLowerCase());
+  const runtimeTag = agentTags?.get(rawUsername.toLowerCase()) || agentTags?.get(author.toLowerCase());
   const handleAuthorClick = isClickable ? () => onAuthorClick?.(rawUsername) : undefined;
   const time = formatRelativeTime(message.created_at);
 
@@ -501,9 +535,14 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
 
   return (
     <div
+      id={`message-${message.id}`}
       data-testid={isDecisionRuling ? 'decision-ruling-row' : undefined}
-      className={`v2-msg v2-message-row${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}${actionsRevealed ? ' v2-msg--reveal' : ''}`}
+      className={`v2-msg v2-message-row${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}${actionsRevealed ? ' v2-msg--reveal' : ''}${runtimeTag ? ' v2-msg--agent' : ''}`}
       onClick={onBubbleTap}
+      onPointerDown={onPressStart}
+      onPointerUp={onPressEnd}
+      onPointerLeave={onPressEnd}
+      onPointerCancel={onPressEnd}
     >
       {grouped ? (
         <div className="v2-msg__avatar-ghost" aria-hidden="true" />
@@ -554,9 +593,11 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
           )}
           {isLead && <span className="v2-msg__lead-badge">{t('podChat.leadBadge')}</span>}
           {time && <span className="v2-msg__time">{time}</span>}
+          {runtimeTag && <span className="v2-msg__tag">{runtimeTag}</span>}
           {isDecisionRuling && <span className="v2-msg__ruled">· {t('activity.decision.ruledShort')}</span>}
         </div>
         )}
+        {grouped && time && <span className="v2-msg__gutter-time" aria-hidden="true">{time}</span>}
         {(() => {
           // Quoted context for replies. POST responses carry a normalized
           // `replyTo` object; list rows may carry raw reply_* columns instead.
@@ -589,10 +630,24 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
             && quoteTargetId !== null
             && String(quoteTargetId) === String(insideThreadRoot);
           if (quotesTheRailRoot) return null;
+          // Land on the source when it is loaded; otherwise set the hash so the
+          // thread pages back until it is (V2Thread's landing effect).
+          const jump = () => {
+            if (landOnMessage(quoteTargetId as string | number | null | undefined)) return;
+            if (quoteTargetId !== undefined && quoteTargetId !== null && typeof window !== 'undefined') {
+              window.location.hash = `#message-${quoteTargetId}`;
+            }
+          };
           return (
-            <div className="v2-msg__quote">
-              <span className="v2-msg__quote-author">{quoteAuthor || 'earlier message'}</span>
-              <span className="v2-msg__quote-text">{String(quoteContent).slice(0, 140)}</span>
+            <div
+              className="v2-msg__quote"
+              role={quoteTargetId ? 'link' : undefined}
+              tabIndex={quoteTargetId ? 0 : undefined}
+              onClick={(event) => { event.stopPropagation(); jump(); }}
+              onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); jump(); } }}
+            >
+              <span className="v2-msg__quote-author">{quoteAuthor || t('podChat.quote.earlier')}</span>
+              <span className="v2-msg__quote-text">{String(quoteContent).slice(0, 240)}</span>
             </div>
           );
         })()}
@@ -664,9 +719,11 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
             return `${names.join(', ')} reacted with ${r.emoji}${r.mine ? ' (you)' : ''}`;
           };
 
+          const visible = reactionsExpanded ? renderList : renderList.slice(0, MAX_REACTION_CHIPS);
+          const hidden = renderList.length - visible.length;
           return (
             <div className="v2-msg__reactions" aria-label="Reactions">
-              {renderList.map((r, idx) => (
+              {visible.map((r, idx) => (
                 <button
                   key={`${r.emoji}-${idx}`}
                   type="button"
@@ -679,6 +736,11 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
                   <span className="v2-msg__reaction-count">{r.count}</span>
                 </button>
               ))}
+              {hidden > 0 && (
+                <button type="button" className="v2-msg__reaction v2-msg__reaction--more" onClick={() => setReactionsExpanded(true)} aria-label={t('podChat.reactions.more', { count: hidden })}>
+                  +{hidden}
+                </button>
+              )}
               {reactionError && (
                 <span className="v2-msg__reaction-error" role="alert">{reactionError}</span>
               )}

--- a/frontend/src/v2/components/V2MessageRow.tsx
+++ b/frontend/src/v2/components/V2MessageRow.tsx
@@ -123,6 +123,10 @@ interface V2MessageRowProps {
   // parent resolves an already-threaded message to its existing root before
   // aiming the composer, so this control never asks the server for nesting.
   onThread?: (message: V2Message) => void;
+  // Notifies the transcript when a quote points at a row hidden behind a
+  // thread fold. Repeating that quote after collapsing must be a fresh
+  // navigation gesture even though the hash string is unchanged.
+  onQuoteNavigate?: (messageId: string | number) => void;
   // Consecutive-author grouping (craft audit finding 7): when the previous
   // message is the same author within the grouping window, the header row
   // (avatar / name / time) is suppressed and the row tightens. The avatar
@@ -335,7 +339,7 @@ export const landOnMessage = (id: string | number | null | undefined): boolean =
   return true;
 };
 
-const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisionRuled, isDecisionRuling = false, isLead, agentDisplayNames, agentTags, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, grouped, insideThreadRoot }) => {
+const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisionRuled, isDecisionRuling = false, isLead, agentDisplayNames, agentTags, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, onQuoteNavigate, grouped, insideThreadRoot }) => {
   const { currentUser } = useAuth();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -638,6 +642,7 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
             if (landOnMessage(quoteTargetId as string | number | null | undefined)) return;
             if (quoteTargetId !== undefined && quoteTargetId !== null && typeof window !== 'undefined') {
               window.location.hash = `#message-${quoteTargetId}`;
+              onQuoteNavigate?.(quoteTargetId as string | number);
             }
           };
           return (

--- a/frontend/src/v2/components/V2MessageRow.tsx
+++ b/frontend/src/v2/components/V2MessageRow.tsx
@@ -557,6 +557,7 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
             name={author}
             src={message.user?.profile_picture || undefined}
             size={insideThreadRoot ? 'sm' : 'md'}
+            tone="flat"
             kind={typeof message.user?.isBot === 'boolean' ? (message.user.isBot ? 'agent' : 'human') : undefined}
             seed={message.user_id || undefined}
           />
@@ -566,6 +567,7 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
           name={author}
           src={message.user?.profile_picture || undefined}
           size={insideThreadRoot ? 'sm' : 'md'}
+          tone="flat"
           kind={typeof message.user?.isBot === 'boolean' ? (message.user.isBot ? 'agent' : 'human') : undefined}
           seed={message.user_id || undefined}
         />

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -2,13 +2,14 @@ import React, {
   useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState,
 } from 'react';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import ViewSidebarOutlinedIcon from '@mui/icons-material/ViewSidebarOutlined';
 import V2Avatar from './V2Avatar';
 import V2CatchUpStrip from './V2CatchUpStrip';
 import V2Composer from './V2Composer';
 import { type V2DecisionCardData, type V2DecisionRuling } from './V2DecisionCard';
 import V2ThreadMessages from './V2ThreadMessages';
+import { landOnMessage } from './V2MessageRow';
 import V2ThreadStarter from './V2ThreadStarter';
 import {
   UseV2PodDetailResult,
@@ -158,6 +159,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   } = detail;
   const api = useV2Api();
   const navigate = useNavigate();
+  const location = useLocation();
   const headerMeta = useV2PodHeaderMeta(pod?._id);
   const { socket, connected } = useSocket();
   const { currentUser } = useAuth();
@@ -583,6 +585,18 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   useEffect(() => {
     if (!loading && pod && messages.length === 0) composerInputRef.current?.focus();
   }, [loading, pod?._id, messages.length]);
+  // Landing on a message from Activity / a quote: `#message-<id>` scrolls to the
+  // row and marks it landed. If the row is not in the loaded window yet, the
+  // previous pages load until it is (the `after` cursor is kernel row k4).
+  const landedHashRef = useRef<string | null>(null);
+  useEffect(() => {
+    const hash = location.hash || '';
+    const match = hash.match(/^#message-(.+)$/);
+    if (!match) { landedHashRef.current = null; return; }
+    if (landedHashRef.current === hash) return;
+    if (landOnMessage(match[1])) { landedHashRef.current = hash; return; }
+    if (hasMore && !loadingOlder && !loading) void handleLoadOlder();
+  }, [location.hash, messages, hasMore, loadingOlder, loading, handleLoadOlder]);
 
   // Reaching the top loads the previous page; the edge line is the sentinel.
   useEffect(() => {
@@ -663,6 +677,30 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     const key = agentKeyByAuthorString.get(author.toLowerCase());
     if (key) onOpenMember(key);
   }, [agentKeyByAuthorString, onOpenMember]);
+
+  // Runtime short name per agent author key (direction C, walk-3 miss 51):
+  // the mono tag after the time. Unknown runtime = no tag.
+  const agentTags = React.useMemo(() => {
+    const shortName = (runtimeType?: string): string | null => {
+      switch ((runtimeType || '').toLowerCase()) {
+        case 'codex': return 'codex';
+        case 'claude-code': return 'claude';
+        case 'openclaw': case 'moltbot': return 'openclaw';
+        case 'internal': return 'hosted';
+        case 'webhook': return 'webhook';
+        default: return null;
+      }
+    };
+    const map = new Map<string, string>();
+    (agents || []).forEach((agent) => {
+      const tag = shortName(agent.runtime?.runtimeType || agent.runtime?.wrappedCli);
+      if (!tag) return;
+      const label = agent.profile?.displayName || agent.displayName || agent.agentName;
+      const username = buildAgentUsername(agent.agentName, agent.instanceId || 'default');
+      [label, username, agent.agentName].filter(Boolean).forEach((key) => map.set(String(key).toLowerCase(), tag));
+    });
+    return map;
+  }, [agents]);
 
   const agentAuthorKeys = React.useMemo(
     () => new Set(agentKeyByAuthorString.keys()),
@@ -1086,6 +1124,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           decisionByMessageId={decisionByMessageId}
           settledDecisionByMessageId={settledDecisionByMessageId}
           agentDisplayNames={agentDisplayNames}
+          agentTags={agentTags}
           agentAuthorKeys={agentAuthorKeys}
           onAuthorClick={onOpenMember ? handleAuthorClick : undefined}
           onOpenFile={onOpenFile}
@@ -1268,6 +1307,11 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
                   if (event.key === 'Enter' && !event.shiftKey) {
                     event.preventDefault();
                     void handleSend();
+                  }
+                  if (event.key === 'Escape' && (replyTarget || threadTarget)) {
+                    event.preventDefault();
+                    setReplyTarget(null);
+                    setThreadTarget(null);
                   }
                 }}
                 onMentionSelect={selectMention}

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -589,14 +589,33 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // row and marks it landed. If the row is not in the loaded window yet, the
   // previous pages load until it is (the `after` cursor is kernel row k4).
   const landedHashRef = useRef<string | null>(null);
+  // A target that is loaded but not rendered (collapsed thread, `N more
+  // replies` fold) is REVEALED, not fetched: the transcript opens the thread
+  // and bumps `revealTick` so this effect runs again against the new DOM.
+  const [revealRequest, setRevealRequest] = useState<string | null>(null);
+  const [revealTick, setRevealTick] = useState(0);
+  const revealTriedRef = useRef<string | null>(null);
+  const onRevealed = useCallback((messageId: string, found: boolean) => {
+    setRevealRequest(null);
+    if (found) setRevealTick((tick) => tick + 1);
+    else revealTriedRef.current = `miss:${messageId}`;
+  }, []);
   useEffect(() => {
     const hash = location.hash || '';
     const match = hash.match(/^#message-(.+)$/);
     if (!match) { landedHashRef.current = null; return; }
     if (landedHashRef.current === hash) return;
     if (landOnMessage(match[1])) { landedHashRef.current = hash; return; }
+    const target = match[1];
+    const folded = threadView.some((item) => item.kind === 'card'
+      && (item.rootId === target || item.replies.some((reply) => String(reply.id) === target)));
+    if (folded && revealTriedRef.current !== target) {
+      revealTriedRef.current = target;
+      setRevealRequest(target);
+      return;
+    }
     if (hasMore && !loadingOlder && !loading) void handleLoadOlder();
-  }, [location.hash, messages, hasMore, loadingOlder, loading, handleLoadOlder]);
+  }, [location.hash, messages, threadView, revealTick, hasMore, loadingOlder, loading, handleLoadOlder]);
 
   // Reaching the top loads the previous page; the edge line is the sentinel.
   useEffect(() => {
@@ -1121,6 +1140,8 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           messages={messages}
           threadView={threadView}
           threadState={threadState}
+          revealMessageId={revealRequest}
+          onRevealed={onRevealed}
           decisionByMessageId={decisionByMessageId}
           settledDecisionByMessageId={settledDecisionByMessageId}
           agentDisplayNames={agentDisplayNames}

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -24,7 +24,7 @@ import type { V2InviteTab } from './V2InviteModal';
 
 import { useV2ThreadState } from '../hooks/useV2ThreadState';
 import { useV2ThreadMentions } from '../hooks/useV2ThreadMentions';
-import { buildThreadView } from '../utils/threadView';
+import { buildThreadView, freezeOrphanReplyIds } from '../utils/threadView';
 import { agentKeyFor } from '../utils/agentKey';
 import {
   buildAgentUsername,
@@ -234,10 +234,17 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // Memoized: it was called in the render body, so every keystroke in the
   // composer re-folded the whole message list. @sprint-review on #1150.
   // Recomputes only when the messages or the thread state actually change.
-  const threadView = useMemo(
-    () => buildThreadView(messages, threadState.byRoot),
-    [messages, threadState.byRoot],
-  );
+  const flatReplyIdsRef = useRef<{ podId: string | null; ids: Set<string> }>({ podId: null, ids: new Set() });
+  const threadView = useMemo(() => {
+    const podId = pod?._id || null;
+    if (flatReplyIdsRef.current.podId !== podId) {
+      flatReplyIdsRef.current = { podId, ids: new Set() };
+    }
+    // A reply visible flat before its root arrived must stay flat. Otherwise
+    // prepending an older page relocates it into a resting thread chip.
+    flatReplyIdsRef.current.ids = freezeOrphanReplyIds(messages, flatReplyIdsRef.current.ids);
+    return buildThreadView(messages, threadState.byRoot, flatReplyIdsRef.current.ids);
+  }, [messages, pod?._id, threadState.byRoot]);
 
   // #891 surface 1: agent reachability at the moment of composing a mention.
   // Best-effort — a failed read renders nothing rather than something wrong,
@@ -595,6 +602,14 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   const [revealRequest, setRevealRequest] = useState<string | null>(null);
   const [revealTick, setRevealTick] = useState(0);
   const revealTriedRef = useRef<string | null>(null);
+  const onQuoteNavigate = useCallback((_messageId: string | number) => {
+    // A repeated quote can have the same hash after the user collapsed the
+    // thread. Clear the landing guards and bump the effect so this gesture
+    // reopens the fold instead of being treated as an already-landed hash.
+    landedHashRef.current = null;
+    revealTriedRef.current = null;
+    setRevealTick((tick) => tick + 1);
+  }, []);
   const onRevealed = useCallback((messageId: string, found: boolean) => {
     setRevealRequest(null);
     if (found) setRevealTick((tick) => tick + 1);
@@ -1151,6 +1166,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           onOpenFile={onOpenFile}
           onReply={isReadOnly ? undefined : aimAtMessage}
           onThread={isReadOnly ? undefined : aimAtMessageThread}
+          onQuoteNavigate={onQuoteNavigate}
           onDecisionRuled={handleDecisionRuled}
           onAimAtThread={aimAtThread}
           hasMore={hasMore}

--- a/frontend/src/v2/components/V2ThreadCard.tsx
+++ b/frontend/src/v2/components/V2ThreadCard.tsx
@@ -1,25 +1,18 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import V2Avatar from './V2Avatar';
 import { shortTimeSince } from '../utils/shortTime';
 
 /**
- * The thread summary chip (direction C, walk-3 miss 54).
+ * The thread chip (direction C, Thread states board — @ux-lead 64476).
  *
- * Sits directly under its root message and renders INSTEAD of that root's
- * replies while collapsed: overlapping 16px face squares, `N replies` in
- * cobalt, `· last <age>` in muted mono. No chevron at rest, no separate reply
- * button in the chip, no accent dot unless something in the thread addresses
- * me — the card is a door and not a preview.
+ * Renders under its root while the thread is collapsed: up to three 16px
+ * faces, `N replies` and `· last <age>` — and nothing else. No chevron, no
+ * reply button, no follow toggle: those live in the expanded band's foot
+ * (V2ThreadMessages). The chip is a door, not a preview — no reply bodies,
+ * no names.
  *
- * `collapsed` is a prop, never derived here. It arrives already resolved from
- * the payload (#1145, @ux-lead 56996): a client that computed it would need
- * the threading cutoff, which is the migration detail that ruling removed from
- * the wire.
- *
- * `following` is the raw tri-state and renders three labels. Null is NOT
- * "not following" — it means the server will decide from participation — so it
- * reads "Follow" (an invitation) rather than "Muted" (a state). Shown expanded.
+ * `collapsed` is a prop, never derived here; the resting state is the chip
+ * and V2ThreadMessages owns which roots are open.
  */
 export interface V2ThreadParticipant {
   userId: string;
@@ -33,44 +26,24 @@ interface V2ThreadCardProps {
   participants: V2ThreadParticipant[];
   lastActivityAt?: string | null;
   collapsed: boolean;
-  following: boolean | null;
-  /** An item in this thread addresses me. The chip's only use of accent beyond the count. */
+  /** An item in this thread addresses me. The card's only use of accent. */
   addressed?: boolean;
   onToggleCollapsed: () => void;
-  onToggleFollowing: () => void;
-  /** Aim the composer at this card's root without first opening the rail. */
-  onReplyInThread?: () => void;
   /** Injected in tests so the stamp is about boundaries, not about the clock. */
   now?: Date;
 }
 
 const MAX_AVATARS = 3;
 
-const followLabel = (following: boolean | null): string => {
-  if (following === true) return 'Following';
-  if (following === false) return 'Muted';
-  return 'Follow';
-};
-
-const followClass = (following: boolean | null): string => {
-  if (following === true) return 'v2-thread-card__follow v2-thread-card__follow--on';
-  if (following === false) return 'v2-thread-card__follow v2-thread-card__follow--muted';
-  return 'v2-thread-card__follow';
-};
-
 const V2ThreadCard: React.FC<V2ThreadCardProps> = ({
   replyCount,
   participants,
   lastActivityAt,
   collapsed,
-  following,
   addressed = false,
   onToggleCollapsed,
-  onToggleFollowing,
-  onReplyInThread,
   now,
 }) => {
-  const { t } = useTranslation();
   const shown = participants.slice(0, MAX_AVATARS);
   const stamp = shortTimeSince(lastActivityAt, now);
   const countLabel = `${replyCount} ${replyCount === 1 ? 'reply' : 'replies'}`;
@@ -85,8 +58,7 @@ const V2ThreadCard: React.FC<V2ThreadCardProps> = ({
         className="v2-thread-card__main v2-msg__thread-chip"
         onClick={onToggleCollapsed}
         aria-expanded={!collapsed}
-        // The accessible name carries the state, because the visual cue for it
-        // is a small chevron and a rotation is not announced.
+        // The accessible name carries the state — there is no visual cue for it.
         aria-label={`${collapsed ? 'Expand' : 'Collapse'} thread, ${countLabel}`}
       >
         {shown.length > 0 && (
@@ -97,6 +69,7 @@ const V2ThreadCard: React.FC<V2ThreadCardProps> = ({
                 name={p.name}
                 src={p.avatarUrl || undefined}
                 size="sm"
+                tone="flat"
                 kind={typeof p.isBot === 'boolean' ? (p.isBot ? 'agent' : 'human') : undefined}
                 seed={p.userId}
               />
@@ -107,33 +80,8 @@ const V2ThreadCard: React.FC<V2ThreadCardProps> = ({
           {addressed && <span className="v2-thread-card__dot" aria-hidden="true" />}
           {countLabel}
         </span>
-        {stamp && <span className="v2-thread-card__time">· {t('podChat.thread.last')} {stamp}</span>}
-        {!collapsed && <span className="v2-thread-card__chevron" aria-hidden="true">⌄</span>}
+        {stamp && <span className="v2-thread-card__time">· last {stamp}</span>}
       </button>
-
-      {onReplyInThread && (
-        <button
-          type="button"
-          className="v2-thread-card__reply"
-          onClick={onReplyInThread}
-        >
-          {t('podChat.thread.replyInThread')}
-        </button>
-      )}
-
-      {/* Follow lives outside the expand button: nesting a control inside a
-          control is invalid, and a mis-hit that silently muted a thread is the
-          expensive direction. Only shown expanded, per the brief. */}
-      {!collapsed && (
-        <button
-          type="button"
-          className={followClass(following)}
-          onClick={onToggleFollowing}
-          aria-pressed={following === true}
-        >
-          {followLabel(following)}
-        </button>
-      )}
     </div>
   );
 };

--- a/frontend/src/v2/components/V2ThreadCard.tsx
+++ b/frontend/src/v2/components/V2ThreadCard.tsx
@@ -4,22 +4,22 @@ import V2Avatar from './V2Avatar';
 import { shortTimeSince } from '../utils/shortTime';
 
 /**
- * The thread headline card (W-T, TASK-029 4/4) — @ux-lead's render brief.
+ * The thread summary chip (direction C, walk-3 miss 54).
  *
- * Sits directly under its root message, in the channel column, and renders
- * INSTEAD of that root's replies while collapsed. Content is count, up to
- * three participant avatars, and a short last-activity stamp — deliberately no
- * reply bodies and no names, so the card is a door and not a preview.
+ * Sits directly under its root message and renders INSTEAD of that root's
+ * replies while collapsed: overlapping 16px face squares, `N replies` in
+ * cobalt, `· last <age>` in muted mono. No chevron at rest, no separate reply
+ * button in the chip, no accent dot unless something in the thread addresses
+ * me — the card is a door and not a preview.
  *
  * `collapsed` is a prop, never derived here. It arrives already resolved from
  * the payload (#1145, @ux-lead 56996): a client that computed it would need
  * the threading cutoff, which is the migration detail that ruling removed from
- * the wire. If you find yourself wanting a date comparison in this file, the
- * bug is upstream.
+ * the wire.
  *
  * `following` is the raw tri-state and renders three labels. Null is NOT
  * "not following" — it means the server will decide from participation — so it
- * reads "Follow" (an invitation) rather than "Muted" (a state).
+ * reads "Follow" (an invitation) rather than "Muted" (a state). Shown expanded.
  */
 export interface V2ThreadParticipant {
   userId: string;
@@ -34,7 +34,7 @@ interface V2ThreadCardProps {
   lastActivityAt?: string | null;
   collapsed: boolean;
   following: boolean | null;
-  /** An item in this thread addresses me. The card's only use of accent. */
+  /** An item in this thread addresses me. The chip's only use of accent beyond the count. */
   addressed?: boolean;
   onToggleCollapsed: () => void;
   onToggleFollowing: () => void;
@@ -82,17 +82,13 @@ const V2ThreadCard: React.FC<V2ThreadCardProps> = ({
     >
       <button
         type="button"
-        className="v2-thread-card__main"
+        className="v2-thread-card__main v2-msg__thread-chip"
         onClick={onToggleCollapsed}
         aria-expanded={!collapsed}
         // The accessible name carries the state, because the visual cue for it
-        // is a rotated chevron and a rotation is not announced.
+        // is a small chevron and a rotation is not announced.
         aria-label={`${collapsed ? 'Expand' : 'Collapse'} thread, ${countLabel}`}
       >
-        <span className="v2-thread-card__count">
-          {addressed && <span className="v2-thread-card__dot" aria-hidden="true" />}
-          {countLabel}
-        </span>
         {shown.length > 0 && (
           <span className="v2-thread-card__faces" aria-hidden="true">
             {shown.map((p) => (
@@ -107,7 +103,11 @@ const V2ThreadCard: React.FC<V2ThreadCardProps> = ({
             ))}
           </span>
         )}
-        {stamp && <span className="v2-thread-card__time">{stamp}</span>}
+        <span className="v2-thread-card__count">
+          {addressed && <span className="v2-thread-card__dot" aria-hidden="true" />}
+          {countLabel}
+        </span>
+        {stamp && <span className="v2-thread-card__time">· {t('podChat.thread.last')} {stamp}</span>}
         {!collapsed && <span className="v2-thread-card__chevron" aria-hidden="true">⌄</span>}
       </button>
 

--- a/frontend/src/v2/components/V2ThreadMessages.tsx
+++ b/frontend/src/v2/components/V2ThreadMessages.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { V2Message } from '../hooks/useV2PodDetail';
 import { UseV2ThreadState } from '../hooks/useV2ThreadState';
@@ -8,6 +8,9 @@ import V2MessageRow from './V2MessageRow';
 import V2ThreadCard from './V2ThreadCard';
 import { V2DecisionCardData, V2DecisionRuling } from './V2DecisionCard';
 
+// Expanded threads show the newest eight; a `N more replies` line reveals the rest.
+const MAX_EXPANDED_REPLIES = 8;
+
 interface V2ThreadMessagesProps {
   messages: V2Message[];
   threadView: ThreadViewItem[];
@@ -15,6 +18,7 @@ interface V2ThreadMessagesProps {
   decisionByMessageId: Map<string, V2DecisionCardData>;
   settledDecisionByMessageId: Map<string, V2DecisionRuling>;
   agentDisplayNames: Map<string, string>;
+  agentTags?: Map<string, string>;
   agentAuthorKeys: Set<string>;
   onAuthorClick?: (author: string) => void;
   onOpenFile?: (fileName: string) => void;
@@ -54,6 +58,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
   decisionByMessageId,
   settledDecisionByMessageId,
   agentDisplayNames,
+  agentTags,
   agentAuthorKeys,
   onAuthorClick,
   onOpenFile,
@@ -77,6 +82,9 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
   messagesEndRef,
 }) => {
   const { t } = useTranslation();
+  // Expanded threads show the newest MAX_EXPANDED_REPLIES; "N more replies"
+  // reveals the rest for that root (walk-3 §3).
+  const [expandedAll, setExpandedAll] = useState<Set<string>>(() => new Set());
 
   const rootPreview = (rootId: string): string => String(
     messages.find((message) => String(message.id) === rootId)?.content || '',
@@ -136,6 +144,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
                 isDecisionRuling={Boolean(settledRuling)}
                 onDecisionRuled={onDecisionRuled}
                 agentDisplayNames={agentDisplayNames}
+                agentTags={agentTags}
                 agentAuthorKeys={agentAuthorKeys}
                 onAuthorClick={onAuthorClick}
                 onOpenFile={onOpenFile}
@@ -166,8 +175,12 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
         if (settledDecisionByMessageId.has(item.rootId)) return null;
         // A missing state row is not permission to invent a collapsed thread.
         const collapsed = state ? state.collapsed : false;
+        const shownReplies = collapsed || expandedAll.has(item.rootId) || item.replies.length <= MAX_EXPANDED_REPLIES
+          ? item.replies
+          : item.replies.slice(item.replies.length - MAX_EXPANDED_REPLIES);
+        const hiddenReplies = item.replies.length - shownReplies.length;
         return (
-          <div className="v2-thread-block" key={`thread-${item.rootId}`}>
+          <div className={`v2-thread-block${collapsed ? '' : ' v2-thread-block--open'}`} key={`thread-${item.rootId}`}>
             <V2ThreadCard
               replyCount={item.replyCount}
               participants={item.participants}
@@ -180,32 +193,44 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
             />
             {!collapsed && (
               <div className="v2-thread-replies">
-                {item.replies.map((reply, replyIndex) => (
+                {hiddenReplies > 0 && (
+                  <button type="button" className="v2-thread-replies__more" onClick={() => setExpandedAll((current) => new Set(current).add(item.rootId))}>
+                    {t('podChat.thread.moreReplies', { count: hiddenReplies })}
+                  </button>
+                )}
+                {shownReplies.map((reply, replyIndex) => (
                   <V2MessageRow
                     key={reply.id}
                     message={reply}
                     decision={decisionByMessageId.get(String(reply.id))}
                     onDecisionRuled={onDecisionRuled}
                     agentDisplayNames={agentDisplayNames}
+                    agentTags={agentTags}
                     agentAuthorKeys={agentAuthorKeys}
                     onAuthorClick={onAuthorClick}
                     onOpenFile={onOpenFile}
                     onReply={onReply}
                     onThread={onThread}
-                    grouped={isGroupedWithPrevious(reply, item.replies[replyIndex - 1])}
+                    grouped={isGroupedWithPrevious(reply, shownReplies[replyIndex - 1])}
                     insideThreadRoot={item.rootId}
                   />
                 ))}
-                {onReply && (
-                  <button
-                    type="button"
-                    className="v2-thread-replies__aim"
-                    aria-label={t('podChat.thread.replyFromExpandedThread')}
-                    onClick={() => onAimAtThread(item.rootId, rootPreview(item.rootId))}
-                  >
-                    {t('podChat.thread.replyInThread')}
+                <div className="v2-thread-replies__foot">
+                  <button type="button" className="v2-thread-replies__collapse" onClick={() => threadState.toggleCollapsed(item.rootId)}>
+                    {t('podChat.thread.collapse')}
                   </button>
-                )}
+                  <span className="v2-thread-replies__count">{item.replyCount} {item.replyCount === 1 ? t('podChat.thread.replyOne') : t('podChat.thread.replyOther')}</span>
+                  {onReply && (
+                    <button
+                      type="button"
+                      className="v2-thread-replies__aim"
+                      aria-label={t('podChat.thread.replyFromExpandedThread')}
+                      onClick={() => onAimAtThread(item.rootId, rootPreview(item.rootId))}
+                    >
+                      {t('podChat.thread.replyInThread')}
+                    </button>
+                  )}
+                </div>
               </div>
             )}
           </div>

--- a/frontend/src/v2/components/V2ThreadMessages.tsx
+++ b/frontend/src/v2/components/V2ThreadMessages.tsx
@@ -24,6 +24,7 @@ interface V2ThreadMessagesProps {
   onOpenFile?: (fileName: string) => void;
   onReply?: (message: V2Message) => void;
   onThread?: (message: V2Message) => void;
+  onQuoteNavigate?: (messageId: string | number) => void;
   onDecisionRuled?: (decisionId: string, ruling: V2DecisionRuling) => void;
   onAimAtThread: (rootId: string, preview: string) => void;
   hasMore: boolean;
@@ -73,6 +74,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
   onOpenFile,
   onReply,
   onThread,
+  onQuoteNavigate,
   onDecisionRuled,
   onAimAtThread,
   hasMore,
@@ -186,6 +188,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
                 onOpenFile={onOpenFile}
                 onReply={onReply}
                 onThread={onThread}
+                onQuoteNavigate={onQuoteNavigate}
                 grouped={isGroupedWithPrevious(
                   message,
                   previous && previous.kind === 'message' ? previous.message : undefined,
@@ -262,6 +265,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
                     onOpenFile={onOpenFile}
                     onReply={onReply}
                     onThread={onThread}
+                    onQuoteNavigate={onQuoteNavigate}
                     grouped={isGroupedWithPrevious(reply, shownReplies[replyIndex - 1])}
                     insideThreadRoot={item.rootId}
                   />

--- a/frontend/src/v2/components/V2ThreadMessages.tsx
+++ b/frontend/src/v2/components/V2ThreadMessages.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { V2Message } from '../hooks/useV2PodDetail';
 import { UseV2ThreadState } from '../hooks/useV2ThreadState';
@@ -14,7 +14,7 @@ const MAX_EXPANDED_REPLIES = 8;
 interface V2ThreadMessagesProps {
   messages: V2Message[];
   threadView: ThreadViewItem[];
-  threadState: Pick<UseV2ThreadState, 'byRoot' | 'toggleCollapsed' | 'toggleFollowing'>;
+  threadState: Pick<UseV2ThreadState, 'byRoot' | 'toggleCollapsed' | 'toggleFollowing'> & Partial<Pick<UseV2ThreadState, 'setCollapsed'>>;
   decisionByMessageId: Map<string, V2DecisionCardData>;
   settledDecisionByMessageId: Map<string, V2DecisionRuling>;
   agentDisplayNames: Map<string, string>;
@@ -37,6 +37,15 @@ interface V2ThreadMessagesProps {
   // Mount the pill once the reader is a viewport up, even before arrivals.
   showJump?: boolean;
   onJump?: () => void;
+  /**
+   * A message id the reader is landing on (quote link, Activity) that is not
+   * in the DOM because its thread is collapsed or folded behind `N more
+   * replies`. The transcript opens that thread in full and reports back, so
+   * the landing effect can re-run — a reveal, never a history fetch
+   * (sprint-review 64477).
+   */
+  revealMessageId?: string | null;
+  onRevealed?: (messageId: string, found: boolean) => void;
   loading: boolean;
   error: string | null;
   starterPanel?: React.ReactNode;
@@ -73,6 +82,8 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
   jumpCount = 0,
   showJump = false,
   onJump,
+  revealMessageId,
+  onRevealed,
   loading,
   error,
   starterPanel,
@@ -85,6 +96,33 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
   // Expanded threads show the newest MAX_EXPANDED_REPLIES; "N more replies"
   // reveals the rest for that root (walk-3 §3).
   const [expandedAll, setExpandedAll] = useState<Set<string>>(() => new Set());
+  // The resting state of a thread is the chip (ux-lead 64476 (4)). Which
+  // roots are open is a session gesture held here; the server `collapsed`
+  // row is written to match on each open/close (it still drives the wake
+  // path), but a fresh mount always shows chips.
+  const [openRoots, setOpenRoots] = useState<Set<string>>(() => new Set());
+  const setOpen = useCallback((rootId: string, open: boolean) => {
+    setOpenRoots((current) => {
+      const next = new Set(current);
+      if (open) next.add(rootId); else next.delete(rootId);
+      return next;
+    });
+    threadState.setCollapsed?.(rootId, !open);
+  }, [threadState]);
+
+  // Landing on a folded reply: open its thread, drop the `N more replies`
+  // fold, then tell the caller so it can land on the now-rendered row.
+  useEffect(() => {
+    if (!revealMessageId) return;
+    const target = String(revealMessageId);
+    const owner = threadView.find((item) => item.kind === 'card'
+      && (item.rootId === target || item.replies.some((reply) => String(reply.id) === target)));
+    if (owner && owner.kind === 'card') {
+      setOpenRoots((current) => (current.has(owner.rootId) ? current : new Set(current).add(owner.rootId)));
+      setExpandedAll((current) => (current.has(owner.rootId) ? current : new Set(current).add(owner.rootId)));
+    }
+    onRevealed?.(target, Boolean(owner));
+  }, [revealMessageId, threadView, onRevealed]);
 
   const rootPreview = (rootId: string): string => String(
     messages.find((message) => String(message.id) === rootId)?.content || '',
@@ -132,9 +170,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
       {starterPanel}
       {emptyState}
       {threadView.map((item, index, view) => {
-        if (item.kind === 'message') {
-          const message = item.message;
-          const previous = view[index - 1];
+        const renderMessage = (message: V2Message, previous: ThreadViewItem | undefined) => {
           const settledRuling = settledDecisionByMessageId.get(String(message.id));
           return (
             <React.Fragment key={message.id}>
@@ -166,6 +202,15 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
               )}
             </React.Fragment>
           );
+        };
+
+        if (item.kind === 'message') {
+          const next = view[index + 1];
+          // A root with a live thread renders INSIDE its band (below), so the
+          // root and its replies share one surface — ux-lead 64476 (2).
+          if (next && next.kind === 'card' && next.rootId === String(item.message.id)
+            && !settledDecisionByMessageId.has(next.rootId)) return null;
+          return renderMessage(item.message, view[index - 1]);
         }
 
         const state = threadState.byRoot.get(item.rootId);
@@ -173,24 +218,30 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
         // in the flat transcript above. Its durable reply remains in the
         // server list, but rendering both would show the same pick twice.
         if (settledDecisionByMessageId.has(item.rootId)) return null;
-        // A missing state row is not permission to invent a collapsed thread.
-        const collapsed = state ? state.collapsed : false;
+        const rootItem = view[index - 1];
+        const rootMessage = rootItem && rootItem.kind === 'message' && String(rootItem.message.id) === item.rootId
+          ? rootItem.message
+          : messages.find((message) => String(message.id) === item.rootId);
+        const collapsed = !openRoots.has(item.rootId);
         const shownReplies = collapsed || expandedAll.has(item.rootId) || item.replies.length <= MAX_EXPANDED_REPLIES
           ? item.replies
           : item.replies.slice(item.replies.length - MAX_EXPANDED_REPLIES);
         const hiddenReplies = item.replies.length - shownReplies.length;
+        const following = state ? state.following : null;
+        const followLabel = following === true ? t('podChat.thread.following') : following === false ? t('podChat.thread.muted') : t('podChat.thread.follow');
         return (
           <div className={`v2-thread-block${collapsed ? '' : ' v2-thread-block--open'}`} key={`thread-${item.rootId}`}>
-            <V2ThreadCard
-              replyCount={item.replyCount}
-              participants={item.participants}
-              lastActivityAt={item.lastActivityAt}
-              collapsed={collapsed}
-              following={state ? state.following : null}
-              onToggleCollapsed={() => threadState.toggleCollapsed(item.rootId)}
-              onToggleFollowing={() => threadState.toggleFollowing(item.rootId)}
-              onReplyInThread={onReply ? () => onAimAtThread(item.rootId, rootPreview(item.rootId)) : undefined}
-            />
+            {rootMessage && renderMessage(rootMessage, view[index - 2])}
+            <div className="v2-thread-block__inner">
+            {collapsed && (
+              <V2ThreadCard
+                replyCount={item.replyCount}
+                participants={item.participants}
+                lastActivityAt={item.lastActivityAt}
+                collapsed
+                onToggleCollapsed={() => setOpen(item.rootId, true)}
+              />
+            )}
             {!collapsed && (
               <div className="v2-thread-replies">
                 {hiddenReplies > 0 && (
@@ -216,7 +267,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
                   />
                 ))}
                 <div className="v2-thread-replies__foot">
-                  <button type="button" className="v2-thread-replies__collapse" onClick={() => threadState.toggleCollapsed(item.rootId)}>
+                  <button type="button" className="v2-thread-replies__collapse" onClick={() => setOpen(item.rootId, false)}>
                     {t('podChat.thread.collapse')}
                   </button>
                   <span className="v2-thread-replies__count">{item.replyCount} {item.replyCount === 1 ? t('podChat.thread.replyOne') : t('podChat.thread.replyOther')}</span>
@@ -230,9 +281,18 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
                       {t('podChat.thread.replyInThread')}
                     </button>
                   )}
+                  <button
+                    type="button"
+                    className={`v2-thread-replies__follow${following === true ? ' v2-thread-replies__follow--on' : ''}${following === false ? ' v2-thread-replies__follow--muted' : ''}`}
+                    aria-pressed={following === true}
+                    onClick={() => threadState.toggleFollowing(item.rootId)}
+                  >
+                    {followLabel}
+                  </button>
                 </div>
               </div>
             )}
+            </div>
           </div>
         );
       })}

--- a/frontend/src/v2/hooks/useV2ThreadState.ts
+++ b/frontend/src/v2/hooks/useV2ThreadState.ts
@@ -35,6 +35,13 @@ export interface UseV2ThreadState {
   /** Roots the server told us about — a message not in here is not a thread. */
   isThreadRoot: (messageId: string) => boolean;
   toggleCollapsed: (messageId: string) => void;
+  /**
+   * Write an explicit collapsed value. The transcript's resting state is the
+   * chip (ux-lead 64476): every thread mounts collapsed and opening is a
+   * session gesture, so the server row is brought to the visible state on
+   * each open/close rather than blindly flipped.
+   */
+  setCollapsed: (messageId: string, collapsed: boolean) => void;
   toggleFollowing: (messageId: string) => void;
 }
 
@@ -92,6 +99,14 @@ export const useV2ThreadState = (podId: string | undefined): UseV2ThreadState =>
       .catch(() => patch(messageId, { collapsed: row.collapsed }));
   }, [api, byRoot, patch]);
 
+  const setCollapsed = useCallback((messageId: string, collapsed: boolean) => {
+    const row = byRoot.get(key(messageId));
+    if (!row || row.collapsed === collapsed) return;
+    patch(messageId, { collapsed });
+    api.put(`/api/messages/${messageId}/collapsed`, { collapsed })
+      .catch(() => patch(messageId, { collapsed: row.collapsed }));
+  }, [api, byRoot, patch]);
+
   const toggleFollowing = useCallback((messageId: string) => {
     const row = byRoot.get(key(messageId));
     if (!row) return;
@@ -111,8 +126,8 @@ export const useV2ThreadState = (podId: string | undefined): UseV2ThreadState =>
   );
 
   return useMemo(
-    () => ({ byRoot, loading, isThreadRoot, toggleCollapsed, toggleFollowing }),
-    [byRoot, loading, isThreadRoot, toggleCollapsed, toggleFollowing],
+    () => ({ byRoot, loading, isThreadRoot, toggleCollapsed, setCollapsed, toggleFollowing }),
+    [byRoot, loading, isThreadRoot, toggleCollapsed, setCollapsed, toggleFollowing],
   );
 };
 

--- a/frontend/src/v2/utils/threadView.ts
+++ b/frontend/src/v2/utils/threadView.ts
@@ -27,6 +27,24 @@ const rootOf = (m: V2Message): string | null => (
 );
 const whenOf = (m: V2Message): string => String(m.created_at || m.createdAt || '');
 
+/**
+ * Keep replies that were visible before their root arrived flat for the life
+ * of this transcript. A history prepend can otherwise make the same reply
+ * move into a resting thread chip and disappear from the reader's viewport.
+ */
+export const freezeOrphanReplyIds = (
+  messages: V2Message[],
+  frozen: ReadonlySet<string> = new Set(),
+): Set<string> => {
+  const next = new Set(frozen);
+  const presentIds = new Set(messages.map(idOf));
+  for (const message of messages) {
+    const root = rootOf(message);
+    if (root && !presentIds.has(root)) next.add(idOf(message));
+  }
+  return next;
+};
+
 const participantOf = (m: V2Message): V2ThreadParticipant => {
   const uid = String(m.user_id || '');
   const nested = typeof m.userId === 'object' && m.userId ? m.userId : undefined;
@@ -41,6 +59,7 @@ const participantOf = (m: V2Message): V2ThreadParticipant => {
 export const buildThreadView = (
   messages: V2Message[],
   byRoot: Map<string, V2ThreadState>,
+  flatIds: ReadonlySet<string> = new Set(),
 ): ThreadViewItem[] => {
   // Ids up front. This used to be `messages.some(...)` inside the loop below,
   // which is O(n²) on a pod's whole scrollback — fine at 20 messages and not
@@ -51,6 +70,7 @@ export const buildThreadView = (
   for (const m of messages) {
     const root = rootOf(m);
     if (!root) continue;
+    if (flatIds.has(idOf(m))) continue;
     // A message whose root is not in this list (paged out, or deleted) is NOT
     // hidden. It renders flat rather than vanishing — losing a message is the
     // one outcome worse than showing it in the wrong place.
@@ -63,7 +83,7 @@ export const buildThreadView = (
   const out: ThreadViewItem[] = [];
   for (const m of messages) {
     const root = rootOf(m);
-    if (root && repliesByRoot.has(root)) continue; // rendered under its card
+    if (root && repliesByRoot.has(root) && !flatIds.has(idOf(m))) continue; // rendered under its card
 
     out.push({ kind: 'message', message: m });
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -11230,7 +11230,7 @@ body.modern-ui.v2-canvas {
   top: -14px;
   right: 0;
   gap: 2px;
-  padding: 2px;
+  padding: 1px;
   border: 1px solid var(--v2-border-soft);
   border-radius: 4px;
   box-shadow: none;
@@ -11278,7 +11278,7 @@ body.modern-ui.v2-canvas {
   font: 600 13px/18px var(--v2-font);
 }
 .v2-root .v2-thread button.v2-msg__thread-chip:hover { background: var(--v2-surface-hover); border-color: var(--v2-border); }
-.v2-thread .v2-thread-card__faces .v2-avatar { width: 16px; height: 16px; border-radius: 4px; border: 1px solid var(--v2-surface); font-size: 8px; }
+.v2-thread .v2-thread-card__faces .v2-avatar { width: 16px; height: 16px; border-radius: 4px; border: 1px solid var(--v2-surface); font: 650 11px/1 var(--v2-font-mono); }
 .v2-thread .v2-thread-card__faces > * + * { margin-left: -4px; }
 .v2-thread .v2-thread-card__count { color: var(--v2-accent-text); font-weight: 600; }
 .v2-thread .v2-thread-card__time { color: var(--v2-text-muted); font: 400 11px/16px var(--v2-font-mono); }
@@ -11295,7 +11295,7 @@ body.modern-ui.v2-canvas {
 .v2-thread .v2-thread-replies { margin: 6px 0 0; padding-left: 14px; border-left: 2px solid var(--v2-border); }
 .v2-thread .v2-thread-replies .v2-msg { grid-template-columns: 24px minmax(0, 1fr); gap: 8px; padding: 4px 0; }
 .v2-thread .v2-thread-replies .v2-msg:hover { background: transparent; }
-.v2-thread .v2-thread-replies .v2-msg .v2-avatar { width: 24px; height: 24px; font-size: 9px; }
+.v2-thread .v2-thread-replies .v2-msg .v2-avatar { width: 24px; height: 24px; font-size: 12px; }
 .v2-thread-replies__foot {
   display: flex;
   align-items: center;
@@ -11330,11 +11330,11 @@ body.modern-ui.v2-canvas {
 
 /* Transcript avatars are two-tone squares (ux-lead 64476 (1)): human tint +
    #4f5c6e initials, agent cobalt + white initials; a photo still wins. */
-.v2-thread .v2-avatar--flat { border: 0; box-shadow: none; border-radius: 4px; font: 650 11px/1 var(--v2-font); letter-spacing: 0.02em; }
+.v2-thread .v2-avatar--flat { border: 0; box-shadow: none; border-radius: 4px; font: 650 12px/1 var(--v2-font); letter-spacing: 0.02em; }
 .v2-thread .v2-avatar--flat-human { background: #f2f4f7; color: #4f5c6e; }
 .v2-thread .v2-avatar--flat-agent { background: var(--v2-accent); color: #fff; }
-.v2-thread .v2-thread-replies .v2-msg .v2-avatar--flat { font-size: 9px; }
-.v2-thread .v2-thread-card__faces .v2-avatar--flat { font-size: 7px; }
+.v2-thread .v2-thread-replies .v2-msg .v2-avatar--flat { font: 650 12px/1 var(--v2-font); }
+.v2-thread .v2-thread-card__faces .v2-avatar--flat { font: 650 11px/1 var(--v2-font-mono); }
 .v2-root .v2-thread button.v2-thread-replies__aim { margin-left: auto; padding: 0; color: var(--v2-text-muted); font: 500 12px/16px var(--v2-font); }
 
 /* Jump pill: white, #dde0e6 border, r14, ink 13/600, cobalt count (walk-3 miss 58). */
@@ -11369,7 +11369,7 @@ body.modern-ui.v2-canvas {
 
 @media (max-width: 760px) {
   /* Sizing is a width question, not a capability one. */
-  .v2-root .v2-thread button.v2-msg__action { width: 28px; height: 28px; }
+  .v2-root .v2-thread button.v2-msg__action { width: 24px; height: 24px; }
   .v2-root .v2-thread button.v2-msg__thread-chip { min-height: 32px; }
   .v2-thread .v2-msg__gutter-time { display: none; }
 }

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8462,21 +8462,7 @@ body.modern-ui.v2-canvas {
 
 /* This is deliberately outside the expand button: it must aim the composer
    without toggling the rail, and nested controls are invalid HTML. */
-.v2-root button.v2-thread-card__reply {
-  min-height: 44px;
-  padding: 6px 10px;
-  border: none;
-  border-radius: 8px;
-  background: transparent;
-  color: #7b8494;
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
-}
 
-.v2-root button.v2-thread-card__reply:hover {
-  background: var(--v2-surface-hover);
-}
 
 .v2-thread-card__count {
   font-weight: 500;
@@ -8512,25 +8498,8 @@ body.modern-ui.v2-canvas {
   color: #7b8494;
 }
 
-.v2-thread-card__chevron {
-  transform: rotate(180deg);
-  transition: transform 300ms ease;
-  line-height: 1;
-}
 
-.v2-root button.v2-thread-card__follow {
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  font-size: 12px;
-  color: #7b8494; /* tertiary — the null "Follow" and the false "Muted" */
-  padding: 4px 6px;
-}
 
-.v2-root button.v2-thread-card__follow--on {
-  background: var(--v2-ink);
-  color: var(--v2-on-ink);
-}
 
 /* Expanded replies hang off a left rail at the thread block's own edge.
    The rail used to aim at the root avatar's centre (margin-left 14, rev 2);
@@ -8624,12 +8593,17 @@ body.modern-ui.v2-canvas {
     flex-wrap: wrap;
   }
 
+  /* Reply in thread / Follow / Collapse left the chip for the band's foot
+     (ux-lead 64476 (3)); the 44px touch floor follows them. */
+  .v2-root .v2-thread-replies__foot button {
+    min-height: 44px;
+  }
+
   /* The block's 50px attachment indent is expensive at 390 — tighten it,
      but keep the rail on the block edge (aligned with the card), and the
      inner padding tightens with it. */
-  .v2-thread-block {
+  .v2-thread-block__inner {
     margin-left: 24px;
-    width: calc(100% - 24px); /* same indent+width=100% invariant as desktop */
   }
 
   .v2-thread-replies {
@@ -9407,7 +9381,6 @@ body.modern-ui.v2-canvas {
 
 @media (prefers-reduced-motion: reduce) {
   .v2-root button.v2-thread-card__main,
-  .v2-thread-card__chevron,
   .v2-thread-replies {
     transition: none;
   }
@@ -11206,7 +11179,6 @@ body.modern-ui.v2-canvas {
 .v2-thread .v2-msg--grouped:hover .v2-msg__gutter-time { visibility: visible; }
 
 /* Two-tone avatars inside the transcript: agents cobalt, humans tint. */
-.v2-thread .v2-msg--agent .v2-avatar:not(.v2-avatar--photo) { background: var(--v2-accent); color: #fff; }
 
 /* Quote: 2px rule, two lines, jumps to the source. */
 .v2-thread .v2-msg__quote {
@@ -11310,12 +11282,16 @@ body.modern-ui.v2-canvas {
 .v2-thread .v2-thread-card__faces > * + * { margin-left: -4px; }
 .v2-thread .v2-thread-card__count { color: var(--v2-accent-text); font-weight: 600; }
 .v2-thread .v2-thread-card__time { color: var(--v2-text-muted); font: 400 11px/16px var(--v2-font-mono); }
-.v2-thread .v2-thread-card__chevron { color: var(--v2-text-muted); font-size: 12px; transform: none; }
-.v2-root .v2-thread button.v2-thread-card__reply { min-height: 28px; padding: 0 6px; color: var(--v2-text-muted); font: 500 12px/16px var(--v2-font); }
 
-/* Expanded thread: one band, 2px rule at the text column, indented 24px replies. */
-.v2-thread .v2-thread-block { margin-left: 38px; width: calc(100% - 38px); margin-bottom: 10px; }
+/* Expanded thread: the ROOT and its replies share one band (ux-lead 64476
+   (2)); the chip / rule / replies sit at the text column (28px avatar + 8px
+   gap = 36px). */
+.v2-thread .v2-thread-block { margin: 0 0 10px; width: 100%; }
+.v2-thread .v2-thread-block__inner { margin-left: 36px; }
 .v2-thread .v2-thread-block--open { background: #f9fafb; border-radius: 4px; padding: 0 8px 6px 0; }
+.v2-thread .v2-thread-block--open > .v2-msg:hover,
+.v2-thread .v2-thread-block--open > .v2-msg:focus-within { background: transparent; }
+.v2-thread .v2-thread-block .v2-thread-card { margin: 2px 0 0; }
 .v2-thread .v2-thread-replies { margin: 6px 0 0; padding-left: 14px; border-left: 2px solid var(--v2-border); }
 .v2-thread .v2-thread-replies .v2-msg { grid-template-columns: 24px minmax(0, 1fr); gap: 8px; padding: 4px 0; }
 .v2-thread .v2-thread-replies .v2-msg:hover { background: transparent; }
@@ -11338,16 +11314,44 @@ body.modern-ui.v2-canvas {
   cursor: pointer;
 }
 .v2-root button.v2-thread-replies__more { display: block; margin: 2px 0 4px; }
+.v2-root button.v2-thread-replies__follow {
+  margin-left: auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--v2-text-muted);
+  font: 400 11px/16px var(--v2-font-mono);
+  cursor: pointer;
+}
+.v2-root button.v2-thread-replies__follow--on { color: var(--v2-accent-text); }
+
+/* Mention token: wash + cobalt (ux-lead 64476 (7)); the row tint stays. */
+.v2-thread .v2-msg__mention { background: #e8ecfb; color: var(--v2-accent-text); border-radius: 3px; padding: 0 4px; }
+
+/* Transcript avatars are two-tone squares (ux-lead 64476 (1)): human tint +
+   #4f5c6e initials, agent cobalt + white initials; a photo still wins. */
+.v2-thread .v2-avatar--flat { border: 0; box-shadow: none; border-radius: 4px; font: 650 11px/1 var(--v2-font); letter-spacing: 0.02em; }
+.v2-thread .v2-avatar--flat-human { background: #f2f4f7; color: #4f5c6e; }
+.v2-thread .v2-avatar--flat-agent { background: var(--v2-accent); color: #fff; }
+.v2-thread .v2-thread-replies .v2-msg .v2-avatar--flat { font-size: 9px; }
+.v2-thread .v2-thread-card__faces .v2-avatar--flat { font-size: 7px; }
 .v2-root .v2-thread button.v2-thread-replies__aim { margin-left: auto; padding: 0; color: var(--v2-text-muted); font: 500 12px/16px var(--v2-font); }
 
 /* Jump pill: white, #dde0e6 border, r14, ink 13/600, cobalt count (walk-3 miss 58). */
 /* Composer aim chip (walk-3 miss 59). */
 .v2-composer__aim { background: var(--v2-accent-soft, #e8ecfb); color: var(--v2-accent-text); }
 
-@media (max-width: 760px) {
+/* The reveal is gated on capability in the row — `matchMedia('(hover: none)')`,
+   with no width term and no `(pointer: coarse)` — so its placement matches that
+   query EXACTLY (sprint-review 64468 + 64485). A comma'd `(pointer: coarse)`
+   would style stylus/hybrid machines where `isHoverless()` is false and the
+   reveal never fires: a dead rule. This block sits AFTER the `.v2-thread
+   .v2-msg__strip` rules it overrides (11229) for the same reason the double
+   pod-header meta needed source order, not specificity. */
+@media (hover: none) {
   /* Long-press reveals the strip inline under the body. */
   .v2-thread .v2-msg { -webkit-touch-callout: none; }
-  /* The row is a 38px | 1fr grid and the strip precedes the body in DOM: left
+  /* The row is a 28px | 1fr grid and the strip precedes the body in DOM: left
      to auto-place, a static strip takes the body's cell and the body drops
      into the avatar column (one word per line — 390 walk). Pin it. */
   .v2-thread .v2-msg--reveal { background: #f9fafb; row-gap: 6px; }
@@ -11361,8 +11365,11 @@ body.modern-ui.v2-canvas {
     opacity: 1;
     pointer-events: auto;
   }
+}
+
+@media (max-width: 760px) {
+  /* Sizing is a width question, not a capability one. */
   .v2-root .v2-thread button.v2-msg__action { width: 28px; height: 28px; }
-  .v2-thread .v2-thread-block { margin-left: 0; width: 100%; }
   .v2-root .v2-thread button.v2-msg__thread-chip { min-height: 32px; }
   .v2-thread .v2-msg__gutter-time { display: none; }
 }

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -11165,3 +11165,204 @@ body.modern-ui.v2-canvas {
   .v2-root button.v2-msg__thumb { width: calc(50% - 3px); height: 84px; }
   .v2-composer__tag { max-width: 120px; }
 }
+
+/* ---------- Workspace at scale · direction C · PR 2b (threading restyle, walk-3 misses 51–63) ----------
+   Runtime tag on agent rows; 20px reaction chips; a two-line quote that jumps to
+   its source; the thread summary is one chip; the expanded thread is one #f9fafb
+   band with a 2px rule and a Collapse foot; the action strip is a 28px white box
+   top-right on hover (inline under the body on long-press at 390); the Jump pill
+   is white with a cobalt count; transcript avatars are two-tone. */
+
+/* Hover band and the expanded band share the panel colour, not the tint. */
+.v2-thread .v2-msg:hover,
+.v2-thread .v2-msg:focus-within { background: #f9fafb; }
+.v2-thread .v2-msg { border-radius: 4px; }
+.v2-thread .v2-msg--landed { background: var(--v2-accent-soft, #e8ecfb); transition: background 0.6s ease; }
+
+/* Runtime tag after the time on agent rows. */
+.v2-msg__tag {
+  display: inline-block;
+  height: 16px;
+  padding: 0 5px;
+  margin-left: 8px;
+  border-radius: 3px;
+  background: var(--v2-surface-tint);
+  color: var(--v2-text-muted);
+  font: 500 11px/16px var(--v2-font-mono);
+  vertical-align: middle;
+}
+
+/* Grouped rows: the time shows in the gutter on hover. */
+.v2-msg__gutter-time {
+  position: absolute;
+  left: 0;
+  top: 4px;
+  width: 28px;
+  color: var(--v2-text-placeholder);
+  font: 400 11px/16px var(--v2-font-mono);
+  text-align: center;
+  visibility: hidden;
+}
+.v2-thread .v2-msg--grouped:hover .v2-msg__gutter-time { visibility: visible; }
+
+/* Two-tone avatars inside the transcript: agents cobalt, humans tint. */
+.v2-thread .v2-msg--agent .v2-avatar:not(.v2-avatar--photo) { background: var(--v2-accent); color: #fff; }
+
+/* Quote: 2px rule, two lines, jumps to the source. */
+.v2-thread .v2-msg__quote {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  margin: 2px 0 6px;
+  padding: 0 0 0 10px;
+  border-left: 2px solid var(--v2-border);
+  color: var(--v2-text-secondary);
+  font: 400 13px/17px var(--v2-font);
+  cursor: pointer;
+  max-width: 560px;
+}
+.v2-thread .v2-msg__quote:hover { border-left-color: var(--v2-border-strong); }
+.v2-thread .v2-msg__quote:focus-visible { outline: none; box-shadow: inset 2px 0 0 var(--v2-accent); }
+.v2-thread .v2-msg__quote-author { color: var(--v2-text-primary); font-weight: 600; }
+.v2-thread .v2-msg__quote-text {
+  white-space: normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Reactions: 20px chips, mine in the accent wash. */
+.v2-thread .v2-msg__reactions { gap: 6px; margin-top: 6px; }
+.v2-root .v2-thread button.v2-msg__reaction,
+.v2-thread .v2-msg__reaction {
+  height: 20px;
+  padding: 0 7px;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: 4px;
+  background: var(--v2-surface);
+  color: var(--v2-text-secondary);
+  font: 500 11px/18px var(--v2-font-mono);
+}
+.v2-thread .v2-msg__reaction-emoji { font-size: 12px; line-height: 18px; }
+.v2-thread .v2-msg__reaction-count { font: 500 11px/18px var(--v2-font-mono); }
+.v2-root .v2-thread button.v2-msg__reaction--mine {
+  border-color: #d4dbf7;
+  background: var(--v2-accent-soft, #e8ecfb);
+  color: var(--v2-accent-text);
+}
+.v2-root .v2-thread button.v2-msg__reaction--more { color: var(--v2-accent-text); }
+
+/* Action strip: 28px white box, r4, four 24px icons, top-right on hover. */
+.v2-thread .v2-msg__strip {
+  top: -14px;
+  right: 0;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: 4px;
+  box-shadow: none;
+}
+.v2-root .v2-thread button.v2-msg__action { width: 24px; height: 24px; border-radius: 3px; color: #4f5c6e; }
+.v2-msg__more-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 7;
+  display: flex;
+  min-width: 140px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px;
+  border: 1px solid var(--v2-border);
+  border-radius: 6px;
+  background: var(--v2-surface);
+}
+.v2-root .v2-msg__more-menu > button {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--v2-text-primary);
+  font: 400 13px/18px var(--v2-font);
+  text-align: left;
+}
+.v2-root .v2-msg__more-menu > button:hover { background: var(--v2-surface-hover); }
+
+/* Thread summary chip: faces · N replies · last age. */
+.v2-thread .v2-thread-card { margin: 4px 0 0; gap: 10px; }
+.v2-root .v2-thread button.v2-msg__thread-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 0 8px 0 4px;
+  border: 1px solid var(--v2-border-soft);
+  border-radius: 4px;
+  background: var(--v2-surface);
+  color: var(--v2-accent-text);
+  font: 600 13px/18px var(--v2-font);
+}
+.v2-root .v2-thread button.v2-msg__thread-chip:hover { background: var(--v2-surface-hover); border-color: var(--v2-border); }
+.v2-thread .v2-thread-card__faces .v2-avatar { width: 16px; height: 16px; border-radius: 4px; border: 1px solid var(--v2-surface); font-size: 8px; }
+.v2-thread .v2-thread-card__faces > * + * { margin-left: -4px; }
+.v2-thread .v2-thread-card__count { color: var(--v2-accent-text); font-weight: 600; }
+.v2-thread .v2-thread-card__time { color: var(--v2-text-muted); font: 400 11px/16px var(--v2-font-mono); }
+.v2-thread .v2-thread-card__chevron { color: var(--v2-text-muted); font-size: 12px; transform: none; }
+.v2-root .v2-thread button.v2-thread-card__reply { min-height: 28px; padding: 0 6px; color: var(--v2-text-muted); font: 500 12px/16px var(--v2-font); }
+
+/* Expanded thread: one band, 2px rule at the text column, indented 24px replies. */
+.v2-thread .v2-thread-block { margin-left: 38px; width: calc(100% - 38px); margin-bottom: 10px; }
+.v2-thread .v2-thread-block--open { background: #f9fafb; border-radius: 4px; padding: 0 8px 6px 0; }
+.v2-thread .v2-thread-replies { margin: 6px 0 0; padding-left: 14px; border-left: 2px solid var(--v2-border); }
+.v2-thread .v2-thread-replies .v2-msg { grid-template-columns: 24px minmax(0, 1fr); gap: 8px; padding: 4px 0; }
+.v2-thread .v2-thread-replies .v2-msg:hover { background: transparent; }
+.v2-thread .v2-thread-replies .v2-msg .v2-avatar { width: 24px; height: 24px; font-size: 9px; }
+.v2-thread-replies__foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0 0;
+  color: var(--v2-text-muted);
+  font: 400 11px/16px var(--v2-font-mono);
+}
+.v2-root button.v2-thread-replies__collapse,
+.v2-root button.v2-thread-replies__more {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--v2-accent-text);
+  font: 500 13px/18px var(--v2-font);
+  cursor: pointer;
+}
+.v2-root button.v2-thread-replies__more { display: block; margin: 2px 0 4px; }
+.v2-root .v2-thread button.v2-thread-replies__aim { margin-left: auto; padding: 0; color: var(--v2-text-muted); font: 500 12px/16px var(--v2-font); }
+
+/* Jump pill: white, #dde0e6 border, r14, ink 13/600, cobalt count (walk-3 miss 58). */
+/* Composer aim chip (walk-3 miss 59). */
+.v2-composer__aim { background: var(--v2-accent-soft, #e8ecfb); color: var(--v2-accent-text); }
+
+@media (max-width: 760px) {
+  /* Long-press reveals the strip inline under the body. */
+  .v2-thread .v2-msg { -webkit-touch-callout: none; }
+  /* The row is a 38px | 1fr grid and the strip precedes the body in DOM: left
+     to auto-place, a static strip takes the body's cell and the body drops
+     into the avatar column (one word per line — 390 walk). Pin it. */
+  .v2-thread .v2-msg--reveal { background: #f9fafb; row-gap: 6px; }
+  .v2-thread .v2-msg--reveal .v2-msg__strip {
+    position: static;
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: start;
+    display: inline-flex;
+    margin: 0;
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .v2-root .v2-thread button.v2-msg__action { width: 28px; height: 28px; }
+  .v2-thread .v2-thread-block { margin-left: 0; width: 100%; }
+  .v2-root .v2-thread button.v2-msg__thread-chip { min-height: 32px; }
+  .v2-thread .v2-msg__gutter-time { display: none; }
+}


### PR DESCRIPTION
Based on the #1582 implementation at c8d4b619 (full diff targets main so required gates can run).

Closes the three UX re-walk defects:
- repeat the same quote after collapsing: clears landing guards and re-runs the reveal path;
- keep an orphan reply flat when its older page/root is prepended;
- raise thread initials above the reviewed type floor (and restore the 28px action-strip geometry).

Proof:
- 117 targeted v2 tests green, including producer tests for repeat quote and root prepend;
- deleting either producer line makes its test red;
- layout invariants pin the strip and avatar sizing;
- targeted eslint: 0 errors.

The worktree's typecheck is blocked only by the existing missing @dicebear/core and @dicebear/collection packages.
