### PR TITLE
feat(connectors): reconcile decision card closures

### DIFF
--- a/backend/__tests__/unit/routes/activity.identity.test.js
+++ b/backend/__tests__/unit/routes/activity.identity.test.js
@@ -65,6 +65,7 @@ describe('activity route identity handling', () => {
 
     expect(DecisionRequestService.chooseDecision).toHaveBeenCalledWith({
       decisionId: 'decision-1', callerUserId: 'human-1', value: 'Ship now',
+      origin: { via: 'workspace' },
     });
   });
 });

--- a/backend/__tests__/unit/services/decisionCardReconcileService.test.js
+++ b/backend/__tests__/unit/services/decisionCardReconcileService.test.js
@@ -1,0 +1,277 @@
+jest.mock('../../../models/Pod', () => ({ findById: jest.fn() }));
+jest.mock('../../../services/telegramService', () => ({ sendMessage: jest.fn() }));
+jest.mock('../../../services/slackApi', () => jest.fn());
+jest.mock('../../../services/connectorSecrets', () => ({ get: jest.fn(async () => 'slack-token') }));
+
+const mongoose = require('mongoose');
+const { setupMongoDb, closeMongoDb, clearMongoDb } = require('../../utils/testUtils');
+const Integration = require('../../../models/Integration');
+const DecisionRequest = require('../../../models/DecisionRequest');
+const Pod = require('../../../models/Pod');
+const telegramSend = require('../../../services/telegramService');
+const SlackApi = require('../../../services/slackApi');
+const Verdict = require('../../../models/ChannelVerdict');
+const {
+  fanoutDecisionClosure, sweepDecisionCards, CLOSED_CARD_RETENTION_MS,
+} = require('../../../services/decisionCardReconcileService');
+
+const podId = new mongoose.Types.ObjectId();
+const ownerId = new mongoose.Types.ObjectId();
+const siblingId = new mongoose.Types.ObjectId();
+const memberId = new mongoose.Types.ObjectId();
+const cardId = 'decision-message-1';
+
+const chain = (value) => ({ select: () => ({ lean: async () => value }) });
+
+beforeAll(async () => { await setupMongoDb(); });
+afterAll(() => closeMongoDb());
+beforeEach(async () => {
+  await clearMongoDb();
+  jest.clearAllMocks();
+  process.env.TELEGRAM_BOT_TOKEN = 'telegram-token';
+  Pod.findById.mockImplementation(() => chain({ createdBy: ownerId, members: [ownerId, memberId] }));
+  telegramSend.sendMessage.mockResolvedValue({ success: true, messageId: 19 });
+  SlackApi.mockImplementation(() => ({ postMessage: jest.fn(async () => ({ ok: true, ts: '2.1' })) }));
+});
+afterEach(() => { jest.restoreAllMocks(); });
+
+describe('decision card closure fan-out', () => {
+  test('stamps every receipt and sends workspace confirmation only to eligible siblings', async () => {
+    const origin = await Integration.create({
+      podId, scope: 'user', type: 'telegram', createdBy: ownerId, isActive: true, status: 'connected',
+      config: {
+        liveRelay: true, linkedUserId: String(ownerId), chatType: 'private', chatId: 'origin',
+        gates: { [String(podId)]: { enabled: true, since: new Date() } },
+        cards: [{ podMessageId: cardId, tgMessageId: '11', sentAt: new Date() }],
+      },
+    });
+    const sibling = await Integration.create({
+      podId, scope: 'user', type: 'telegram', createdBy: memberId, isActive: true, status: 'connected',
+      config: {
+        liveRelay: true, linkedUserId: String(memberId), chatType: 'private', chatId: 'sibling',
+        gates: { [String(podId)]: { enabled: true, since: new Date() } },
+        cards: [{ podMessageId: cardId, tgMessageId: '12', sentAt: new Date() }],
+      },
+    });
+    await Verdict.create([
+      {
+        integrationId: origin._id, podId, provider: 'telegram',
+        event: { kind: 'decision_request', podMessageId: cardId },
+        verdict: 'interrupt', reason: 'card',
+      },
+      {
+        integrationId: sibling._id, podId, provider: 'telegram',
+        event: { kind: 'decision_request', podMessageId: cardId },
+        verdict: 'interrupt', reason: 'card',
+      },
+    ]);
+
+    await fanoutDecisionClosure(
+      { _id: new mongoose.Types.ObjectId(), podId, messageId: cardId, ruling: { value: 'Now', byUsername: 'Sam' } },
+      { via: 'workspace', integrationId: origin._id },
+    );
+
+    expect(telegramSend.sendMessage).toHaveBeenCalledWith(
+      'telegram-token', 'sibling', '✓ Ruled by Sam: Now',
+      { replyToMessageId: '12', plainText: true },
+    );
+    expect((await Integration.findById(origin._id)).config.cards[0].closedAt).toEqual(expect.any(Date));
+    expect((await Integration.findById(sibling._id)).config.cards[0].closedAt).toEqual(expect.any(Date));
+    expect(await Verdict.find({ 'event.podMessageId': cardId })).toEqual([
+      expect.objectContaining({ ruledVia: 'workspace', reachedHumanAt: undefined }),
+      expect.objectContaining({ ruledVia: 'workspace', reachedHumanAt: undefined }),
+    ]);
+  });
+
+  test('carries a channel origin through every fork ledger row', async () => {
+    const origin = await Integration.create({
+      podId, scope: 'user', type: 'telegram', createdBy: ownerId, isActive: true, status: 'connected',
+      config: {
+        liveRelay: true, linkedUserId: String(ownerId), chatType: 'private', chatId: 'origin',
+        gates: { [String(podId)]: { enabled: true, since: new Date() } },
+        cards: [{ podMessageId: cardId, tgMessageId: '16', sentAt: new Date() }],
+      },
+    });
+    const sibling = await Integration.create({
+      podId, scope: 'user', type: 'telegram', createdBy: memberId, isActive: true, status: 'connected',
+      config: {
+        liveRelay: true, linkedUserId: String(memberId), chatType: 'private', chatId: 'sibling',
+        gates: { [String(podId)]: { enabled: true, since: new Date() } },
+        cards: [{ podMessageId: cardId, tgMessageId: '17', sentAt: new Date() }],
+      },
+    });
+    await Verdict.create([
+      {
+        integrationId: origin._id, podId, provider: 'telegram',
+        event: { kind: 'decision_request', podMessageId: cardId },
+        verdict: 'interrupt', reason: 'card',
+      },
+      {
+        integrationId: sibling._id, podId, provider: 'telegram',
+        event: { kind: 'decision_request', podMessageId: cardId },
+        verdict: 'interrupt', reason: 'card',
+      },
+    ]);
+
+    await fanoutDecisionClosure(
+      { _id: new mongoose.Types.ObjectId(), podId, messageId: cardId, ruling: { value: 'Now', byUsername: 'Sam' } },
+      { via: 'telegram', integrationId: origin._id },
+    );
+
+    expect(await Verdict.find({ 'event.podMessageId': cardId })).toEqual([
+      expect.objectContaining({ ruledVia: 'telegram', reachedHumanAt: undefined }),
+      expect.objectContaining({ ruledVia: 'telegram', reachedHumanAt: undefined }),
+    ]);
+  });
+
+  test('targets the sibling Slack card thread rather than the first receipt', async () => {
+    const origin = await Integration.create({
+      podId, scope: 'user', type: 'slack', createdBy: ownerId, isActive: true, status: 'connected',
+      config: {
+        liveRelay: true, linkedUserId: String(ownerId), chatType: 'im', chatId: 'origin', teamId: 'T1',
+        botTokenRef: 'origin-ref', gates: { [String(podId)]: { enabled: true, since: new Date() } },
+        cards: [{ podMessageId: cardId, externalMessageId: '1.1', sentAt: new Date() }],
+      },
+    });
+    const siblingSend = jest.fn(async () => ({ ok: true, ts: '2.2' }));
+    SlackApi.mockImplementation(() => ({ postMessage: siblingSend }));
+    const sibling = await Integration.create({
+      podId, scope: 'user', type: 'slack', createdBy: memberId, isActive: true, status: 'connected',
+      config: {
+        liveRelay: true, linkedUserId: String(memberId), chatType: 'im', chatId: 'sibling', teamId: 'T1',
+        botTokenRef: 'sibling-ref', gates: { [String(podId)]: { enabled: true, since: new Date() } },
+        cards: [{ podMessageId: cardId, externalMessageId: '2.2', sentAt: new Date() }],
+      },
+    });
+
+    await fanoutDecisionClosure(
+      { _id: new mongoose.Types.ObjectId(), podId, messageId: cardId, ruling: { value: 'A < B', byUsername: 'Sam' } },
+      { via: 'workspace', integrationId: origin._id },
+    );
+
+    expect(siblingSend).toHaveBeenCalledWith('sibling', '✓ Ruled by Sam: A &lt; B', undefined, '2.2');
+    expect((await Integration.findById(sibling._id)).config.cards[0].closedAt).toEqual(expect.any(Date));
+  });
+
+  test('rechecks mute and gate at ruling time but still closes their receipts', async () => {
+    const held = await Integration.create({
+      podId, scope: 'user', type: 'telegram', createdBy: memberId, isActive: true, status: 'connected',
+      config: {
+        liveRelay: true, linkedUserId: String(memberId), chatType: 'private', chatId: 'held',
+        relayMutedUntil: new Date(Date.now() + 60000),
+        gates: { [String(podId)]: { enabled: false, since: new Date() } },
+        cards: [{ podMessageId: cardId, tgMessageId: '13', sentAt: new Date() }],
+      },
+    });
+
+    await fanoutDecisionClosure(
+      { _id: new mongoose.Types.ObjectId(), podId, messageId: cardId, ruling: { value: 'Later', byUsername: 'Sam' } },
+      { via: 'workspace' },
+    );
+
+    expect(telegramSend.sendMessage).not.toHaveBeenCalled();
+    expect((await Integration.findById(held._id)).config.cards[0].closedAt).toEqual(expect.any(Date));
+  });
+
+  test('does not authorize a closing line from createdBy when linkedUserId is absent', async () => {
+    const missingLink = await Integration.create({
+      podId, scope: 'user', type: 'telegram', createdBy: memberId, isActive: true, status: 'connected',
+      config: {
+        liveRelay: true, chatType: 'private', chatId: 'wrong-recipient',
+        gates: { [String(podId)]: { enabled: true, since: new Date() } },
+        cards: [{ podMessageId: cardId, tgMessageId: '15', sentAt: new Date() }],
+      },
+    });
+
+    await fanoutDecisionClosure(
+      { _id: new mongoose.Types.ObjectId(), podId, messageId: cardId, ruling: { value: 'Now', byUsername: 'Sam' } },
+      { via: 'workspace' },
+    );
+
+    expect(telegramSend.sendMessage).not.toHaveBeenCalled();
+    expect((await Integration.findById(missingLink._id)).config.cards[0].closedAt).toEqual(expect.any(Date));
+  });
+
+  test('returns after durable closure while a sibling provider send is still pending', async () => {
+    let releaseSend;
+    const pendingSend = new Promise((resolve) => { releaseSend = resolve; });
+    telegramSend.sendMessage.mockReturnValueOnce(pendingSend);
+    const sibling = await Integration.create({
+      podId, scope: 'user', type: 'telegram', createdBy: memberId, isActive: true, status: 'connected',
+      config: {
+        liveRelay: true, linkedUserId: String(memberId), chatType: 'private', chatId: 'sibling',
+        gates: { [String(podId)]: { enabled: true, since: new Date() } },
+        cards: [{ podMessageId: cardId, tgMessageId: '14', sentAt: new Date() }],
+      },
+    });
+
+    const returned = await fanoutDecisionClosure(
+      { _id: new mongoose.Types.ObjectId(), podId, messageId: cardId, ruling: { value: 'Now', byUsername: 'Sam' } },
+      { via: 'workspace' },
+    );
+
+    expect(returned).toBeUndefined();
+    expect((await Integration.findById(sibling._id)).config.cards[0].closedAt).toEqual(expect.any(Date));
+    expect(telegramSend.sendMessage).toHaveBeenCalled();
+    releaseSend({ success: true, messageId: 20 });
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+});
+
+describe('decision card receipt sweep', () => {
+  test('stamps ruled and missing rows, leaves pending and prunes only finished old rows', async () => {
+    const now = new Date('2026-09-07T00:00:00.000Z');
+    const old = new Date(now.getTime() - CLOSED_CARD_RETENTION_MS - 1);
+    const ruled = await DecisionRequest.create({
+      podId, agentUserId: ownerId, agentName: 'kai', decisionClass: 'implementation',
+      title: 'T', question: 'Q', options: [{ label: 'A' }, { label: 'B' }], messageId: 'ruled-row', status: 'ruled',
+      ruling: { value: 'A', byUserId: ownerId, byUsername: 'Sam', at: now, messageId: 'reply' },
+    });
+    await DecisionRequest.create({
+      podId, agentUserId: ownerId, agentName: 'kai', decisionClass: 'implementation',
+      title: 'T', question: 'Q', options: [{ label: 'A' }, { label: 'B' }], messageId: 'pending-row', status: 'pending',
+    });
+    await DecisionRequest.create({
+      podId, agentUserId: ownerId, agentName: 'kai', decisionClass: 'implementation',
+      title: 'T', question: 'Q', options: [{ label: 'A' }, { label: 'B' }], messageId: 'pending-marked', status: 'pending',
+    });
+    const integration = await Integration.create({
+      podId, scope: 'user', type: 'telegram', createdBy: ownerId, isActive: false, status: 'disconnected',
+      config: {
+        cards: [
+          { podMessageId: 'ruled-row', sentAt: now },
+          { podMessageId: 'missing-row', sentAt: now },
+          { podMessageId: 'pending-row', sentAt: now },
+          { podMessageId: 'old-ruled', sentAt: old, closedAt: old },
+          { podMessageId: 'pending-marked', sentAt: old, closedAt: old },
+        ],
+      },
+    });
+
+    const result = await sweepDecisionCards(now);
+    const cards = (await Integration.findById(integration._id)).config.cards;
+    expect(result.stamped).toBe(2);
+    expect(result.removed).toBe(1);
+    expect(cards.find((card) => card.podMessageId === 'ruled-row').closedAt).toEqual(now);
+    expect(cards.find((card) => card.podMessageId === 'missing-row').closedAt).toEqual(now);
+    expect(cards.find((card) => card.podMessageId === 'pending-row').closedAt).toBeUndefined();
+    expect(cards.find((card) => card.podMessageId === 'old-ruled')).toBeUndefined();
+    expect(cards.find((card) => card.podMessageId === 'pending-marked').closedAt).toEqual(old);
+    expect(String(ruled._id)).toBeTruthy();
+  });
+
+  test('does not treat a failed row lookup as a missing decision', async () => {
+    const integration = await Integration.create({
+      podId, scope: 'user', type: 'telegram', createdBy: ownerId, isActive: false, status: 'disconnected',
+      config: { cards: [{ podMessageId: 'unreadable', sentAt: new Date() }] },
+    });
+    const original = DecisionRequest.find;
+    DecisionRequest.find = jest.fn(() => ({ select: () => ({ lean: async () => { throw new Error('db down'); } }) }));
+    try {
+      expect(await sweepDecisionCards()).toEqual({ stamped: 0, removed: 0 });
+    } finally {
+      DecisionRequest.find = original;
+    }
+    expect((await Integration.findById(integration._id)).config.cards[0].closedAt).toBeUndefined();
+  });
+});

--- a/backend/__tests__/unit/services/decisionCardReply.bridges.test.js
+++ b/backend/__tests__/unit/services/decisionCardReply.bridges.test.js
@@ -112,7 +112,10 @@ describe.each(['telegram', 'slack'])('%s decision reply', (provider) => {
   test('200: one threaded ruling, one typed wake, one closed receipt and reached ledger', async () => {
     await receive();
     expect(choose).toHaveBeenCalledTimes(1);
-    expect(choose).toHaveBeenCalledWith({ decisionId: String(decision._id), callerUserId: ownerId, value: 'Now' });
+    expect(choose).toHaveBeenCalledWith({
+      decisionId: String(decision._id), callerUserId: ownerId, value: 'Now',
+      origin: { via: provider, integrationId: binding._id },
+    });
     expect(messages).toEqual([expect.objectContaining({ podId, userId: ownerId, content: 'Now', replyTo: '700', thread_root_id: '700' })]);
     expect(messages.filter((m) => m.thread_root_id == null)).toHaveLength(0);
     expect(enqueue).toHaveBeenCalledTimes(1);
@@ -234,7 +237,7 @@ describe.each(['telegram', 'slack'])('%s decision reply', (provider) => {
     expect(messages[1].content).toContain('1');
     expect((await receipts())[0].closedAt).toEqual(expect.any(Date));
     expect((await ledger())[0].reachedHumanAt).toBeUndefined();
-    expect((await ledger())[0].ruledVia).toBeUndefined();
+    expect((await ledger())[0].ruledVia).toBe(provider);
     expect(confirmation()).toContain('Already ruled');
   });
 

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -125,6 +125,9 @@ router.post('/decisions/:decisionId/choose', auth, async (req: Req, res: Res) =>
       decisionId,
       callerUserId: String(userId || ''),
       value,
+      // Origin is server-owned. A browser can choose from the workspace only;
+      // never accept provider/integration identifiers from the request body.
+      origin: { via: 'workspace' },
     });
     return res.status(result.status).json(result.body);
   } catch (error: any) {

--- a/backend/services/decisionCardReconcileService.ts
+++ b/backend/services/decisionCardReconcileService.ts
@@ -1,0 +1,282 @@
+import type { DecisionOrigin } from './decisionRequestService';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const Integration = require('../models/Integration');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const DecisionRequest = require('../models/DecisionRequest');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const Pod = require('../models/Pod');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const isPodMember = require('../utils/isPodMember');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const telegramSend = require('./telegramService');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const SlackApi = require('./slackApi');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const connectorSecrets = require('./connectorSecrets');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const channelVerdictService = require('./channelVerdictService');
+
+const CLOSED_CARD_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+let sweepInFlight = false;
+
+const mongoReady = (): boolean => !Integration?.db || Integration.db.readyState === 1;
+
+interface DecisionRow {
+  _id: unknown;
+  podId: unknown;
+  messageId?: string;
+  ruling?: {
+    value?: string;
+    byUsername?: string;
+  };
+}
+
+interface CardEntry {
+  podMessageId: string;
+  tgMessageId?: string;
+  externalMessageId?: string;
+  closedAt?: Date | string;
+}
+
+interface IntegrationDoc {
+  _id: unknown;
+  createdBy?: unknown;
+  podId?: unknown;
+  scope?: 'pod' | 'user';
+  type?: string;
+  status?: string;
+  isActive?: boolean;
+  config?: {
+    liveRelay?: boolean;
+    linkedUserId?: string;
+    chatId?: string;
+    chatType?: string;
+    botTokenRef?: string;
+    relayMutedUntil?: Date | string;
+    adminPause?: unknown;
+    gates?: Record<string, { enabled?: boolean }>;
+    cards?: CardEntry[];
+  };
+}
+
+const escapeSlack = (value: unknown): string => String(value || '')
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;');
+
+const memberIdFor = (integration: IntegrationDoc): string | null => {
+  const linked = integration.config?.linkedUserId;
+  return linked ? String(linked) : null;
+};
+
+const canSendClosingLine = (
+  integration: IntegrationDoc,
+  podId: string,
+  pod: unknown,
+  now: Date,
+): boolean => {
+  if (integration.isActive !== true || integration.status === 'error') return false;
+  if (integration.config?.liveRelay !== true || integration.config.adminPause) return false;
+  if (integration.type !== 'telegram' && integration.type !== 'slack') return false;
+  if (integration.scope === 'user' && integration.config.gates?.[podId]?.enabled !== true) return false;
+  if (integration.scope !== 'user' && String(integration.podId) !== podId) return false;
+  const mutedUntil = integration.config.relayMutedUntil;
+  if (mutedUntil && new Date(mutedUntil).getTime() > now.getTime()) return false;
+  const linkedUserId = memberIdFor(integration);
+  if (!linkedUserId || !isPodMember(pod, linkedUserId)) return false;
+  if (!integration.config.chatId) return false;
+  if (integration.type === 'telegram') {
+    return integration.config.chatType === 'private' && Boolean(process.env.TELEGRAM_BOT_TOKEN);
+  }
+  return integration.config.chatType === 'im' && Boolean(integration.config.botTokenRef);
+};
+
+const sendClosingLine = async (
+  integration: IntegrationDoc,
+  card: CardEntry,
+  text: string,
+): Promise<void> => {
+  if (integration.type === 'telegram') {
+    const sent = await telegramSend.sendMessage(
+      process.env.TELEGRAM_BOT_TOKEN,
+      String(integration.config?.chatId),
+      text,
+      { replyToMessageId: card.tgMessageId, plainText: true },
+    );
+    if (!sent?.success) throw new Error('Telegram ruling confirmation was not sent');
+    return;
+  }
+  const token = await connectorSecrets.get(String(integration.config?.botTokenRef));
+  const sent = await new SlackApi(token).postMessage(
+    String(integration.config?.chatId),
+    escapeSlack(text),
+    undefined,
+    card.externalMessageId,
+  );
+  if (!sent?.ok) throw new Error(`Slack ruling confirmation was not sent: ${String(sent?.error || 'unknown error')}`);
+};
+
+/**
+ * Close every durable card receipt for a settled fork, then best-effort send
+ * the interrupt confirmation to eligible sibling chats. The row settlement
+ * is already durable when this runs, so a provider failure cannot make the
+ * caller retry the ruling or leave one receipt looking open.
+ */
+export const fanoutDecisionClosure = async (
+  decision: DecisionRow,
+  origin: DecisionOrigin,
+): Promise<void> => {
+  const podMessageId = String(decision.messageId || '');
+  if (!podMessageId) return;
+  const now = new Date();
+  const podId = String(decision.podId);
+  const value = String(decision.ruling?.value || '');
+  const by = String(decision.ruling?.byUsername || 'Human');
+
+  // Unit callers can exercise the decision verb without booting Mongo. Do not
+  // leave Mongoose's default 10-second buffer timer running in that case; the
+  // production process always reaches this path after its DB is ready.
+  if (!mongoReady()) return;
+
+  // This is a fork-level ledger fact. It intentionally includes held rows;
+  // the person who was muted or gate-off was still part of the decision's
+  // channel census even though they did not receive the closing text.
+  try {
+    await channelVerdictService.markRuled({ podMessageId, ruledVia: origin.via });
+  } catch (error) {
+    // The ledger is observational; receipt closure and provider sends still
+    // proceed when its projection is temporarily unavailable.
+    console.warn('[decision-card] ruling ledger stamp failed:', (error as Error).message);
+  }
+
+  // Marking is unconditional and does not depend on connector liveness. Use
+  // an array filter rather than an array index: sibling receipts may be
+  // reordered or appended concurrently by the relay workers.
+  try {
+    await Integration.updateMany(
+      { 'config.cards.podMessageId': podMessageId },
+      { $set: { 'config.cards.$[card].closedAt': now } },
+      { arrayFilters: [{ 'card.podMessageId': podMessageId }] },
+    );
+  } catch (error) {
+    console.warn('[decision-card] closure stamp failed:', (error as Error).message);
+  }
+
+  let integrations: IntegrationDoc[];
+  try {
+    integrations = await Integration.find({ 'config.cards.podMessageId': podMessageId }).lean();
+  } catch (error) {
+    console.warn('[decision-card] closure lookup failed:', (error as Error).message);
+    return;
+  }
+
+  let pod: unknown = null;
+  try {
+    pod = await Pod.findById(podId).select('members createdBy').lean();
+  } catch (error) {
+    console.warn('[decision-card] membership lookup failed:', (error as Error).message);
+  }
+  const text = `✓ Ruled by ${by}: ${value}`;
+  // Provider delivery is deliberately detached. The local ledger and receipt
+  // writes above are part of the ruling's durable return contract; a stalled
+  // sibling API must not hold up the typed event or HTTP response.
+  void Promise.allSettled(integrations.map(async (integration) => {
+    if (String(integration._id) === String(origin.integrationId || '')) return;
+    if (!canSendClosingLine(integration, podId, pod, now)) return;
+    const card = (integration.config?.cards || []).find((entry) => entry.podMessageId === podMessageId);
+    if (!card) return;
+    try {
+      await sendClosingLine(integration, card, text);
+    } catch (error) {
+      console.warn(`[decision-card] ${integration.type} ruling confirmation failed:`, (error as Error).message);
+    }
+  }));
+};
+
+const stampClosed = async (integrationId: unknown, podMessageId: string, now: Date): Promise<void> => {
+  await Integration.updateOne(
+    {
+      _id: integrationId,
+      'config.cards': { $elemMatch: { podMessageId, closedAt: { $exists: false } } },
+    },
+    { $set: { 'config.cards.$[card].closedAt': now } },
+    { arrayFilters: [{ 'card.podMessageId': podMessageId, 'card.closedAt': { $exists: false } }] },
+  );
+};
+
+/**
+ * Repair durable receipts and bound their retention. A failed row lookup is
+ * skipped, never interpreted as a missing decision, so a transient Mongo
+ * outage cannot close every live card in a connector.
+ */
+export const sweepDecisionCards = async (now: Date = new Date()): Promise<{
+  stamped: number;
+  removed: number;
+}> => {
+  if (sweepInFlight) return { stamped: 0, removed: 0 };
+  sweepInFlight = true;
+  try {
+  if (!mongoReady()) return { stamped: 0, removed: 0 };
+  let integrations: IntegrationDoc[];
+  try {
+    integrations = await Integration.find({ 'config.cards.0': { $exists: true } }).lean();
+  } catch (error) {
+    console.warn('[decision-card] sweep lookup failed:', (error as Error).message);
+    return { stamped: 0, removed: 0 };
+  }
+
+  const cutoff = new Date(now.getTime() - CLOSED_CARD_RETENTION_MS);
+  const messageIds = [...new Set(integrations.flatMap((integration) =>
+    (integration.config?.cards || []).map((card) => card.podMessageId)))];
+  let rows: Array<{ messageId?: string; status?: string }>;
+  try {
+    rows = await DecisionRequest.find({ messageId: { $in: messageIds } }).select('messageId status').lean();
+  } catch (error) {
+    console.warn('[decision-card] sweep row lookup failed:', (error as Error).message);
+    return { stamped: 0, removed: 0 };
+  }
+  const rowByMessageId = new Map(rows.map((row) => [String(row.messageId), row]));
+  let stamped = 0;
+  let removed = 0;
+  for (const integration of integrations) {
+    for (const card of integration.config?.cards || []) {
+      const row = rowByMessageId.get(card.podMessageId) || null;
+      // Pending + closedAt is unreachable by construction. Treat it as a
+      // protected invariant rather than pruning or unsetting the mark.
+      if (row && row.status === 'pending') continue;
+      if (card.closedAt) {
+        if (new Date(card.closedAt).getTime() > cutoff.getTime()) continue;
+        if (row && row.status !== 'ruled') continue;
+        try {
+          const result = await Integration.updateOne(
+            { _id: integration._id },
+            { $pull: { 'config.cards': { podMessageId: card.podMessageId, closedAt: { $lte: cutoff } } } },
+          );
+          removed += Number(result?.modifiedCount ?? result?.nModified ?? 0);
+        } catch (error) {
+          console.warn('[decision-card] sweep prune failed:', (error as Error).message);
+        }
+        continue;
+      }
+      if (row && row.status !== 'ruled') continue;
+      // A missing row and a ruled row are both finished. Pending + closedAt is
+      // unreachable by construction and therefore remains untouched forever.
+      try {
+        await stampClosed(integration._id, card.podMessageId, now);
+        stamped += 1;
+      } catch (error) {
+        console.warn('[decision-card] sweep close stamp failed:', (error as Error).message);
+      }
+    }
+  }
+  return { stamped, removed };
+  } finally {
+    sweepInFlight = false;
+  }
+};
+
+export { CLOSED_CARD_RETENTION_MS };
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = { fanoutDecisionClosure, sweepDecisionCards, CLOSED_CARD_RETENTION_MS };

--- a/backend/services/decisionCardReply.ts
+++ b/backend/services/decisionCardReply.ts
@@ -131,7 +131,12 @@ export const resolveDecisionCardReply = async (input: {
   const { chooseDecision } = require('./decisionRequestService');
   let outcome: { status: number; body: Record<string, any> };
   try {
-    outcome = await chooseDecision({ decisionId: String(row._id), callerUserId: input.linkedUserId, value });
+    outcome = await chooseDecision({
+      decisionId: String(row._id),
+      callerUserId: input.linkedUserId,
+      value,
+      origin: { via: input.provider, integrationId: input.integrationId },
+    });
   } catch (error) {
     const failure = error as { status?: number; code?: string };
     if (failure.code === 'ruling_finalize_conflict') {

--- a/backend/services/decisionRequestService.ts
+++ b/backend/services/decisionRequestService.ts
@@ -64,6 +64,13 @@ interface ChooseDecisionOptions {
   decisionId: string;
   callerUserId: string;
   value: string;
+  /** Internal provenance; HTTP callers are forced to workspace below. */
+  origin?: DecisionOrigin;
+}
+
+export interface DecisionOrigin {
+  via: 'telegram' | 'slack' | 'workspace';
+  integrationId?: unknown;
 }
 
 const cleanText = (value: unknown, field: string, max: number): string => {
@@ -440,6 +447,20 @@ export const chooseDecision = async (
       409,
       'ruling_finalize_conflict',
     );
+  }
+  // The row is settled. Fan-out is one best-effort projection immediately
+  // after that confirmation, before attention/event delivery can fail. A
+  // channel-originated ruling excludes its own integration because the
+  // bridge sends the shorter "✓ Ruled" confirmation after this verb returns.
+  const origin: DecisionOrigin = input.origin || { via: 'workspace' };
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const { fanoutDecisionClosure } = require('./decisionCardReconcileService');
+    await fanoutDecisionClosure(ruled, origin);
+  } catch (error) {
+    // This is deliberately a projection failure. The ruling and typed return
+    // remain durable, and the five-minute sweep repairs receipts.
+    console.warn('[decision-request] card closure fan-out failed:', (error as Error).message);
   }
   // eslint-disable-next-line global-require
   const { resolve } = require('./attentionItemService');

--- a/backend/services/schedulerService.ts
+++ b/backend/services/schedulerService.ts
@@ -465,6 +465,26 @@ class SchedulerService {
       { scheduled: false, timezone: 'UTC' },
     );
 
+    // Decision card receipts are durable until the fork settles. Reconcile
+    // every five minutes: close rows whose decision was ruled or removed, and
+    // prune receipts seven days after their closedAt mark.
+    const decisionCardReconcileJob: CronJob = cron.schedule(
+      '*/5 * * * *',
+      async () => {
+        try {
+          // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+          const { sweepDecisionCards } = require('./decisionCardReconcileService');
+          const result = await sweepDecisionCards();
+          if (result.stamped || result.removed) {
+            console.log(`[decision-card] sweep stamped=${result.stamped} removed=${result.removed}`);
+          }
+        } catch (error) {
+          console.error('[decision-card] scheduled sweep failed:', error);
+        }
+      },
+      { scheduled: false, timezone: 'UTC' },
+    );
+
     this.jobs = [
       summarizerJob,
       externalFeedJob,
@@ -483,6 +503,7 @@ class SchedulerService {
       stalledConnectJob,
       kernelWorkSweepJob,
       installableReconcileJob,
+      decisionCardReconcileJob,
     ];
     this.jobs.forEach((job) => job.start());
     this.isRunning = true;


### PR DESCRIPTION
## Summary
- settle decision-card origin internally (`telegram`, `slack`, or `workspace`); Activity route forces workspace and ignores forged provider fields
- after the row CAS settles, run one best-effort D6 fan-out before attention/event delivery; exclude the answering integration, recheck membership/mute/gate/admin pause, and stamp `closedAt` on every receipt unconditionally
- add the five-minute receipt reconciler: stamp ruled/missing rows, preserve pending rows (including the unreachable pending+closedAt invariant), and prune finished receipts after seven days

## Verification
- `npm run tsc:check`
- focused Jest: 87 tests across decision request, both bridges, reconcile/sweep, and Activity route identity suites
- targeted ESLint: no errors; existing max-line warnings only
