### PR TITLE
feat(activity): separate handoff attention from decisions

### DIFF
--- a/backend/__tests__/service/attentionQueue.counts.test.js
+++ b/backend/__tests__/service/attentionQueue.counts.test.js
@@ -94,6 +94,9 @@ describe('uncapped attention counts — persisted query and membership', () => {
     ]);
     const before = await service.getOpenQueue(recipient);
     expect(before.countsByKind).toEqual({ mention: 1, handoff: 2, decision: 1, approval: 1 });
+    expect(before.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'task-2:update-1', kind: 'handoff' }),
+    ]));
 
     await expect(service.acknowledgeMention(recipient, mention.id)).resolves.toEqual({ success: true });
     await expect(service.acknowledgeMention(recipient, handoff.id)).resolves.toEqual({ success: true });

--- a/backend/__tests__/service/attentionQueue.counts.test.js
+++ b/backend/__tests__/service/attentionQueue.counts.test.js
@@ -27,36 +27,42 @@ describe('uncapped attention counts — persisted query and membership', () => {
       ...Array.from({ length: 4 }, (_, i) => make(`approval-${i}`, busy, 'approval')),
       ...Array.from({ length: 3 }, (_, i) => make(`handoff-${i}`, busy, 'handoff')),
       { ...make('oldest', omitted), createdAt: new Date('2020-01-01') },
+      ...Array.from({ length: 51 }, (_, i) => make(`omitted-mention-${i}`, omitted)),
       make('revoked', revoked), make('other-user', busy, 'mention', other),
       make('closed', busy, 'mention', recipient, 'resolved'),
     ]);
     const queue = await service.getOpenQueue(recipient);
-    expect(queue.count).toBe(98);
-    expect(queue.countsByPod).toEqual({ [busy.id]: 97, [omitted.id]: 1 });
-    expect(queue.countsByKind).toEqual({ mention: 91, approval: 4, handoff: 3 });
+    expect(queue.count).toBe(149);
+    expect(queue.countsByPod).toEqual({ [busy.id]: 97, [omitted.id]: 52 });
+    expect(queue.countsByKind).toEqual({ mention: 142, approval: 4, handoff: 3 });
     expect(queue.items).toHaveLength(50);
     expect(queue.items.filter((item) => item.kind === 'mention')).toHaveLength(43);
-    expect(queue.items.some((item) => item.podId === omitted.id)).toBe(false);
-    expect(queue.remaining).toBe(48);
+    expect(queue.remaining).toBe(99);
     expect(queue.hasMore).toBe(true);
 
     const nextPage = await service.getOpenQueue(recipient, { offset: 50 });
-    expect(nextPage.items).toHaveLength(48);
-    expect(nextPage.remaining).toBe(0);
-    expect(nextPage.hasMore).toBe(false);
+    expect(nextPage.items).toHaveLength(50);
+    expect(nextPage.remaining).toBe(49);
+    expect(nextPage.hasMore).toBe(true);
 
     const scoped = await service.getOpenQueue(recipient, { podId: omitted.id.toString() });
-    expect(scoped.count).toBe(1);
-    expect(scoped.items).toHaveLength(1);
+    expect(scoped.count).toBe(52);
+    expect(scoped.items).toHaveLength(50);
     expect(scoped.items[0].podId).toBe(omitted.id.toString());
-    expect(scoped.remaining).toBe(0);
+    expect(scoped.countsByKind).toEqual({ mention: 52 });
+    expect(scoped.remaining).toBe(2);
+
+    const busyScoped = await service.getOpenQueue(recipient, { podId: busy.id.toString(), limit: 50 });
+    expect(busyScoped.count).toBe(97);
+    expect(busyScoped.countsByKind).toEqual({ mention: 90, approval: 4, handoff: 3 });
+    expect(Object.values(busyScoped.countsByKind).reduce((sum, value) => sum + value, 0)).toBe(busyScoped.count);
 
     const old = await AttentionItem.findOne({ 'source.id': 'oldest' });
     expect(await service.acknowledgeMention(other, old.id)).toMatchObject({ success: false });
     expect(await service.acknowledgeMention(recipient, old.id)).toMatchObject({ success: true });
     const next = await service.getOpenQueue(recipient);
-    expect(next.count).toBe(97);
-    expect(next.countsByPod).toEqual({ [busy.id]: 97 });
+    expect(next.count).toBe(148);
+    expect(next.countsByPod).toEqual({ [busy.id]: 97, [omitted.id]: 51 });
   });
 
   it('returns an authoritative empty shape for invalid recipients', async () => {

--- a/backend/__tests__/service/attentionQueue.counts.test.js
+++ b/backend/__tests__/service/attentionQueue.counts.test.js
@@ -19,27 +19,29 @@ describe('uncapped attention counts — persisted query and membership', () => {
     ]);
     const make = (id, pod, kind = 'mention', who = recipient, status = 'open') => ({
       recipientUserId: who, podId: pod._id, kind, status,
-      source: { type: kind === 'mention' ? 'message' : 'approval', id }, title: id,
+      source: { type: kind === 'mention' ? 'message' : kind === 'approval' ? 'approval' : 'task', id }, title: id,
       createdAt: new Date('2026-09-01T00:00:00Z'),
     });
     await AttentionItem.insertMany([
       ...Array.from({ length: 90 }, (_, i) => make(`mention-${i}`, busy)),
       ...Array.from({ length: 4 }, (_, i) => make(`approval-${i}`, busy, 'approval')),
+      ...Array.from({ length: 3 }, (_, i) => make(`handoff-${i}`, busy, 'handoff')),
       { ...make('oldest', omitted), createdAt: new Date('2020-01-01') },
       make('revoked', revoked), make('other-user', busy, 'mention', other),
       make('closed', busy, 'mention', recipient, 'resolved'),
     ]);
     const queue = await service.getOpenQueue(recipient);
-    expect(queue.count).toBe(95);
-    expect(queue.countsByPod).toEqual({ [busy.id]: 94, [omitted.id]: 1 });
+    expect(queue.count).toBe(98);
+    expect(queue.countsByPod).toEqual({ [busy.id]: 97, [omitted.id]: 1 });
+    expect(queue.countsByKind).toEqual({ mention: 91, approval: 4, handoff: 3 });
     expect(queue.items).toHaveLength(50);
-    expect(queue.items.filter((item) => item.kind === 'mention')).toHaveLength(46);
+    expect(queue.items.filter((item) => item.kind === 'mention')).toHaveLength(43);
     expect(queue.items.some((item) => item.podId === omitted.id)).toBe(false);
-    expect(queue.remaining).toBe(45);
+    expect(queue.remaining).toBe(48);
     expect(queue.hasMore).toBe(true);
 
     const nextPage = await service.getOpenQueue(recipient, { offset: 50 });
-    expect(nextPage.items).toHaveLength(45);
+    expect(nextPage.items).toHaveLength(48);
     expect(nextPage.remaining).toBe(0);
     expect(nextPage.hasMore).toBe(false);
 
@@ -53,14 +55,48 @@ describe('uncapped attention counts — persisted query and membership', () => {
     expect(await service.acknowledgeMention(other, old.id)).toMatchObject({ success: false });
     expect(await service.acknowledgeMention(recipient, old.id)).toMatchObject({ success: true });
     const next = await service.getOpenQueue(recipient);
-    expect(next.count).toBe(94);
-    expect(next.countsByPod).toEqual({ [busy.id]: 94 });
+    expect(next.count).toBe(97);
+    expect(next.countsByPod).toEqual({ [busy.id]: 97 });
   });
 
   it('returns an authoritative empty shape for invalid recipients', async () => {
     expect(await service.getOpenQueue('invalid')).toEqual({
-      items: [], count: 0, countsByPod: {}, composePodId: null,
+      items: [], count: 0, countsByPod: {}, countsByKind: {}, composePodId: null,
       offset: 0, limit: 50, remaining: 0, hasMore: false,
     });
+  });
+
+  it('acknowledges mentions and handoffs but never a decision request or approval', async () => {
+    const recipient = new mongoose.Types.ObjectId();
+    const pod = await Pod.create({ name: 'Authority', type: 'team', createdBy: recipient, members: [recipient] });
+    const make = (kind, sourceType, id) => ({
+      recipientUserId: recipient,
+      podId: pod._id,
+      kind,
+      source: { type: sourceType, id },
+      title: id,
+      status: 'open',
+    });
+    const [mention, handoff, legacy, decision, approval] = await AttentionItem.create([
+      make('mention', 'message', 'mention-1'),
+      make('handoff', 'task', 'task-1:update-1'),
+      make('decision', 'task', 'task-2:update-1'),
+      make('decision', 'decision_request', 'decision-1'),
+      make('approval', 'approval', 'approval-1'),
+    ]);
+
+    await expect(service.acknowledgeMention(recipient, mention.id)).resolves.toEqual({ success: true });
+    await expect(service.acknowledgeMention(recipient, handoff.id)).resolves.toEqual({ success: true });
+    await expect(service.acknowledgeMention(recipient, legacy.id)).resolves.toEqual({ success: true });
+    await expect(service.acknowledgeMention(recipient, decision.id)).resolves.toEqual({ success: false, error: 'Attention item not found' });
+    await expect(service.acknowledgeMention(recipient, approval.id)).resolves.toEqual({ success: false, error: 'Attention item not found' });
+
+    await expect(AttentionItem.find({ recipientUserId: recipient }).sort({ createdAt: 1 }).lean()).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({ _id: mention._id, status: 'resolved', resolvedBy: 'acknowledged' }),
+      expect.objectContaining({ _id: handoff._id, status: 'resolved', resolvedBy: 'acknowledged' }),
+      expect.objectContaining({ _id: legacy._id, status: 'resolved', resolvedBy: 'acknowledged' }),
+      expect.objectContaining({ _id: decision._id, status: 'open' }),
+      expect.objectContaining({ _id: approval._id, status: 'open' }),
+    ]));
   });
 });

--- a/backend/__tests__/service/attentionQueue.counts.test.js
+++ b/backend/__tests__/service/attentionQueue.counts.test.js
@@ -26,23 +26,25 @@ describe('uncapped attention counts — persisted query and membership', () => {
       ...Array.from({ length: 90 }, (_, i) => make(`mention-${i}`, busy)),
       ...Array.from({ length: 4 }, (_, i) => make(`approval-${i}`, busy, 'approval')),
       ...Array.from({ length: 3 }, (_, i) => make(`handoff-${i}`, busy, 'handoff')),
+      make('legacy-handoff', busy, 'decision'),
+      { ...make('decision-request', busy, 'decision'), source: { type: 'decision_request', id: 'decision-request' } },
       { ...make('oldest', omitted), createdAt: new Date('2020-01-01') },
       ...Array.from({ length: 51 }, (_, i) => make(`omitted-mention-${i}`, omitted)),
       make('revoked', revoked), make('other-user', busy, 'mention', other),
       make('closed', busy, 'mention', recipient, 'resolved'),
     ]);
     const queue = await service.getOpenQueue(recipient);
-    expect(queue.count).toBe(149);
-    expect(queue.countsByPod).toEqual({ [busy.id]: 97, [omitted.id]: 52 });
-    expect(queue.countsByKind).toEqual({ mention: 142, approval: 4, handoff: 3 });
+    expect(queue.count).toBe(151);
+    expect(queue.countsByPod).toEqual({ [busy.id]: 99, [omitted.id]: 52 });
+    expect(queue.countsByKind).toEqual({ mention: 142, approval: 4, handoff: 4, decision: 1 });
     expect(queue.items).toHaveLength(50);
-    expect(queue.items.filter((item) => item.kind === 'mention')).toHaveLength(43);
-    expect(queue.remaining).toBe(99);
+    expect(queue.items.filter((item) => item.kind === 'mention')).toHaveLength(41);
+    expect(queue.remaining).toBe(101);
     expect(queue.hasMore).toBe(true);
 
     const nextPage = await service.getOpenQueue(recipient, { offset: 50 });
     expect(nextPage.items).toHaveLength(50);
-    expect(nextPage.remaining).toBe(49);
+    expect(nextPage.remaining).toBe(51);
     expect(nextPage.hasMore).toBe(true);
 
     const scoped = await service.getOpenQueue(recipient, { podId: omitted.id.toString() });
@@ -53,16 +55,16 @@ describe('uncapped attention counts — persisted query and membership', () => {
     expect(scoped.remaining).toBe(2);
 
     const busyScoped = await service.getOpenQueue(recipient, { podId: busy.id.toString(), limit: 50 });
-    expect(busyScoped.count).toBe(97);
-    expect(busyScoped.countsByKind).toEqual({ mention: 90, approval: 4, handoff: 3 });
+    expect(busyScoped.count).toBe(99);
+    expect(busyScoped.countsByKind).toEqual({ mention: 90, approval: 4, handoff: 4, decision: 1 });
     expect(Object.values(busyScoped.countsByKind).reduce((sum, value) => sum + value, 0)).toBe(busyScoped.count);
 
     const old = await AttentionItem.findOne({ 'source.id': 'oldest' });
     expect(await service.acknowledgeMention(other, old.id)).toMatchObject({ success: false });
     expect(await service.acknowledgeMention(recipient, old.id)).toMatchObject({ success: true });
     const next = await service.getOpenQueue(recipient);
-    expect(next.count).toBe(148);
-    expect(next.countsByPod).toEqual({ [busy.id]: 97, [omitted.id]: 51 });
+    expect(next.count).toBe(150);
+    expect(next.countsByPod).toEqual({ [busy.id]: 99, [omitted.id]: 51 });
   });
 
   it('returns an authoritative empty shape for invalid recipients', async () => {

--- a/backend/__tests__/service/attentionQueue.counts.test.js
+++ b/backend/__tests__/service/attentionQueue.counts.test.js
@@ -92,6 +92,8 @@ describe('uncapped attention counts — persisted query and membership', () => {
       make('decision', 'decision_request', 'decision-1'),
       make('approval', 'approval', 'approval-1'),
     ]);
+    const before = await service.getOpenQueue(recipient);
+    expect(before.countsByKind).toEqual({ mention: 1, handoff: 2, decision: 1, approval: 1 });
 
     await expect(service.acknowledgeMention(recipient, mention.id)).resolves.toEqual({ success: true });
     await expect(service.acknowledgeMention(recipient, handoff.id)).resolves.toEqual({ success: true });

--- a/backend/__tests__/unit/models/AttentionItem.test.js
+++ b/backend/__tests__/unit/models/AttentionItem.test.js
@@ -49,6 +49,22 @@ describe('AttentionItem', () => {
 
     await expect(row.validate()).resolves.toBeUndefined();
   });
+
+  it('accepts a new handoff kind without widening resolvedBy', async () => {
+    const row = new AttentionItem({
+      recipientUserId: recipient,
+      podId: pod,
+      kind: 'handoff',
+      source: { type: 'task', id: 'task-2:update-1' },
+      title: 'Ready for your press',
+      resolvedBy: 'acknowledged',
+    });
+
+    await expect(row.validate()).resolves.toBeUndefined();
+    await expect(new AttentionItem({
+      ...row.toObject(), resolvedBy: 'handoff',
+    }).validate()).rejects.toMatchObject({ errors: { resolvedBy: expect.any(Object) } });
+  });
 });
   beforeAll(async () => { await setupMongoDb(); });
   afterAll(async () => { await closeMongoDb(); });

--- a/backend/__tests__/unit/routes/activity.read.test.js
+++ b/backend/__tests__/unit/routes/activity.read.test.js
@@ -13,7 +13,7 @@ jest.mock('../../../services/activityService', () => ({
   getDecisionQueue: jest.fn(async () => ({ items: [], count: 0, countsByPod: {}, remaining: 0, hasMore: false })),
   getPodFeed: jest.fn(async () => ({ activities: [], hasMore: false })),
   getPendingApprovals: jest.fn(async () => []),
-  acknowledgeMention: jest.fn(async () => ({ success: true })),
+  acknowledgeAttention: jest.fn(async () => ({ success: true })),
   toggleLike: jest.fn(async () => ({ success: true })),
   addReply: jest.fn(async () => ({ success: true })),
   approveActivity: jest.fn(async () => ({ success: true })),
@@ -71,9 +71,9 @@ describe('activity read routes', () => {
     await request(app).post('/api/activity/mark-read').send({}).expect(400);
   });
 
-  it('POST /api/activity/:id/acknowledge uses the dedicated mention acknowledgement', async () => {
+  it('POST /api/activity/:id/acknowledge uses the recipient-owned attention acknowledgement', async () => {
     await request(app).post('/api/activity/mention-1/acknowledge').expect(200);
-    expect(ActivityService.acknowledgeMention).toHaveBeenCalledWith('user123', 'mention-1');
+    expect(ActivityService.acknowledgeAttention).toHaveBeenCalledWith('user123', 'mention-1');
   });
 
   it('preserves a membership-gate 403 from the approval writer', async () => {

--- a/backend/__tests__/unit/routes/activity.read.test.js
+++ b/backend/__tests__/unit/routes/activity.read.test.js
@@ -13,7 +13,7 @@ jest.mock('../../../services/activityService', () => ({
   getDecisionQueue: jest.fn(async () => ({ items: [], count: 0, countsByPod: {}, remaining: 0, hasMore: false })),
   getPodFeed: jest.fn(async () => ({ activities: [], hasMore: false })),
   getPendingApprovals: jest.fn(async () => []),
-  acknowledgeAttention: jest.fn(async () => ({ success: true })),
+  acknowledgeMention: jest.fn(async () => ({ success: true })),
   toggleLike: jest.fn(async () => ({ success: true })),
   addReply: jest.fn(async () => ({ success: true })),
   approveActivity: jest.fn(async () => ({ success: true })),
@@ -71,9 +71,9 @@ describe('activity read routes', () => {
     await request(app).post('/api/activity/mark-read').send({}).expect(400);
   });
 
-  it('POST /api/activity/:id/acknowledge uses the recipient-owned attention acknowledgement', async () => {
+  it('POST /api/activity/:id/acknowledge uses the recipient-owned mention acknowledgement path', async () => {
     await request(app).post('/api/activity/mention-1/acknowledge').expect(200);
-    expect(ActivityService.acknowledgeAttention).toHaveBeenCalledWith('user123', 'mention-1');
+    expect(ActivityService.acknowledgeMention).toHaveBeenCalledWith('user123', 'mention-1');
   });
 
   it('preserves a membership-gate 403 from the approval writer', async () => {

--- a/backend/__tests__/unit/services/activityService.recap.test.js
+++ b/backend/__tests__/unit/services/activityService.recap.test.js
@@ -2,11 +2,11 @@ jest.mock('../../../models/Pod', () => ({ find: jest.fn(), findById: jest.fn() }
 jest.mock('../../../models/Task', () => ({ find: jest.fn() }));
 
 const mockGetOpenQueue = jest.fn();
-const mockAcknowledgeMention = jest.fn();
+const mockAcknowledgeAttention = jest.fn();
 const mockResolve = jest.fn();
 jest.mock('../../../services/attentionItemService', () => ({
   getOpenQueue: (...args) => mockGetOpenQueue(...args),
-  acknowledgeMention: (...args) => mockAcknowledgeMention(...args),
+  acknowledgeAttention: (...args) => mockAcknowledgeAttention(...args),
   resolve: (...args) => mockResolve(...args),
 }));
 
@@ -37,7 +37,7 @@ describe('ActivityService recap and legacy approval authorization', () => {
     Pod.findById.mockReturnValue({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(pod) })) });
     Task.find.mockReturnValue(taskQuery([]));
     mockGetOpenQueue.mockResolvedValue({ items: [], count: 0, composePodId: null });
-    mockAcknowledgeMention.mockResolvedValue({ success: true });
+    mockAcknowledgeAttention.mockResolvedValue({ success: true });
     mockResolve.mockResolvedValue(undefined);
     feedSpy = jest.spyOn(ActivityService, 'getUserFeed').mockResolvedValue({ activities: [] });
   });
@@ -70,9 +70,9 @@ describe('ActivityService recap and legacy approval authorization', () => {
     expect(mockGetOpenQueue).toHaveBeenCalledWith(ownerId);
   });
 
-  test('acknowledges a mention only through the recipient-owned attention record', async () => {
-    await expect(ActivityService.acknowledgeMention(ownerId, 'attention-1')).resolves.toEqual({ success: true });
-    expect(mockAcknowledgeMention).toHaveBeenCalledWith(ownerId, 'attention-1');
+  test('acknowledges attention only through the recipient-owned attention record', async () => {
+    await expect(ActivityService.acknowledgeAttention(ownerId, 'attention-1')).resolves.toEqual({ success: true });
+    expect(mockAcknowledgeAttention).toHaveBeenCalledWith(ownerId, 'attention-1');
   });
 
   test('allows a pod member to approve a legacy Activity approval', async () => {

--- a/backend/__tests__/unit/services/activityService.recap.test.js
+++ b/backend/__tests__/unit/services/activityService.recap.test.js
@@ -71,7 +71,7 @@ describe('ActivityService recap and legacy approval authorization', () => {
   });
 
   test('acknowledges attention only through the recipient-owned attention record', async () => {
-    await expect(ActivityService.acknowledgeAttention(ownerId, 'attention-1')).resolves.toEqual({ success: true });
+    await expect(ActivityService.acknowledgeMention(ownerId, 'attention-1')).resolves.toEqual({ success: true });
     expect(mockAcknowledgeAttention).toHaveBeenCalledWith(ownerId, 'attention-1');
   });
 

--- a/backend/__tests__/unit/services/attentionItemService.test.js
+++ b/backend/__tests__/unit/services/attentionItemService.test.js
@@ -125,7 +125,7 @@ describe('attentionItemService', () => {
     expect(queue.items).toEqual([expect.objectContaining({ id: '41', attentionItemId: 'attention-1', podName: 'Current' })]);
     await AttentionItemService.acknowledgeMention('507f191e810c19729de860ea', '507f191e810c19729de860eb');
     expect(mockUpdateOne).toHaveBeenLastCalledWith(
-      expect.objectContaining({ recipientUserId: '507f191e810c19729de860ea', kind: 'mention' }),
+      expect.objectContaining({ recipientUserId: '507f191e810c19729de860ea', status: 'open', $or: expect.any(Array) }),
       expect.any(Object),
     );
   });
@@ -198,7 +198,7 @@ describe('attentionItemService', () => {
     await AttentionItemService.acknowledgeMention('507f191e810c19729de860ea', '507f191e810c19729de860eb');
 
     expect(mockUpdateOne).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: 'mention', status: 'open' }),
+      expect.objectContaining({ status: 'open', $or: expect.any(Array) }),
       { $set: expect.objectContaining({ status: 'resolved', resolvedBy: 'acknowledged' }) },
     );
   });
@@ -256,9 +256,28 @@ describe('attentionItemService', () => {
     expect(mockUpdateOne).toHaveBeenCalledTimes(2);
     expect(mockUpdateOne).toHaveBeenCalledWith(
       expect.objectContaining({ 'source.type': 'task', 'source.id': 'task-1:update-1' }),
-      expect.objectContaining({ $setOnInsert: expect.objectContaining({ kind: 'decision', title: 'Choose a deploy shape' }) }),
+      expect.objectContaining({ $setOnInsert: expect.objectContaining({ kind: 'handoff', title: 'Choose a deploy shape' }) }),
       { upsert: true },
     );
+  });
+
+  it('acknowledges only recipient-owned mentions and handoffs, never decisions or approvals', async () => {
+    await AttentionItemService.acknowledgeMention('sam', '507f191e810c19729de860eb');
+
+    const selector = mockUpdateOne.mock.calls.at(-1)[0];
+    expect(selector).toEqual({
+      _id: '507f191e810c19729de860eb',
+      recipientUserId: 'sam',
+      status: 'open',
+      $or: [
+        { kind: 'mention' },
+        { kind: 'handoff' },
+        { kind: 'decision', 'source.type': 'task' },
+      ],
+    });
+    expect(mockUpdateOne.mock.calls.at(-1)[1]).toEqual({
+      $set: expect.objectContaining({ status: 'resolved', resolvedBy: 'acknowledged' }),
+    });
   });
 
   it('resolves every outstanding fact for a task once the task no longer needs a human', async () => {

--- a/backend/models/AttentionItem.ts
+++ b/backend/models/AttentionItem.ts
@@ -1,6 +1,6 @@
 import mongoose, { Document, Model, Schema, Types } from 'mongoose';
 
-export type AttentionKind = 'mention' | 'approval' | 'decision';
+export type AttentionKind = 'mention' | 'approval' | 'decision' | 'handoff';
 export type AttentionSourceType = 'message' | 'approval' | 'decision_request' | 'task';
 
 export interface IAttentionItem extends Document {
@@ -21,8 +21,9 @@ export interface IAttentionItem extends Document {
   sourceCreatedAt?: Date;
   status: 'open' | 'resolved';
   resolvedAt?: Date;
-  // Mention rows resolve only when their recipient replies in the pod or
-  // explicitly acknowledges them. Other attention sources do not use this.
+  // Mention/handoff rows resolve when their recipient replies or explicitly
+  // acknowledges them. Decision and approval actions have source-specific
+  // writers and never become dismissible through this field.
   resolvedBy?: 'replied' | 'acknowledged';
   createdAt: Date;
   updatedAt: Date;
@@ -37,7 +38,7 @@ const optionSchema = new Schema({
 const attentionItemSchema = new Schema<IAttentionItem>({
   recipientUserId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
   podId: { type: Schema.Types.ObjectId, ref: 'Pod', required: true },
-  kind: { type: String, enum: ['mention', 'approval', 'decision'], required: true },
+  kind: { type: String, enum: ['mention', 'approval', 'decision', 'handoff'], required: true },
   source: {
     type: { type: String, enum: ['message', 'approval', 'decision_request', 'task'], required: true },
     id: { type: String, required: true },

--- a/backend/models/AttentionItem.ts
+++ b/backend/models/AttentionItem.ts
@@ -21,9 +21,10 @@ export interface IAttentionItem extends Document {
   sourceCreatedAt?: Date;
   status: 'open' | 'resolved';
   resolvedAt?: Date;
-  // Mention/handoff rows resolve when their recipient replies or explicitly
-  // acknowledges them. Decision and approval actions have source-specific
-  // writers and never become dismissible through this field.
+  // Mention rows may resolve when their recipient replies; mention and handoff
+  // rows also support an explicit recipient acknowledgement. Decision and
+  // approval actions have source-specific writers and never become dismissible
+  // through this field.
   resolvedBy?: 'replied' | 'acknowledged';
   createdAt: Date;
   updatedAt: Date;

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -207,11 +207,11 @@ router.post('/:activityId/acknowledge', auth, async (req: Req, res: Res) => {
     const { activityId } = req.params || {};
     const userId = getAuthenticatedUserId(req);
     const result = await ActivityService.acknowledgeMention(userId, String(activityId)) as { success?: boolean; error?: string };
-    if (!result.success) return res.status(400).json({ error: result.error || 'Failed to acknowledge mention' });
+    if (!result.success) return res.status(400).json({ error: result.error || 'Failed to acknowledge attention' });
     return res.json(result);
   } catch (error) {
-    console.error('Error acknowledging activity mention:', error);
-    return res.status(500).json({ error: 'Failed to acknowledge mention' });
+    console.error('Error acknowledging activity attention:', error);
+    return res.status(500).json({ error: 'Failed to acknowledge attention' });
   }
 });
 

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -206,7 +206,7 @@ router.post('/:activityId/acknowledge', auth, async (req: Req, res: Res) => {
   try {
     const { activityId } = req.params || {};
     const userId = getAuthenticatedUserId(req);
-    const result = await ActivityService.acknowledgeMention(userId, String(activityId)) as { success?: boolean; error?: string };
+    const result = await ActivityService.acknowledgeAttention(userId, String(activityId)) as { success?: boolean; error?: string };
     if (!result.success) return res.status(400).json({ error: result.error || 'Failed to acknowledge attention' });
     return res.json(result);
   } catch (error) {

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -206,7 +206,7 @@ router.post('/:activityId/acknowledge', auth, async (req: Req, res: Res) => {
   try {
     const { activityId } = req.params || {};
     const userId = getAuthenticatedUserId(req);
-    const result = await ActivityService.acknowledgeAttention(userId, String(activityId)) as { success?: boolean; error?: string };
+    const result = await ActivityService.acknowledgeMention(userId, String(activityId)) as { success?: boolean; error?: string };
     if (!result.success) return res.status(400).json({ error: result.error || 'Failed to acknowledge attention' });
     return res.json(result);
   } catch (error) {

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -822,9 +822,7 @@ class ActivityService {
   }
 
   static async acknowledgeMention(userId: unknown, activityId: string): Promise<Record<string, unknown>> {
-    // eslint-disable-next-line global-require
-    const AttentionItemService = require('./attentionItemService');
-    return AttentionItemService.acknowledgeMention(userId, activityId);
+    return ActivityService.acknowledgeAttention(userId, activityId);
   }
 
   static async acknowledgeAttention(userId: unknown, activityId: string): Promise<Record<string, unknown>> {

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -822,10 +822,6 @@ class ActivityService {
   }
 
   static async acknowledgeMention(userId: unknown, activityId: string): Promise<Record<string, unknown>> {
-    return ActivityService.acknowledgeAttention(userId, activityId);
-  }
-
-  static async acknowledgeAttention(userId: unknown, activityId: string): Promise<Record<string, unknown>> {
     // eslint-disable-next-line global-require
     const AttentionItemService = require('./attentionItemService');
     return AttentionItemService.acknowledgeAttention(userId, activityId);

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -827,6 +827,12 @@ class ActivityService {
     return AttentionItemService.acknowledgeMention(userId, activityId);
   }
 
+  static async acknowledgeAttention(userId: unknown, activityId: string): Promise<Record<string, unknown>> {
+    // eslint-disable-next-line global-require
+    const AttentionItemService = require('./attentionItemService');
+    return AttentionItemService.acknowledgeAttention(userId, activityId);
+  }
+
   static async getUnreadCount(userId: unknown, options: GetFeedOptions = {}): Promise<{ unreadCount: number }> {
     const activitiesResult = await ActivityService.getUserFeed(userId, {
       ...options,

--- a/backend/services/attentionItemService.ts
+++ b/backend/services/attentionItemService.ts
@@ -383,11 +383,6 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
     counts[podId] = (counts[podId] || 0) + 1;
     return counts;
   }, {});
-  const countsByKind = valid.reduce((counts: Record<string, number>, row: any) => {
-    const kind = renderKind(row);
-    counts[kind] = (counts[kind] || 0) + 1;
-    return counts;
-  }, {});
   // The composer target is an account-level fact, not a property of the
   // rendered page. A priority-heavy first page can contain no mentions even
   // while an accessible mention exists later in the global ordering.
@@ -396,6 +391,14 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   const scoped = requestedPodId
     ? valid.filter((row: any) => String(row.podId) === requestedPodId)
     : valid;
+  // Per-kind totals describe the requested view, but are calculated before
+  // pagination. Legacy task rows are projected through renderKind so their
+  // handoff bucket agrees with the card and acknowledgement semantics.
+  const countsByKind = scoped.reduce((counts: Record<string, number>, row: any) => {
+    const kind = renderKind(row);
+    counts[kind] = (counts[kind] || 0) + 1;
+    return counts;
+  }, {});
   const page = scoped.slice(offset, offset + limit);
   const picked: any[] = [];
   for (const row of page) {

--- a/backend/services/attentionItemService.ts
+++ b/backend/services/attentionItemService.ts
@@ -13,7 +13,7 @@ const Message = require('../models/Message');
 const PGMessage = require('../models/pg/Message');
 
 type SourceType = 'message' | 'approval' | 'decision_request' | 'task';
-type Kind = 'mention' | 'approval' | 'decision';
+type Kind = 'mention' | 'approval' | 'decision' | 'handoff';
 type MentionOptions = {
   isAlreadyAcknowledged?: (recipientUserId: unknown, legacyMentionId: string) => boolean;
 };
@@ -291,7 +291,7 @@ export const recordTaskAttention = async (task: any, options: TaskAttentionOptio
     const taskKey = String(task._id || task.taskId);
     const sequence = String(last?._id || last?.createdAt?.getTime?.() || task.updatedAt?.getTime?.() || taskKey);
     await recordForRecipients(recipients, {
-      podId: task.podId, kind: 'decision' as Kind, sourceType: 'task' as SourceType,
+      podId: task.podId, kind: 'handoff' as Kind, sourceType: 'task' as SourceType,
       sourceId: `${taskKey}:${sequence}`,
       title: String(task.title || 'Task needs attention'), detail: compact(last?.text || task.notes, 220),
       podName: pod?.name || 'Pod',
@@ -347,6 +347,7 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   items: any[];
   count: number;
   countsByPod: Record<string, number>;
+  countsByKind: Record<string, number>;
   composePodId: string | null;
   offset: number;
   limit: number;
@@ -360,7 +361,7 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   // value keeps malformed/read-only callers from turning a cast error into a
   // 500 and makes the authorization boundary explicit.
   if (!/^[a-f\d]{24}$/i.test(String(recipientUserId))) {
-    return { items: [], count: 0, countsByPod: {}, composePodId: null, offset, limit, remaining: 0, hasMore: false };
+    return { items: [], count: 0, countsByPod: {}, countsByKind: {}, composePodId: null, offset, limit, remaining: 0, hasMore: false };
   }
   // Counts include every accessible open item. The selected pod scope is
   // applied before pagination so a scoped list cannot show a positive count
@@ -369,7 +370,10 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   const podIds = [...new Set(rows.map((row: any) => String(row.podId)))];
   const pods = await Pod.find({ _id: { $in: podIds } }).select('_id name createdBy members').lean();
   const allowed = new Map(pods.filter((pod: any) => isCurrentMember(pod, recipientUserId)).map((pod: any) => [String(pod._id), pod]));
-  const priority: Record<string, number> = { approval: 0, decision: 1, mention: 2 };
+  const priority: Record<string, number> = { approval: 0, decision: 1, handoff: 1, mention: 2 };
+  const renderKind = (row: any): Kind => (
+    row.kind === 'decision' && row.source?.type === 'task' ? 'handoff' : row.kind
+  );
   const valid = rows.filter((row: any) => allowed.has(String(row.podId))).sort((a: any, b: any) => (
     (priority[a.kind] ?? 9) - (priority[b.kind] ?? 9)
     || new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
@@ -377,6 +381,11 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   const countsByPod = valid.reduce((counts: Record<string, number>, row: any) => {
     const podId = String(row.podId);
     counts[podId] = (counts[podId] || 0) + 1;
+    return counts;
+  }, {});
+  const countsByKind = valid.reduce((counts: Record<string, number>, row: any) => {
+    const kind = renderKind(row);
+    counts[kind] = (counts[kind] || 0) + 1;
     return counts;
   }, {});
   // The composer target is an account-level fact, not a property of the
@@ -391,7 +400,7 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   const picked: any[] = [];
   for (const row of page) {
     picked.push({
-      id: String(row.source.id), attentionItemId: String(row._id), kind: row.kind, title: row.title, actorName: row.actorName || undefined, detail: row.detail || '',
+      id: String(row.source.id), attentionItemId: String(row._id), kind: renderKind(row), title: row.title, actorName: row.actorName || undefined, detail: row.detail || '',
       podId: String(row.podId), podName: (allowed.get(String(row.podId)) as any)?.name || row.podName || 'Pod',
       messageId: row.messageId, threadRootId: row.threadRootId, options: row.options || [], createdAt: row.createdAt,
     });
@@ -401,6 +410,7 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
     items: picked,
     count: scoped.length,
     countsByPod,
+    countsByKind,
     composePodId,
     offset,
     limit,
@@ -409,15 +419,29 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   };
 };
 
-export const acknowledgeMention = async (recipientUserId: unknown, attentionItemId: string): Promise<{ success: boolean; error?: string }> => {
+export const acknowledgeAttention = async (recipientUserId: unknown, attentionItemId: string): Promise<{ success: boolean; error?: string }> => {
   if (!/^[a-f\d]{24}$/i.test(String(attentionItemId))) return { success: false, error: 'Invalid attention item' };
   const result = await AttentionItem.updateOne(
-    { _id: attentionItemId, recipientUserId, kind: 'mention', status: 'open' },
+    {
+      _id: attentionItemId,
+      recipientUserId,
+      status: 'open',
+      $or: [
+        { kind: 'mention' },
+        { kind: 'handoff' },
+        { kind: 'decision', 'source.type': 'task' },
+      ],
+    },
     { $set: { status: 'resolved', resolvedAt: new Date(), resolvedBy: 'acknowledged' } },
   );
   return result.modifiedCount === 1 ? { success: true } : { success: false, error: 'Attention item not found' };
 };
 
-export default { recordMentionedUsers, resolveMentionAttentionForReply, sweepResolvedMentionAttention, recordApproval, recordDecision, recordTaskAttention, resolveTaskAttention, resolve, resolveMany, getOpenQueue, acknowledgeMention };
+// Kept as the public name for the existing Activity route. The selector is
+// now deliberately recipient-owned and covers mentions plus handoffs while
+// excluding true decisions and approvals.
+export const acknowledgeMention = acknowledgeAttention;
+
+export default { recordMentionedUsers, resolveMentionAttentionForReply, sweepResolvedMentionAttention, recordApproval, recordDecision, recordTaskAttention, resolveTaskAttention, resolve, resolveMany, getOpenQueue, acknowledgeAttention, acknowledgeMention };
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-module.exports = { recordMentionedUsers, resolveMentionAttentionForReply, sweepResolvedMentionAttention, recordApproval, recordDecision, recordTaskAttention, resolveTaskAttention, resolve, resolveMany, getOpenQueue, acknowledgeMention, TASK_HANDOFF_RE };
+module.exports = { recordMentionedUsers, resolveMentionAttentionForReply, sweepResolvedMentionAttention, recordApproval, recordDecision, recordTaskAttention, resolveTaskAttention, resolve, resolveMany, getOpenQueue, acknowledgeAttention, acknowledgeMention, TASK_HANDOFF_RE };

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -62,7 +62,8 @@
       "placeholder": "Reply in thread…",
       "send": "Send",
       "working": "Sending…",
-      "sent": "Reply posted"
+      "sent": "Reply posted",
+      "actionFailed": "Your reply could not be sent. Try again."
     },
     "lastActive": "Active {{time}} ago",
     "updatesCount_one": "{{count}} update",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -82,6 +82,7 @@
         "mention": "Mention",
         "approval": "Approval",
         "decision": "Decision needed",
+        "handoff": "Handoff",
         "press": "Ready for your press"
       },
       "countLabel": "{{count}} waiting on you"
@@ -129,6 +130,11 @@
       "markHandled": "Mark handled",
       "working": "Saving…",
       "actionFailed": "That mention could not be acknowledged. Try again."
+    },
+    "handoff": {
+      "markHandled": "Mark handled",
+      "working": "Saving…",
+      "actionFailed": "That handoff could not be marked handled. Try again."
     },
     "agents": {
       "eyebrow": "Agent recap",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -82,6 +82,7 @@
         "mention": "提及",
         "approval": "审批",
         "decision": "待你决策",
+        "handoff": "交接",
         "press": "待你合并"
       },
       "countLabel": "{{count}} 项等你处理"
@@ -129,6 +130,11 @@
       "markHandled": "标记已处理",
       "working": "正在保存…",
       "actionFailed": "无法确认该提及，请重试。"
+    },
+    "handoff": {
+      "markHandled": "标记已处理",
+      "working": "正在保存…",
+      "actionFailed": "无法标记该交接，请重试。"
     },
     "agents": {
       "eyebrow": "智能体回顾",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -62,7 +62,8 @@
       "placeholder": "在话题中回复…",
       "send": "发送",
       "working": "发送中…",
-      "sent": "已回复"
+      "sent": "已回复",
+      "actionFailed": "回复发送失败，请重试。"
     },
     "lastActive": "{{time}}前活跃",
     "updatesCount_one": "{{count}} 条更新",

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -359,10 +359,10 @@ describe('V2ActivityPage', () => {
     fireEvent.click(within(row).getByRole('button', { name: 'Mark handled' }));
 
     expect(await within(row).findByRole('alert')).toHaveTextContent(/could not be marked handled/i);
-    expect(within(row).getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(within(row).getByRole('button', { name: 'Mark handled' })).toBeInTheDocument();
     expect(screen.getAllByRole('alert')).toHaveLength(1);
 
-    fireEvent.click(within(row).getByRole('button', { name: 'Retry' }));
+    fireEvent.click(within(row).getByRole('button', { name: 'Mark handled' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(2));
     expect(await screen.findByText('Nothing open.')).toBeInTheDocument();
   });

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -356,15 +356,36 @@ describe('V2ActivityPage', () => {
     renderPage();
 
     const row = (await screen.findByText('Needs a retry')).closest('article') as HTMLElement;
-    fireEvent.click(within(row).getByRole('button', { name: 'Mark handled' }));
+    const markHandled = within(row).getByRole('button', { name: 'Mark handled' });
+    markHandled.focus();
+    fireEvent.click(markHandled);
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    (document.activeElement as HTMLElement | null)?.blur();
 
     expect(await within(row).findByRole('alert')).toHaveTextContent(/could not be marked handled/i);
+    await waitFor(() => expect(markHandled).toHaveFocus());
     expect(within(row).getByRole('button', { name: 'Mark handled' })).toBeInTheDocument();
     expect(screen.getAllByRole('alert')).toHaveLength(1);
 
     fireEvent.click(within(row).getByRole('button', { name: 'Mark handled' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(2));
     expect(await screen.findByText('Nothing open.')).toBeInTheDocument();
+  });
+
+  test('keeps a failed reply actionable with reply-specific feedback and focus', async () => {
+    mockPost.mockRejectedValueOnce(new Error('reply down'));
+    renderPage();
+
+    const row = (await screen.findByText('Review requested')).closest('article') as HTMLElement;
+    fireEvent.click(within(row).getByRole('button', { name: 'Reply' }));
+    const composer = await within(row).findByRole('textbox', { name: 'Reply in thread…' });
+    fireEvent.change(composer, { target: { value: 'please check this' } });
+    composer.focus();
+    fireEvent.keyDown(composer, { key: 'Enter', ctrlKey: true });
+    (document.activeElement as HTMLElement | null)?.blur();
+
+    expect(await within(row).findByRole('alert')).toHaveTextContent(/Your reply could not be sent/i);
+    await waitFor(() => expect(composer).toHaveFocus());
   });
 
   test('opens an inline reply and posts it into the source thread', async () => {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -372,6 +372,58 @@ describe('V2ActivityPage', () => {
     expect(await screen.findByText('Nothing open.')).toBeInTheDocument();
   });
 
+  test('does not steal focus when the user moves during a failed action', async () => {
+    let rejectRequest: (error: Error) => void;
+    mockPost.mockImplementationOnce(() => new Promise((resolve, reject) => { rejectRequest = reject; }));
+    renderPage();
+    const acknowledge = await screen.findByRole('button', { name: 'Mark handled' });
+    acknowledge.focus();
+    fireEvent.click(acknowledge);
+    acknowledge.blur(); // Real browsers blur a newly disabled focused button.
+    const compose = screen.getByRole('textbox', { name: i18n.t('activity.compose.placeholder') });
+    compose.focus();
+    await act(async () => { rejectRequest(new Error('temporary failure')); });
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+    expect(compose).toHaveFocus();
+    expect(acknowledge).not.toBeDisabled();
+  });
+
+  test('an older failed action does not consume a newer action focus target', async () => {
+    const queue = {
+      ...decisionQueue,
+      items: [
+        { ...decisionQueue.items[0], id: 'approval-focus', kind: 'approval', title: 'Approval focus' },
+        { ...decisionQueue.items[0], id: 'handoff-focus', attentionItemId: 'handoff-attention', kind: 'handoff', title: 'Handoff focus' },
+      ],
+    };
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? queue : recap }));
+    let rejectApproval: (error: Error) => void;
+    let rejectHandoff: (error: Error) => void;
+    mockPost.mockImplementation((url: string) => {
+      (document.activeElement as HTMLElement | null)?.blur();
+      return new Promise((resolve, reject) => {
+        if (url.endsWith('/approve')) rejectApproval = reject;
+        else rejectHandoff = reject;
+      });
+    });
+    renderPage();
+    const approve = await screen.findByRole('button', { name: 'Approve' });
+    const handled = screen.getByRole('button', { name: 'Mark handled' });
+    approve.focus();
+    fireEvent.click(approve);
+    handled.focus();
+    fireEvent.click(handled);
+    expect(mockPost).toHaveBeenCalledTimes(2);
+    await act(async () => { rejectApproval(new Error('approval failed')); });
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+    expect(document.body).toHaveFocus();
+    expect(handled).toBeDisabled();
+    await act(async () => { rejectHandoff(new Error('handoff failed')); });
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+    expect(handled).toHaveFocus();
+    expect(handled).not.toBeDisabled();
+  });
+
   test('keeps a failed reply actionable with reply-specific feedback and focus', async () => {
     mockPost.mockRejectedValueOnce(new Error('reply down'));
     renderPage();

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -330,6 +330,43 @@ describe('V2ActivityPage', () => {
     expect(await screen.findByText('Nothing open.')).toBeInTheDocument();
   });
 
+  test('keeps a failed handoff acknowledgement and retry beside its row', async () => {
+    const handoffQueue = {
+      items: [{
+        id: 'task-1:update-2', attentionItemId: 'attention-handoff-2', kind: 'handoff',
+        title: 'Needs a retry', detail: 'The first acknowledgement fails.',
+        podId: 'pod-1', podName: 'Launch pod', createdAt: '2026-08-26T11:00:00.000Z',
+      }],
+      count: 1,
+      countsByPod: { 'pod-1': 1 },
+      countsByKind: { handoff: 1 },
+      composePodId: 'pod-1',
+    };
+    let queueReads = 0;
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') {
+        queueReads += 1;
+        return Promise.resolve({ data: queueReads === 1 ? handoffQueue : { items: [], count: 0, countsByPod: {}, countsByKind: {} } });
+      }
+      return Promise.resolve({ data: { ...recap, needsYou: [] } });
+    });
+    mockPost
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce({ data: { success: true } });
+    renderPage();
+
+    const row = (await screen.findByText('Needs a retry')).closest('article') as HTMLElement;
+    fireEvent.click(within(row).getByRole('button', { name: 'Mark handled' }));
+
+    expect(await within(row).findByRole('alert')).toHaveTextContent(/could not be marked handled/i);
+    expect(within(row).getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+
+    fireEvent.click(within(row).getByRole('button', { name: 'Retry' }));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Nothing open.')).toBeInTheDocument();
+  });
+
   test('opens an inline reply and posts it into the source thread', async () => {
     mockPost.mockResolvedValue({ data: { id: 123 } });
     renderPage();

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -272,12 +272,12 @@ describe('V2ActivityPage', () => {
     ));
   });
 
-  test('keeps a task attention row as an open-thread fact when it has no declared options', async () => {
+  test('keeps a decision request as an open-thread fact when it has no declared options', async () => {
     const taskQueue = {
       items: [{
-        id: 'task-1:blocked', attentionItemId: 'attention-task-1', kind: 'decision',
+        id: 'decision-1', attentionItemId: 'attention-decision-1', kind: 'decision',
         title: 'Choose a deploy shape', detail: 'Blocked on an upstream choice.',
-        podId: 'pod-1', podName: 'Launch pod', options: [], createdAt: '2026-08-26T11:00:00.000Z',
+        podId: 'pod-1', podName: 'Launch pod', options: [], source: { type: 'decision_request' }, createdAt: '2026-08-26T11:00:00.000Z',
       }],
       count: 1,
       composePodId: null,
@@ -291,6 +291,43 @@ describe('V2ActivityPage', () => {
     expect(screen.queryByRole('button', { name: 'Other…' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Rule:/ })).not.toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Open pod' })).not.toHaveLength(0);
+  });
+
+  test('renders a handoff as a handled action, never as a decision', async () => {
+    const handoffQueue = {
+      items: [{
+        id: 'task-1:update-1', attentionItemId: 'attention-handoff-1', kind: 'handoff',
+        title: 'Ready for your press', detail: 'The bounded implementation is ready for review.',
+        podId: 'pod-1', podName: 'Launch pod', createdAt: '2026-08-26T11:00:00.000Z',
+      }],
+      count: 1,
+      countsByPod: { 'pod-1': 1 },
+      countsByKind: { handoff: 1 },
+      composePodId: 'pod-1',
+    };
+    let queueReads = 0;
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') {
+        queueReads += 1;
+        return Promise.resolve({ data: queueReads === 1 ? handoffQueue : { items: [], count: 0, countsByPod: {}, countsByKind: {} } });
+      }
+      return Promise.resolve({ data: { ...recap, needsYou: [] } });
+    });
+    mockPost.mockResolvedValue({ data: { success: true } });
+    renderPage();
+
+    expect(await screen.findByText('Ready for your press')).toBeInTheDocument();
+    expect(screen.getByText(/Handoff · Launch pod/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Mark handled' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rule:/ })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark handled' }));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
+      '/api/activity/attention-handoff-1/acknowledge',
+      {},
+      expect.objectContaining({ headers: expect.any(Object) }),
+    ));
+    expect(await screen.findByText('Nothing open.')).toBeInTheDocument();
   });
 
   test('opens an inline reply and posts it into the source thread', async () => {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -388,6 +388,81 @@ describe('V2ActivityPage', () => {
     await waitFor(() => expect(composer).toHaveFocus());
   });
 
+  test('does not steal focus when the user moves to another control during a failed action', async () => {
+    const handoffQueue = {
+      items: [{
+        id: 'task-1:update-focus', attentionItemId: 'attention-handoff-focus', kind: 'handoff',
+        title: 'Focus-safe handoff', detail: 'Keep the user in control.',
+        podId: 'pod-1', podName: 'Launch pod', createdAt: '2026-08-26T11:00:00.000Z',
+      }],
+      count: 1,
+      countsByPod: { 'pod-1': 1 },
+      countsByKind: { handoff: 1 },
+      composePodId: 'pod-1',
+    };
+    let rejectAction: ((error: Error) => void) | null = null;
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? handoffQueue : { ...recap, needsYou: [] } }));
+    mockPost.mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectAction = reject; }));
+    renderPage();
+
+    const row = (await screen.findByText('Focus-safe handoff')).closest('article') as HTMLElement;
+    const markHandled = within(row).getByRole('button', { name: 'Mark handled' });
+    const openPod = within(row).getByRole('button', { name: 'Open pod' });
+    markHandled.focus();
+    fireEvent.click(markHandled);
+    await waitFor(() => expect(markHandled).toHaveTextContent('Saving…'));
+    openPod.focus();
+    await act(async () => { rejectAction?.(new Error('temporary failure')); });
+
+    expect(await within(row).findByRole('alert')).toHaveTextContent(/could not be marked handled/i);
+    expect(openPod).toHaveFocus();
+  });
+
+  test('keeps concurrent action failures on their own focus requests', async () => {
+    const queue = {
+      items: [
+        {
+          id: 'approval-focus', kind: 'approval', title: 'Approve the change', detail: 'A protected action.',
+          podId: 'pod-1', podName: 'Launch pod', createdAt: '2026-08-26T11:00:00.000Z',
+        },
+        {
+          id: 'handoff-focus', attentionItemId: 'attention-handoff-focus-2', kind: 'handoff', title: 'Review the change', detail: 'A recipient-owned handoff.',
+          podId: 'pod-1', podName: 'Launch pod', createdAt: '2026-08-26T10:00:00.000Z',
+        },
+      ],
+      count: 2,
+      countsByPod: { 'pod-1': 2 },
+      countsByKind: { approval: 1, handoff: 1 },
+      composePodId: 'pod-1',
+    };
+    let rejectApproval: ((error: Error) => void) | null = null;
+    let rejectHandoff: ((error: Error) => void) | null = null;
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? queue : { ...recap, needsYou: [] } }));
+    mockPost.mockImplementation((url: string) => new Promise((_resolve, reject) => {
+      if (url.includes('/approval-focus/')) rejectApproval = reject;
+      else rejectHandoff = reject;
+    }));
+    renderPage();
+
+    const approvalRow = (await screen.findByText('Approve the change')).closest('article') as HTMLElement;
+    const handoffRow = (await screen.findByText('Review the change')).closest('article') as HTMLElement;
+    const approve = within(approvalRow).getByRole('button', { name: 'Approve' });
+    const markHandled = within(handoffRow).getByRole('button', { name: 'Mark handled' });
+    approve.focus();
+    fireEvent.click(approve);
+    markHandled.focus();
+    fireEvent.click(markHandled);
+
+    await act(async () => { rejectApproval?.(new Error('approval down')); await Promise.resolve(); });
+    expect(await within(approvalRow).findByRole('alert')).toHaveTextContent(/approval could not be updated/i);
+    expect(markHandled).toHaveFocus();
+
+    markHandled.blur();
+    await act(async () => { rejectHandoff?.(new Error('handoff down')); await Promise.resolve(); });
+    expect(await within(handoffRow).findByRole('alert')).toHaveTextContent(/handoff could not be marked handled/i);
+    await waitFor(() => expect(markHandled).toHaveFocus());
+  });
+
   test('opens an inline reply and posts it into the source thread', async () => {
     mockPost.mockResolvedValue({ data: { id: 123 } });
     renderPage();

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -372,58 +372,6 @@ describe('V2ActivityPage', () => {
     expect(await screen.findByText('Nothing open.')).toBeInTheDocument();
   });
 
-  test('does not steal focus when the user moves during a failed action', async () => {
-    let rejectRequest: (error: Error) => void;
-    mockPost.mockImplementationOnce(() => new Promise((resolve, reject) => { rejectRequest = reject; }));
-    renderPage();
-    const acknowledge = await screen.findByRole('button', { name: 'Mark handled' });
-    acknowledge.focus();
-    fireEvent.click(acknowledge);
-    acknowledge.blur(); // Real browsers blur a newly disabled focused button.
-    const compose = screen.getByRole('textbox', { name: i18n.t('activity.compose.placeholder') });
-    compose.focus();
-    await act(async () => { rejectRequest(new Error('temporary failure')); });
-    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
-    expect(compose).toHaveFocus();
-    expect(acknowledge).not.toBeDisabled();
-  });
-
-  test('an older failed action does not consume a newer action focus target', async () => {
-    const queue = {
-      ...decisionQueue,
-      items: [
-        { ...decisionQueue.items[0], id: 'approval-focus', kind: 'approval', title: 'Approval focus' },
-        { ...decisionQueue.items[0], id: 'handoff-focus', attentionItemId: 'handoff-attention', kind: 'handoff', title: 'Handoff focus' },
-      ],
-    };
-    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? queue : recap }));
-    let rejectApproval: (error: Error) => void;
-    let rejectHandoff: (error: Error) => void;
-    mockPost.mockImplementation((url: string) => {
-      (document.activeElement as HTMLElement | null)?.blur();
-      return new Promise((resolve, reject) => {
-        if (url.endsWith('/approve')) rejectApproval = reject;
-        else rejectHandoff = reject;
-      });
-    });
-    renderPage();
-    const approve = await screen.findByRole('button', { name: 'Approve' });
-    const handled = screen.getByRole('button', { name: 'Mark handled' });
-    approve.focus();
-    fireEvent.click(approve);
-    handled.focus();
-    fireEvent.click(handled);
-    expect(mockPost).toHaveBeenCalledTimes(2);
-    await act(async () => { rejectApproval(new Error('approval failed')); });
-    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
-    expect(document.body).toHaveFocus();
-    expect(handled).toBeDisabled();
-    await act(async () => { rejectHandoff(new Error('handoff failed')); });
-    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
-    expect(handled).toHaveFocus();
-    expect(handled).not.toBeDisabled();
-  });
-
   test('keeps a failed reply actionable with reply-specific feedback and focus', async () => {
     mockPost.mockRejectedValueOnce(new Error('reply down'));
     renderPage();

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -1632,7 +1632,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(lastRuleBody(v2, '.v2-activity__scope-menu')).toContain('overflow-y: auto');
       expect(lastRuleBody(v2, '.v2-activity__queue-row .v2-activity__queue-actions')).toContain('grid-column: 3');
       expect(lastRuleBody(v2, '.v2-activity__queue-row .v2-activity__queue-actions:has(textarea)')).toContain('grid-column: 2 / -1');
-      const rowActionError = ruleBody(v2, '.v2-activity__row-action-error');
+      const rowActionError = ruleBody(v2, '.v2-root .v2-activity__row-action-error');
       expect(rowActionError).toContain('grid-column: 1 / -1');
       expect(rowActionError).toContain('color: var(--v2-ink)');
     });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -1632,6 +1632,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(lastRuleBody(v2, '.v2-activity__scope-menu')).toContain('overflow-y: auto');
       expect(lastRuleBody(v2, '.v2-activity__queue-row .v2-activity__queue-actions')).toContain('grid-column: 3');
       expect(lastRuleBody(v2, '.v2-activity__queue-row .v2-activity__queue-actions:has(textarea)')).toContain('grid-column: 2 / -1');
+      expect(v2).toMatch(/@media \(max-width: 640px\) \{[\s\S]*?\.v2-root \.v2-activity__reply button \{ min-height: 44px; \}/);
       const rowActionError = ruleBody(v2, '.v2-root .v2-activity__row-action-error');
       expect(rowActionError).toContain('grid-column: 1 / -1');
       expect(rowActionError).toContain('color: var(--v2-ink)');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -1632,6 +1632,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(lastRuleBody(v2, '.v2-activity__scope-menu')).toContain('overflow-y: auto');
       expect(lastRuleBody(v2, '.v2-activity__queue-row .v2-activity__queue-actions')).toContain('grid-column: 3');
       expect(lastRuleBody(v2, '.v2-activity__queue-row .v2-activity__queue-actions:has(textarea)')).toContain('grid-column: 2 / -1');
+      const rowActionError = ruleBody(v2, '.v2-activity__row-action-error');
+      expect(rowActionError).toContain('grid-column: 1 / -1');
+      expect(rowActionError).toContain('color: var(--v2-ink)');
     });
 
     test('halo focus: no hard outline in any Activity focus-visible rule; the global halo still carries the ring', () => {

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -165,7 +165,7 @@ const V2ActivityPage: React.FC = () => {
   const [queueMoreError, setQueueMoreError] = useState(false);
   const [queueFailed, setQueueFailed] = useState(false);
   const [queueHydrated, setQueueHydrated] = useState(false);
-  const actionFocusRef = useRef<Map<string, HTMLElement>>(new Map());
+  const actionFocusGenerationRef = useRef(0);
   const queueScopeRef = useRef('all');
   const queueGenerationRef = useRef(0);
   const revalidationExtentRef = useRef(0);
@@ -525,38 +525,29 @@ const V2ActivityPage: React.FC = () => {
     navigate('/v2');
   };
 
-  // Action requests can overlap across kinds. Keep their focus targets keyed
-  // to the request so a late failure cannot restore another row's control.
-  const rememberActionFocus = (action: string, item: NeedsYouItem): string => {
-    const key = `${action}:${item.id}`;
+  const captureActionFocus = (item: NeedsYouItem) => {
+    const generation = ++actionFocusGenerationRef.current;
     const active = document.activeElement;
     const row = active?.closest<HTMLElement>('[data-activity-item-id]');
-    if (active instanceof HTMLElement && row?.dataset.activityItemId === item.id) {
-      actionFocusRef.current.set(key, active);
-    } else {
-      actionFocusRef.current.delete(key);
-    }
-    return key;
-  };
-
-  const clearActionFocus = (key: string) => {
-    actionFocusRef.current.delete(key);
-  };
-
-  const restoreActionFocus = (key: string) => {
-    const target = actionFocusRef.current.get(key);
-    actionFocusRef.current.delete(key);
-    if (!target) return;
-    globalThis.window.requestAnimationFrame(() => {
-      const active = document.activeElement;
-      const focusWasLost = !active || active === document.body || active === document.documentElement;
-      if ((focusWasLost || active === target) && document.contains(target)) target.focus({ preventScroll: true });
-    });
+    const target = active instanceof HTMLElement && row?.dataset.activityItemId === item.id ? active : null;
+    // Each request owns its target. A later action supersedes older recovery,
+    // and an intentional focus move must survive an eventual failed request.
+    return () => {
+      if (!target) return;
+      globalThis.window.requestAnimationFrame(() => {
+        const current = document.activeElement;
+        if (generation === actionFocusGenerationRef.current
+          && document.contains(target)
+          && (current === document.body || current === target)) {
+          target.focus({ preventScroll: true });
+        }
+      });
+    };
   };
 
   const actOnApproval = async (item: NeedsYouItem, action: 'approve' | 'reject') => {
     if (actingApprovalId) return;
-    const focusKey = rememberActionFocus(`approval:${action}`, item);
+    const restoreActionFocus = captureActionFocus(item);
     setActingApprovalId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -573,16 +564,15 @@ const V2ActivityPage: React.FC = () => {
     } catch {
       setActionErrorItemId(item.id);
       setActionError(t('activity.approval.actionFailed'));
-      restoreActionFocus(focusKey);
+      restoreActionFocus();
     } finally {
-      clearActionFocus(focusKey);
       setActingApprovalId(null);
     }
   };
 
   const ruleDecision = async (item: NeedsYouItem, value: string) => {
     if (rulingId || !value.trim()) return;
-    const focusKey = rememberActionFocus('decision', item);
+    const restoreActionFocus = captureActionFocus(item);
     setRulingId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -608,10 +598,9 @@ const V2ActivityPage: React.FC = () => {
       } else {
         setActionErrorItemId(item.id);
         setActionError(t('activity.decision.actionFailed'));
-        restoreActionFocus(focusKey);
+        restoreActionFocus();
       }
     } finally {
-      clearActionFocus(focusKey);
       setRulingId(null);
     }
   };
@@ -648,7 +637,7 @@ const V2ActivityPage: React.FC = () => {
   const sendReply = async (item: NeedsYouItem) => {
     const content = (replyDrafts[item.id] || '').trim();
     if (!content || replyingId || !item.podId) return;
-    const focusKey = rememberActionFocus('reply', item);
+    const restoreActionFocus = captureActionFocus(item);
     setReplyingId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -667,16 +656,15 @@ const V2ActivityPage: React.FC = () => {
     } catch {
       setActionErrorItemId(item.id);
       setActionError(t('activity.reply.actionFailed', { defaultValue: 'Your reply could not be sent. Try again.' }));
-      restoreActionFocus(focusKey);
+      restoreActionFocus();
     } finally {
-      clearActionFocus(focusKey);
       setReplyingId(null);
     }
   };
 
   const acknowledgeAttention = async (item: NeedsYouItem, errorKey: 'activity.mention.actionFailed' | 'activity.handoff.actionFailed') => {
     if (acknowledgingAttentionId) return;
-    const focusKey = rememberActionFocus('acknowledge', item);
+    const restoreActionFocus = captureActionFocus(item);
     setAcknowledgingAttentionId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -694,9 +682,8 @@ const V2ActivityPage: React.FC = () => {
       const message = t(errorKey, { defaultValue: 'That attention item could not be marked handled. Try again.' });
       setActionErrorItemId(item.id);
       setActionError(message);
-      restoreActionFocus(focusKey);
+      restoreActionFocus();
     } finally {
-      clearActionFocus(focusKey);
       setAcknowledgingAttentionId(null);
     }
   };

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -165,7 +165,7 @@ const V2ActivityPage: React.FC = () => {
   const [queueMoreError, setQueueMoreError] = useState(false);
   const [queueFailed, setQueueFailed] = useState(false);
   const [queueHydrated, setQueueHydrated] = useState(false);
-  const actionFocusRef = useRef<HTMLElement | null>(null);
+  const actionFocusRef = useRef<Map<string, HTMLElement>>(new Map());
   const queueScopeRef = useRef('all');
   const queueGenerationRef = useRef(0);
   const revalidationExtentRef = useRef(0);
@@ -525,24 +525,38 @@ const V2ActivityPage: React.FC = () => {
     navigate('/v2');
   };
 
-  const rememberActionFocus = (item: NeedsYouItem) => {
+  // Action requests can overlap across kinds. Keep their focus targets keyed
+  // to the request so a late failure cannot restore another row's control.
+  const rememberActionFocus = (action: string, item: NeedsYouItem): string => {
+    const key = `${action}:${item.id}`;
     const active = document.activeElement;
     const row = active?.closest<HTMLElement>('[data-activity-item-id]');
-    actionFocusRef.current = active instanceof HTMLElement && row?.dataset.activityItemId === item.id ? active : null;
+    if (active instanceof HTMLElement && row?.dataset.activityItemId === item.id) {
+      actionFocusRef.current.set(key, active);
+    } else {
+      actionFocusRef.current.delete(key);
+    }
+    return key;
   };
 
-  const restoreActionFocus = () => {
-    const target = actionFocusRef.current;
-    actionFocusRef.current = null;
+  const clearActionFocus = (key: string) => {
+    actionFocusRef.current.delete(key);
+  };
+
+  const restoreActionFocus = (key: string) => {
+    const target = actionFocusRef.current.get(key);
+    actionFocusRef.current.delete(key);
     if (!target) return;
     globalThis.window.requestAnimationFrame(() => {
-      if (document.contains(target)) target.focus({ preventScroll: true });
+      const active = document.activeElement;
+      const focusWasLost = !active || active === document.body || active === document.documentElement;
+      if ((focusWasLost || active === target) && document.contains(target)) target.focus({ preventScroll: true });
     });
   };
 
   const actOnApproval = async (item: NeedsYouItem, action: 'approve' | 'reject') => {
     if (actingApprovalId) return;
-    rememberActionFocus(item);
+    const focusKey = rememberActionFocus(`approval:${action}`, item);
     setActingApprovalId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -559,15 +573,16 @@ const V2ActivityPage: React.FC = () => {
     } catch {
       setActionErrorItemId(item.id);
       setActionError(t('activity.approval.actionFailed'));
-      restoreActionFocus();
+      restoreActionFocus(focusKey);
     } finally {
+      clearActionFocus(focusKey);
       setActingApprovalId(null);
     }
   };
 
   const ruleDecision = async (item: NeedsYouItem, value: string) => {
     if (rulingId || !value.trim()) return;
-    rememberActionFocus(item);
+    const focusKey = rememberActionFocus('decision', item);
     setRulingId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -593,9 +608,10 @@ const V2ActivityPage: React.FC = () => {
       } else {
         setActionErrorItemId(item.id);
         setActionError(t('activity.decision.actionFailed'));
-        restoreActionFocus();
+        restoreActionFocus(focusKey);
       }
     } finally {
+      clearActionFocus(focusKey);
       setRulingId(null);
     }
   };
@@ -632,7 +648,7 @@ const V2ActivityPage: React.FC = () => {
   const sendReply = async (item: NeedsYouItem) => {
     const content = (replyDrafts[item.id] || '').trim();
     if (!content || replyingId || !item.podId) return;
-    rememberActionFocus(item);
+    const focusKey = rememberActionFocus('reply', item);
     setReplyingId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -651,15 +667,16 @@ const V2ActivityPage: React.FC = () => {
     } catch {
       setActionErrorItemId(item.id);
       setActionError(t('activity.reply.actionFailed', { defaultValue: 'Your reply could not be sent. Try again.' }));
-      restoreActionFocus();
+      restoreActionFocus(focusKey);
     } finally {
+      clearActionFocus(focusKey);
       setReplyingId(null);
     }
   };
 
   const acknowledgeAttention = async (item: NeedsYouItem, errorKey: 'activity.mention.actionFailed' | 'activity.handoff.actionFailed') => {
     if (acknowledgingAttentionId) return;
-    rememberActionFocus(item);
+    const focusKey = rememberActionFocus('acknowledge', item);
     setAcknowledgingAttentionId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -677,8 +694,9 @@ const V2ActivityPage: React.FC = () => {
       const message = t(errorKey, { defaultValue: 'That attention item could not be marked handled. Try again.' });
       setActionErrorItemId(item.id);
       setActionError(message);
-      restoreActionFocus();
+      restoreActionFocus(focusKey);
     } finally {
+      clearActionFocus(focusKey);
       setAcknowledgingAttentionId(null);
     }
   };

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -165,6 +165,7 @@ const V2ActivityPage: React.FC = () => {
   const [queueMoreError, setQueueMoreError] = useState(false);
   const [queueFailed, setQueueFailed] = useState(false);
   const [queueHydrated, setQueueHydrated] = useState(false);
+  const actionFocusRef = useRef<HTMLElement | null>(null);
   const queueScopeRef = useRef('all');
   const queueGenerationRef = useRef(0);
   const revalidationExtentRef = useRef(0);
@@ -524,8 +525,24 @@ const V2ActivityPage: React.FC = () => {
     navigate('/v2');
   };
 
+  const rememberActionFocus = (item: NeedsYouItem) => {
+    const active = document.activeElement;
+    const row = active?.closest<HTMLElement>('[data-activity-item-id]');
+    actionFocusRef.current = active instanceof HTMLElement && row?.dataset.activityItemId === item.id ? active : null;
+  };
+
+  const restoreActionFocus = () => {
+    const target = actionFocusRef.current;
+    actionFocusRef.current = null;
+    if (!target) return;
+    globalThis.window.requestAnimationFrame(() => {
+      if (document.contains(target)) target.focus({ preventScroll: true });
+    });
+  };
+
   const actOnApproval = async (item: NeedsYouItem, action: 'approve' | 'reject') => {
     if (actingApprovalId) return;
+    rememberActionFocus(item);
     setActingApprovalId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -542,6 +559,7 @@ const V2ActivityPage: React.FC = () => {
     } catch {
       setActionErrorItemId(item.id);
       setActionError(t('activity.approval.actionFailed'));
+      restoreActionFocus();
     } finally {
       setActingApprovalId(null);
     }
@@ -549,6 +567,7 @@ const V2ActivityPage: React.FC = () => {
 
   const ruleDecision = async (item: NeedsYouItem, value: string) => {
     if (rulingId || !value.trim()) return;
+    rememberActionFocus(item);
     setRulingId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -574,6 +593,7 @@ const V2ActivityPage: React.FC = () => {
       } else {
         setActionErrorItemId(item.id);
         setActionError(t('activity.decision.actionFailed'));
+        restoreActionFocus();
       }
     } finally {
       setRulingId(null);
@@ -612,6 +632,7 @@ const V2ActivityPage: React.FC = () => {
   const sendReply = async (item: NeedsYouItem) => {
     const content = (replyDrafts[item.id] || '').trim();
     if (!content || replyingId || !item.podId) return;
+    rememberActionFocus(item);
     setReplyingId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -629,7 +650,8 @@ const V2ActivityPage: React.FC = () => {
       setReloadKey((value) => value + 1);
     } catch {
       setActionErrorItemId(item.id);
-      setActionError(t('activity.mention.actionFailed'));
+      setActionError(t('activity.reply.actionFailed', { defaultValue: 'Your reply could not be sent. Try again.' }));
+      restoreActionFocus();
     } finally {
       setReplyingId(null);
     }
@@ -637,6 +659,7 @@ const V2ActivityPage: React.FC = () => {
 
   const acknowledgeAttention = async (item: NeedsYouItem, errorKey: 'activity.mention.actionFailed' | 'activity.handoff.actionFailed') => {
     if (acknowledgingAttentionId) return;
+    rememberActionFocus(item);
     setAcknowledgingAttentionId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -654,6 +677,7 @@ const V2ActivityPage: React.FC = () => {
       const message = t(errorKey, { defaultValue: 'That attention item could not be marked handled. Try again.' });
       setActionErrorItemId(item.id);
       setActionError(message);
+      restoreActionFocus();
     } finally {
       setAcknowledgingAttentionId(null);
     }

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -540,6 +540,7 @@ const V2ActivityPage: React.FC = () => {
       notifyAttentionChanged();
       setReloadKey((value) => value + 1);
     } catch {
+      setActionErrorItemId(item.id);
       setActionError(t('activity.approval.actionFailed'));
     } finally {
       setActingApprovalId(null);
@@ -571,6 +572,7 @@ const V2ActivityPage: React.FC = () => {
           [item.id]: { value: standing.value, by: standing.by },
         }));
       } else {
+        setActionErrorItemId(item.id);
         setActionError(t('activity.decision.actionFailed'));
       }
     } finally {
@@ -626,6 +628,7 @@ const V2ActivityPage: React.FC = () => {
       notifyAttentionChanged();
       setReloadKey((value) => value + 1);
     } catch {
+      setActionErrorItemId(item.id);
       setActionError(t('activity.mention.actionFailed'));
     } finally {
       setReplyingId(null);
@@ -649,12 +652,8 @@ const V2ActivityPage: React.FC = () => {
       setReloadKey((value) => value + 1);
     } catch {
       const message = t(errorKey, { defaultValue: 'That attention item could not be marked handled. Try again.' });
-      if (item.kind === 'handoff') {
-        setActionErrorItemId(item.id);
-        setActionError(message);
-      } else {
-        setActionError(message);
-      }
+      setActionErrorItemId(item.id);
+      setActionError(message);
     } finally {
       setAcknowledgingAttentionId(null);
     }
@@ -924,13 +923,8 @@ const V2ActivityPage: React.FC = () => {
                         {item.messageId === undefined || item.messageId === null || item.messageId === '' ? t('activity.openPod') : t('activity.open')}
                       </button>
                     </div>
-                    {item.kind === 'handoff' && actionErrorItemId === item.id && actionError && (
-                      <div className="v2-activity__row-action-error" role="alert">
-                        <span>{actionError}</span>
-                        <button type="button" onClick={() => markHandoffHandled(item)} disabled={acknowledgingAttentionId === item.id}>
-                          {t('activity.needsYou.retry', { defaultValue: 'Retry' })}
-                        </button>
-                      </div>
+                    {actionErrorItemId === item.id && actionError && (
+                      <div className="v2-activity__row-action-error v2-activity__action-error" role="alert">{actionError}</div>
                     )}
                   </article>
                 ))}
@@ -954,7 +948,6 @@ const V2ActivityPage: React.FC = () => {
             {queue.length === 0 && queueMoreError && !queueFailed && (
               <button type="button" className="v2-activity__queue-more" onClick={() => setReloadKey((value) => value + 1)}>{t('activity.needsYou.retry', { defaultValue: 'Retry' })}</button>
             )}
-            {actionError && !actionErrorItemId && <div className="v2-activity__action-error" role="alert">{actionError}</div>}
           </section>
 
           <section className="v2-activity__section v2-activity__moved" aria-labelledby="activity-moved-forward">

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -93,7 +93,6 @@ interface ActivitySnapshot {
   queueCount?: number | null;
   queueRemaining?: number;
   queueCountsByPod?: Record<string, number>;
-  queueCountsByKind?: Record<string, number>;
   composePodId?: string;
   composeDraft?: string;
   replyDrafts?: Record<string, string>;
@@ -160,7 +159,6 @@ const V2ActivityPage: React.FC = () => {
   const queueRef = useRef<NeedsYouItem[]>([]);
   const [queueCount, setQueueCount] = useState<number | null>(null);
   const [queueCountsByPod, setQueueCountsByPod] = useState<Record<string, number>>({});
-  const [queueCountsByKind, setQueueCountsByKind] = useState<Record<string, number>>({});
   const [queueRemaining, setQueueRemaining] = useState(0);
   const [queueLoadingMore, setQueueLoadingMore] = useState(false);
   const [queueMoreError, setQueueMoreError] = useState(false);
@@ -202,7 +200,6 @@ const V2ActivityPage: React.FC = () => {
       setQueue(queueRef.current);
       setQueueCount(snapshot.queueCount ?? null);
       setQueueCountsByPod(snapshot.queueCountsByPod || {});
-      setQueueCountsByKind(snapshot.queueCountsByKind || {});
       setQueueRemaining(snapshot.queueRemaining || 0);
       setReplyDrafts(snapshot.replyDrafts || {});
       setComposePodId(snapshot.composePodId || '');
@@ -220,7 +217,6 @@ const V2ActivityPage: React.FC = () => {
       setQueue(queueRef.current);
       setQueueCount(null);
       setQueueCountsByPod({});
-      setQueueCountsByKind({});
       setQueueRemaining(0);
       setReplyDrafts({});
       setComposePodId('');
@@ -332,7 +328,6 @@ const V2ActivityPage: React.FC = () => {
         setQueueFailed(false);
         setQueueCount(queueResponse!.data.count);
         setQueueCountsByPod(queueResponse!.data.countsByPod || {});
-        setQueueCountsByKind(queueResponse!.data.countsByKind || {});
         const mapQueueItems = (items: QueueResponse['items']) => items.map((item) => ({
           ...item,
           detail: item.detail || '',
@@ -503,7 +498,6 @@ const V2ActivityPage: React.FC = () => {
         queueCount,
         queueRemaining,
         queueCountsByPod,
-        queueCountsByKind,
         replyDrafts,
         composePodId,
         composeDraft,

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -165,7 +165,7 @@ const V2ActivityPage: React.FC = () => {
   const [queueMoreError, setQueueMoreError] = useState(false);
   const [queueFailed, setQueueFailed] = useState(false);
   const [queueHydrated, setQueueHydrated] = useState(false);
-  const actionFocusGenerationRef = useRef(0);
+  const actionFocusRef = useRef<Map<string, HTMLElement>>(new Map());
   const queueScopeRef = useRef('all');
   const queueGenerationRef = useRef(0);
   const revalidationExtentRef = useRef(0);
@@ -525,29 +525,38 @@ const V2ActivityPage: React.FC = () => {
     navigate('/v2');
   };
 
-  const captureActionFocus = (item: NeedsYouItem) => {
-    const generation = ++actionFocusGenerationRef.current;
+  // Action requests can overlap across kinds. Keep their focus targets keyed
+  // to the request so a late failure cannot restore another row's control.
+  const rememberActionFocus = (action: string, item: NeedsYouItem): string => {
+    const key = `${action}:${item.id}`;
     const active = document.activeElement;
     const row = active?.closest<HTMLElement>('[data-activity-item-id]');
-    const target = active instanceof HTMLElement && row?.dataset.activityItemId === item.id ? active : null;
-    // Each request owns its target. A later action supersedes older recovery,
-    // and an intentional focus move must survive an eventual failed request.
-    return () => {
-      if (!target) return;
-      globalThis.window.requestAnimationFrame(() => {
-        const current = document.activeElement;
-        if (generation === actionFocusGenerationRef.current
-          && document.contains(target)
-          && (current === document.body || current === target)) {
-          target.focus({ preventScroll: true });
-        }
-      });
-    };
+    if (active instanceof HTMLElement && row?.dataset.activityItemId === item.id) {
+      actionFocusRef.current.set(key, active);
+    } else {
+      actionFocusRef.current.delete(key);
+    }
+    return key;
+  };
+
+  const clearActionFocus = (key: string) => {
+    actionFocusRef.current.delete(key);
+  };
+
+  const restoreActionFocus = (key: string) => {
+    const target = actionFocusRef.current.get(key);
+    actionFocusRef.current.delete(key);
+    if (!target) return;
+    globalThis.window.requestAnimationFrame(() => {
+      const active = document.activeElement;
+      const focusWasLost = !active || active === document.body || active === document.documentElement;
+      if ((focusWasLost || active === target) && document.contains(target)) target.focus({ preventScroll: true });
+    });
   };
 
   const actOnApproval = async (item: NeedsYouItem, action: 'approve' | 'reject') => {
     if (actingApprovalId) return;
-    const restoreActionFocus = captureActionFocus(item);
+    const focusKey = rememberActionFocus(`approval:${action}`, item);
     setActingApprovalId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -564,15 +573,16 @@ const V2ActivityPage: React.FC = () => {
     } catch {
       setActionErrorItemId(item.id);
       setActionError(t('activity.approval.actionFailed'));
-      restoreActionFocus();
+      restoreActionFocus(focusKey);
     } finally {
+      clearActionFocus(focusKey);
       setActingApprovalId(null);
     }
   };
 
   const ruleDecision = async (item: NeedsYouItem, value: string) => {
     if (rulingId || !value.trim()) return;
-    const restoreActionFocus = captureActionFocus(item);
+    const focusKey = rememberActionFocus('decision', item);
     setRulingId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -598,9 +608,10 @@ const V2ActivityPage: React.FC = () => {
       } else {
         setActionErrorItemId(item.id);
         setActionError(t('activity.decision.actionFailed'));
-        restoreActionFocus();
+        restoreActionFocus(focusKey);
       }
     } finally {
+      clearActionFocus(focusKey);
       setRulingId(null);
     }
   };
@@ -637,7 +648,7 @@ const V2ActivityPage: React.FC = () => {
   const sendReply = async (item: NeedsYouItem) => {
     const content = (replyDrafts[item.id] || '').trim();
     if (!content || replyingId || !item.podId) return;
-    const restoreActionFocus = captureActionFocus(item);
+    const focusKey = rememberActionFocus('reply', item);
     setReplyingId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -656,15 +667,16 @@ const V2ActivityPage: React.FC = () => {
     } catch {
       setActionErrorItemId(item.id);
       setActionError(t('activity.reply.actionFailed', { defaultValue: 'Your reply could not be sent. Try again.' }));
-      restoreActionFocus();
+      restoreActionFocus(focusKey);
     } finally {
+      clearActionFocus(focusKey);
       setReplyingId(null);
     }
   };
 
   const acknowledgeAttention = async (item: NeedsYouItem, errorKey: 'activity.mention.actionFailed' | 'activity.handoff.actionFailed') => {
     if (acknowledgingAttentionId) return;
-    const restoreActionFocus = captureActionFocus(item);
+    const focusKey = rememberActionFocus('acknowledge', item);
     setAcknowledgingAttentionId(item.id);
     setActionError(null);
     setActionErrorItemId(null);
@@ -682,8 +694,9 @@ const V2ActivityPage: React.FC = () => {
       const message = t(errorKey, { defaultValue: 'That attention item could not be marked handled. Try again.' });
       setActionErrorItemId(item.id);
       setActionError(message);
-      restoreActionFocus();
+      restoreActionFocus(focusKey);
     } finally {
+      clearActionFocus(focusKey);
       setAcknowledgingAttentionId(null);
     }
   };

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -30,7 +30,7 @@ interface NeedsYouItem {
   id: string;
   attentionItemId?: string;
   actorName?: string;
-  kind: 'mention' | 'approval' | 'decision';
+  kind: 'mention' | 'approval' | 'decision' | 'handoff';
   title: string;
   detail: string;
   podId: string | null;
@@ -65,6 +65,7 @@ interface QueueResponse {
   composePodId?: string | null;
   count: number;
   countsByPod: Record<string, number>;
+  countsByKind?: Record<string, number>;
   offset?: number;
   limit?: number;
   remaining?: number;
@@ -92,6 +93,7 @@ interface ActivitySnapshot {
   queueCount?: number | null;
   queueRemaining?: number;
   queueCountsByPod?: Record<string, number>;
+  queueCountsByKind?: Record<string, number>;
   composePodId?: string;
   composeDraft?: string;
   replyDrafts?: Record<string, string>;
@@ -148,7 +150,7 @@ const V2ActivityPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [actingApprovalId, setActingApprovalId] = useState<string | null>(null);
-  const [acknowledgingMentionId, setAcknowledgingMentionId] = useState<string | null>(null);
+  const [acknowledgingAttentionId, setAcknowledgingAttentionId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [rulingId, setRulingId] = useState<string | null>(null);
   const [otherDecisionId, setOtherDecisionId] = useState<string | null>(null);
@@ -158,6 +160,7 @@ const V2ActivityPage: React.FC = () => {
   const queueRef = useRef<NeedsYouItem[]>([]);
   const [queueCount, setQueueCount] = useState<number | null>(null);
   const [queueCountsByPod, setQueueCountsByPod] = useState<Record<string, number>>({});
+  const [queueCountsByKind, setQueueCountsByKind] = useState<Record<string, number>>({});
   const [queueRemaining, setQueueRemaining] = useState(0);
   const [queueLoadingMore, setQueueLoadingMore] = useState(false);
   const [queueMoreError, setQueueMoreError] = useState(false);
@@ -199,6 +202,7 @@ const V2ActivityPage: React.FC = () => {
       setQueue(queueRef.current);
       setQueueCount(snapshot.queueCount ?? null);
       setQueueCountsByPod(snapshot.queueCountsByPod || {});
+      setQueueCountsByKind(snapshot.queueCountsByKind || {});
       setQueueRemaining(snapshot.queueRemaining || 0);
       setReplyDrafts(snapshot.replyDrafts || {});
       setComposePodId(snapshot.composePodId || '');
@@ -216,6 +220,7 @@ const V2ActivityPage: React.FC = () => {
       setQueue(queueRef.current);
       setQueueCount(null);
       setQueueCountsByPod({});
+      setQueueCountsByKind({});
       setQueueRemaining(0);
       setReplyDrafts({});
       setComposePodId('');
@@ -327,6 +332,7 @@ const V2ActivityPage: React.FC = () => {
         setQueueFailed(false);
         setQueueCount(queueResponse!.data.count);
         setQueueCountsByPod(queueResponse!.data.countsByPod || {});
+        setQueueCountsByKind(queueResponse!.data.countsByKind || {});
         const mapQueueItems = (items: QueueResponse['items']) => items.map((item) => ({
           ...item,
           detail: item.detail || '',
@@ -497,6 +503,7 @@ const V2ActivityPage: React.FC = () => {
         queueCount,
         queueRemaining,
         queueCountsByPod,
+        queueCountsByKind,
         replyDrafts,
         composePodId,
         composeDraft,
@@ -627,9 +634,9 @@ const V2ActivityPage: React.FC = () => {
     }
   };
 
-  const acknowledgeMention = async (item: NeedsYouItem) => {
-    if (acknowledgingMentionId) return;
-    setAcknowledgingMentionId(item.id);
+  const acknowledgeAttention = async (item: NeedsYouItem, errorKey: 'activity.mention.actionFailed' | 'activity.handoff.actionFailed') => {
+    if (acknowledgingAttentionId) return;
+    setAcknowledgingAttentionId(item.id);
     setActionError(null);
     try {
       const token = localStorage.getItem('token');
@@ -642,11 +649,14 @@ const V2ActivityPage: React.FC = () => {
       notifyAttentionChanged();
       setReloadKey((value) => value + 1);
     } catch {
-      setActionError(t('activity.mention.actionFailed'));
+      setActionError(t(errorKey, { defaultValue: 'That attention item could not be marked handled. Try again.' }));
     } finally {
-      setAcknowledgingMentionId(null);
+      setAcknowledgingAttentionId(null);
     }
   };
+
+  const acknowledgeMention = (item: NeedsYouItem) => acknowledgeAttention(item, 'activity.mention.actionFailed');
+  const markHandoffHandled = (item: NeedsYouItem) => acknowledgeAttention(item, 'activity.handoff.actionFailed');
 
   const isDayZero = podId === 'all'
     && queueCount === 0
@@ -813,7 +823,7 @@ const V2ActivityPage: React.FC = () => {
                 {queue.map((item) => (
                   <article key={item.id} data-activity-item-id={item.id} tabIndex={-1} className={`v2-activity__queue-row v2-activity__queue-row--${item.kind}${item.kind === 'decision' && ruledDecisions[item.id] ? ' v2-activity__queue-row--settled' : ''}`}>
                     <span className="v2-activity__queue-mark" aria-hidden="true">
-                      {item.kind === 'mention' ? '@' : item.kind === 'approval' ? '!' : '?'}
+                      {item.kind === 'mention' ? '@' : item.kind === 'approval' ? '!' : item.kind === 'handoff' ? '↗' : '?'}
                     </span>
                     <div className="v2-activity__queue-copy">
                       <div className="v2-activity__queue-kind">{t(`activity.needsYou.kinds.${item.kind}`)} · {item.podName}{item.timestamp ? ` · ${relativeTime(item.timestamp)}` : ''}</div>
@@ -839,10 +849,15 @@ const V2ActivityPage: React.FC = () => {
                             <textarea aria-label={t('activity.reply.placeholder')} className="v2-activity__reply-input" rows={2} placeholder={t('activity.reply.placeholder')} value={replyDrafts[item.id] || ''} onChange={(e) => setReplyDrafts((prev) => ({ ...prev, [item.id]: e.target.value }))} onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') sendReply(item); }} disabled={replyingId === item.id} />
                             <button type="button" onClick={() => sendReply(item)} disabled={replyingId === item.id || !(replyDrafts[item.id] || '').trim()}>{replyingId === item.id ? t('activity.reply.working') : repliedIds.has(item.id) ? t('activity.reply.sent') : t('activity.reply.send')}</button>
                           </div>}
-                          <button type="button" className="v2-activity__queue-action--thread" onClick={() => acknowledgeMention(item)} disabled={acknowledgingMentionId === item.id}>
-                            {acknowledgingMentionId === item.id ? t('activity.mention.working') : t('activity.mention.markHandled')}
+                          <button type="button" className="v2-activity__queue-action--thread" onClick={() => acknowledgeMention(item)} disabled={acknowledgingAttentionId === item.id}>
+                            {acknowledgingAttentionId === item.id ? t('activity.mention.working') : t('activity.mention.markHandled')}
                           </button>
                         </>
+                      )}
+                      {item.kind === 'handoff' && (
+                        <button type="button" className="v2-activity__queue-action--thread" onClick={() => markHandoffHandled(item)} disabled={acknowledgingAttentionId === item.id}>
+                          {acknowledgingAttentionId === item.id ? t('activity.handoff.working', { defaultValue: 'Saving…' }) : t('activity.handoff.markHandled', { defaultValue: 'Mark handled' })}
+                        </button>
                       )}
                       {item.kind === 'decision' && (item.options || []).length > 0 && (
                         <>

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -151,6 +151,7 @@ const V2ActivityPage: React.FC = () => {
   const [actingApprovalId, setActingApprovalId] = useState<string | null>(null);
   const [acknowledgingAttentionId, setAcknowledgingAttentionId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [actionErrorItemId, setActionErrorItemId] = useState<string | null>(null);
   const [rulingId, setRulingId] = useState<string | null>(null);
   const [otherDecisionId, setOtherDecisionId] = useState<string | null>(null);
   const [otherDecisionValue, setOtherDecisionValue] = useState('');
@@ -527,6 +528,7 @@ const V2ActivityPage: React.FC = () => {
     if (actingApprovalId) return;
     setActingApprovalId(item.id);
     setActionError(null);
+    setActionErrorItemId(null);
     try {
       const token = localStorage.getItem('token');
       const response = await axios.post<{ success?: boolean }>(
@@ -548,6 +550,7 @@ const V2ActivityPage: React.FC = () => {
     if (rulingId || !value.trim()) return;
     setRulingId(item.id);
     setActionError(null);
+    setActionErrorItemId(null);
     try {
       const token = localStorage.getItem('token');
       const response = await axios.post<{ ok?: boolean }>(
@@ -609,6 +612,7 @@ const V2ActivityPage: React.FC = () => {
     if (!content || replyingId || !item.podId) return;
     setReplyingId(item.id);
     setActionError(null);
+    setActionErrorItemId(null);
     try {
       const token = localStorage.getItem('token');
       await axios.post(
@@ -632,6 +636,7 @@ const V2ActivityPage: React.FC = () => {
     if (acknowledgingAttentionId) return;
     setAcknowledgingAttentionId(item.id);
     setActionError(null);
+    setActionErrorItemId(null);
     try {
       const token = localStorage.getItem('token');
       const response = await axios.post<{ success?: boolean }>(
@@ -643,7 +648,13 @@ const V2ActivityPage: React.FC = () => {
       notifyAttentionChanged();
       setReloadKey((value) => value + 1);
     } catch {
-      setActionError(t(errorKey, { defaultValue: 'That attention item could not be marked handled. Try again.' }));
+      const message = t(errorKey, { defaultValue: 'That attention item could not be marked handled. Try again.' });
+      if (item.kind === 'handoff') {
+        setActionErrorItemId(item.id);
+        setActionError(message);
+      } else {
+        setActionError(message);
+      }
     } finally {
       setAcknowledgingAttentionId(null);
     }
@@ -913,6 +924,14 @@ const V2ActivityPage: React.FC = () => {
                         {item.messageId === undefined || item.messageId === null || item.messageId === '' ? t('activity.openPod') : t('activity.open')}
                       </button>
                     </div>
+                    {item.kind === 'handoff' && actionErrorItemId === item.id && actionError && (
+                      <div className="v2-activity__row-action-error" role="alert">
+                        <span>{actionError}</span>
+                        <button type="button" onClick={() => markHandoffHandled(item)} disabled={acknowledgingAttentionId === item.id}>
+                          {t('activity.needsYou.retry', { defaultValue: 'Retry' })}
+                        </button>
+                      </div>
+                    )}
                   </article>
                 ))}
               </div>
@@ -935,7 +954,7 @@ const V2ActivityPage: React.FC = () => {
             {queue.length === 0 && queueMoreError && !queueFailed && (
               <button type="button" className="v2-activity__queue-more" onClick={() => setReloadKey((value) => value + 1)}>{t('activity.needsYou.retry', { defaultValue: 'Retry' })}</button>
             )}
-            {actionError && <div className="v2-activity__action-error" role="alert">{actionError}</div>}
+            {actionError && !actionErrorItemId && <div className="v2-activity__action-error" role="alert">{actionError}</div>}
           </section>
 
           <section className="v2-activity__section v2-activity__moved" aria-labelledby="activity-moved-forward">

--- a/frontend/src/v2/hooks/useV2PodAttention.ts
+++ b/frontend/src/v2/hooks/useV2PodAttention.ts
@@ -27,7 +27,6 @@ export const useV2PodAttention = (enabled = true) => {
   const [items, setItems] = useState<V2AttentionItem[]>([]);
   const [count, setCount] = useState<number | null>(null);
   const [countByPod, setCountByPod] = useState<Record<string, number>>({});
-  const [countByKind, setCountByKind] = useState<Record<string, number>>({});
   const generation = useRef(0);
 
   const refresh = useCallback(async () => {
@@ -40,7 +39,6 @@ export const useV2PodAttention = (enabled = true) => {
       setItems(data.items);
       setCount(data.count);
       setCountByPod(data.countsByPod);
-      setCountByKind(data.countsByKind || {});
     } catch {
       // Attention is additive UI. A transient read failure must not invent a
       // stale count or block the pod surface; the next refresh retries it.
@@ -48,7 +46,6 @@ export const useV2PodAttention = (enabled = true) => {
       setItems([]);
       setCount(null);
       setCountByPod({});
-      setCountByKind({});
     }
   }, [enabled]);
 
@@ -62,5 +59,5 @@ export const useV2PodAttention = (enabled = true) => {
       window.removeEventListener('focus', refresh);
     };
   }, [refresh]);
-  return { items, count, countByPod, countByKind, refresh };
+  return { items, count, countByPod, refresh };
 };

--- a/frontend/src/v2/hooks/useV2PodAttention.ts
+++ b/frontend/src/v2/hooks/useV2PodAttention.ts
@@ -3,7 +3,7 @@ import { useV2Api } from './useV2Api';
 
 export interface V2AttentionItem {
   id: string;
-  kind: 'mention' | 'approval' | 'decision';
+  kind: 'mention' | 'approval' | 'decision' | 'handoff';
   title: string;
   detail?: string;
   actorName?: string;
@@ -27,18 +27,20 @@ export const useV2PodAttention = (enabled = true) => {
   const [items, setItems] = useState<V2AttentionItem[]>([]);
   const [count, setCount] = useState<number | null>(null);
   const [countByPod, setCountByPod] = useState<Record<string, number>>({});
+  const [countByKind, setCountByKind] = useState<Record<string, number>>({});
   const generation = useRef(0);
 
   const refresh = useCallback(async () => {
     if (!enabled) return;
     const request = ++generation.current;
     try {
-      const data = await apiRef.current.get<{ items: V2AttentionItem[]; count: number; countsByPod: Record<string, number> }>('/api/activity/decision-queue');
+      const data = await apiRef.current.get<{ items: V2AttentionItem[]; count: number; countsByPod: Record<string, number>; countsByKind?: Record<string, number> }>('/api/activity/decision-queue');
       if (request !== generation.current) return;
       if (!Array.isArray(data?.items) || typeof data.count !== 'number' || !data.countsByPod) throw new Error('Invalid attention queue');
       setItems(data.items);
       setCount(data.count);
       setCountByPod(data.countsByPod);
+      setCountByKind(data.countsByKind || {});
     } catch {
       // Attention is additive UI. A transient read failure must not invent a
       // stale count or block the pod surface; the next refresh retries it.
@@ -46,6 +48,7 @@ export const useV2PodAttention = (enabled = true) => {
       setItems([]);
       setCount(null);
       setCountByPod({});
+      setCountByKind({});
     }
   }, [enabled]);
 
@@ -59,5 +62,5 @@ export const useV2PodAttention = (enabled = true) => {
       window.removeEventListener('focus', refresh);
     };
   }, [refresh]);
-  return { items, count, countByPod, refresh };
+  return { items, count, countByPod, countByKind, refresh };
 };

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9281,28 +9281,7 @@ body.modern-ui.v2-canvas {
 
 .v2-activity__row-action-error {
   grid-column: 1 / -1;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 8px;
-  color: var(--v2-danger);
-  font-size: 13px;
-}
-
-.v2-activity__row-action-error button {
-  min-height: 32px;
-  padding: 5px 10px;
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-radius-sm);
-  background: var(--v2-surface);
-  color: var(--v2-text-primary);
-  font: inherit;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.v2-activity__row-action-error button:hover:not(:disabled) {
-  border-color: var(--v2-accent);
+  color: var(--v2-ink);
 }
 
 .v2-activity__queue-row button:disabled,

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9810,6 +9810,7 @@ body.modern-ui.v2-canvas {
 }
 @media (max-width: 640px) {
   .v2-activity__reply { flex-basis: 100%; }
+  .v2-root .v2-activity__reply button { min-height: 44px; }
 }
 
 /* ---------- Workspace sidebar (TASK-129 PR 1) ----------

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9279,7 +9279,7 @@ body.modern-ui.v2-canvas {
   font-size: 13px;
 }
 
-.v2-activity__row-action-error {
+.v2-root .v2-activity__row-action-error {
   grid-column: 1 / -1;
   color: var(--v2-ink);
 }

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9279,6 +9279,32 @@ body.modern-ui.v2-canvas {
   font-size: 13px;
 }
 
+.v2-activity__row-action-error {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  color: var(--v2-danger);
+  font-size: 13px;
+}
+
+.v2-activity__row-action-error button {
+  min-height: 32px;
+  padding: 5px 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.v2-activity__row-action-error button:hover:not(:disabled) {
+  border-color: var(--v2-accent);
+}
+
 .v2-activity__queue-row button:disabled,
 .v2-activity__updates button:disabled {
   cursor: default;


### PR DESCRIPTION
## Summary
- add a persisted `handoff` attention kind for task-origin handoffs
- render legacy `kind: decision` + `source.type: task` rows as handoffs without migration
- add recipient-owned Mark handled acknowledgement while keeping decision requests and approvals non-dismissible
- expose uncapped per-kind queue counts and render handoff cards/actions in Activity

## Verification
- backend focused Jest: 38 tests passed
- frontend Jest: 102 suites / 734 tests passed
- backend `tsc` build and frontend typecheck/build passed
- changed-file ESLint passed with existing warnings only
