### PR TITLE
Fix V2 own-send scroll follow

### DIFF
--- a/frontend/src/v2/__tests__/V2Composer.test.tsx
+++ b/frontend/src/v2/__tests__/V2Composer.test.tsx
@@ -645,6 +645,8 @@ describe('V2Composer send button', () => {
     fireEvent.change(composerInput(), { target: { value: 'old own' } });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
     await waitFor(() => expect(oldDetail.sendMessage).toHaveBeenCalledTimes(1));
+    const scrollIntoView = Element.prototype.scrollIntoView as jest.Mock;
+    scrollIntoView.mockClear();
 
     const newDetail = {
       ...oldDetail,
@@ -659,8 +661,10 @@ describe('V2Composer send button', () => {
         </MemoryRouter>
       </AuthContext.Provider>,
     );
+    // Pod-change cleanup bumps the effect version, but without a recorded
+    // sent id it must not be mistaken for a successful local send.
+    expect(scrollIntoView).not.toHaveBeenCalled();
     const scroller = scrollUp(view);
-    const scrollIntoView = Element.prototype.scrollIntoView as jest.Mock;
     scrollIntoView.mockClear();
     scroller.scrollTop = 0;
     fireEvent.scroll(scroller);

--- a/frontend/src/v2/__tests__/V2Composer.test.tsx
+++ b/frontend/src/v2/__tests__/V2Composer.test.tsx
@@ -433,4 +433,227 @@ describe('V2Composer send button', () => {
       expect(detail.sendMessage).toHaveBeenCalledWith('Replying to a person.', 'text', 'm2', undefined);
     });
   });
+
+  const transcriptMessage = (id: string, userId = 'u2', content = id) => ({
+    id,
+    pod_id: 'p1',
+    user_id: userId,
+    content,
+    message_type: 'text',
+    created_at: `2026-08-22T13:00:${id.length.toString().padStart(2, '0')}Z`,
+    user: { username: userId === 'u1' ? 'solo-user' : 'teammate' },
+  });
+
+  const scrollUp = (view: { container: HTMLElement }) => {
+    const scroller = view.container.querySelector('.v2-chat__messages') as HTMLElement;
+    Object.defineProperties(scroller, {
+      scrollHeight: { configurable: true, value: 1000 },
+      clientHeight: { configurable: true, value: 400 },
+      scrollTop: { configurable: true, writable: true, value: 0 },
+    });
+    fireEvent.scroll(scroller);
+    return scroller;
+  };
+
+  beforeEach(() => {
+    (Element.prototype.scrollIntoView as jest.Mock).mockClear();
+  });
+
+  test('background arrivals stay put even when another tab uses the same user', async () => {
+    const detail = makeDetail({ messages: [transcriptMessage('start')] });
+    const view = renderChat(detail);
+    const scroller = scrollUp(view);
+    const scrollIntoView = Element.prototype.scrollIntoView as jest.Mock;
+    scrollIntoView.mockClear();
+
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={{ ...detail, messages: [
+            transcriptMessage('start'),
+            transcriptMessage('other'),
+          ] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: /Jump to latest/ })).toBeInTheDocument());
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // Same-author rows from another tab are still background arrivals. This
+    // is the mutation that the old currentUser comparison would let through.
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={{ ...detail, messages: [
+            transcriptMessage('start'),
+            transcriptMessage('other'),
+            transcriptMessage('same-user', 'u1'),
+          ] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: /Jump to latest/ })).toBeInTheDocument());
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // The normal bottom-following behavior remains unchanged.
+    scroller.scrollTop = 600;
+    fireEvent.scroll(scroller);
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={{ ...detail, messages: [
+            transcriptMessage('start'),
+            transcriptMessage('other'),
+            transcriptMessage('same-user', 'u1'),
+            transcriptMessage('bottom-arrival'),
+          ] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+  });
+
+  test('a text send follows its own row when the socket wins before POST', async () => {
+    let resolveSend: (message: any) => void = () => undefined;
+    const detail = makeDetail({
+      messages: [transcriptMessage('start')],
+      sendMessage: jest.fn(() => new Promise((resolve) => { resolveSend = resolve; })),
+    });
+    const view = renderChat(detail);
+    scrollUp(view);
+    const scrollIntoView = Element.prototype.scrollIntoView as jest.Mock;
+    scrollIntoView.mockClear();
+
+    fireEvent.change(composerInput(), { target: { value: 'sent from this tab' } });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => expect(detail.sendMessage).toHaveBeenCalledTimes(1));
+
+    // Simulate the socket row being deduped into detail before the POST
+    // promise resolves. The id ref is not known yet, so this must stay put.
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={{ ...detail, messages: [
+            transcriptMessage('start'),
+            transcriptMessage('own-race', 'u1', 'sent from this tab'),
+          ] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: /Jump to latest/ })).toBeInTheDocument());
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    resolveSend(transcriptMessage('own-race', 'u1', 'sent from this tab'));
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+  });
+
+  test('failed sends do not grant follow privileges to a later arrival', async () => {
+    const detail = makeDetail({
+      messages: [transcriptMessage('start')],
+      sendMessage: jest.fn(() => Promise.resolve(null)),
+    });
+    const view = renderChat(detail);
+    const scroller = scrollUp(view);
+    const scrollIntoView = Element.prototype.scrollIntoView as jest.Mock;
+    scrollIntoView.mockClear();
+
+    fireEvent.change(composerInput(), { target: { value: 'will fail' } });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => expect(detail.sendMessage).toHaveBeenCalledTimes(1));
+
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={{ ...detail, messages: [
+            transcriptMessage('start'),
+            transcriptMessage('later-same-user', 'u1'),
+          ] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: /Jump to latest/ })).toBeInTheDocument());
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    // Keep the scroller referenced so this test also exercises the real
+    // scroll-listener path rather than only the initial ref state.
+    expect(scroller).toBeTruthy();
+  });
+
+  test('an image send records the same own-message id as text sends', async () => {
+    mockUpload();
+    const detail = makeDetail({
+      messages: [transcriptMessage('start')],
+      sendMessage: jest.fn(() => Promise.resolve(transcriptMessage('own-image', 'u1'))),
+    });
+    const view = renderChat(detail);
+    scrollUp(view);
+    const scrollIntoView = Element.prototype.scrollIntoView as jest.Mock;
+    scrollIntoView.mockClear();
+
+    upload(view.container);
+    await waitFor(() => expect(detail.sendMessage).toHaveBeenCalledTimes(1));
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={{ ...detail, messages: [
+            transcriptMessage('start'),
+            transcriptMessage('own-image', 'u1'),
+          ] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+  });
+
+  test('switching pods clears the prior composer message id', async () => {
+    const oldDetail = makeDetail({
+      messages: [transcriptMessage('old-start')],
+      sendMessage: jest.fn(() => Promise.resolve(transcriptMessage('old-own', 'u1'))),
+    });
+    const view = renderChat(oldDetail);
+    scrollUp(view);
+    fireEvent.change(composerInput(), { target: { value: 'old own' } });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => expect(oldDetail.sendMessage).toHaveBeenCalledTimes(1));
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={{ ...oldDetail, messages: [
+            transcriptMessage('old-start'),
+            transcriptMessage('old-own', 'u1'),
+          ] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+
+    const newDetail = {
+      ...oldDetail,
+      pod: { _id: 'p2', name: 'Other Workspace', type: 'chat' },
+      messages: [transcriptMessage('new-start')],
+      sendMessage: jest.fn(() => Promise.resolve(null)),
+    };
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={newDetail} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    const scroller = scrollUp(view);
+    const scrollIntoView = Element.prototype.scrollIntoView as jest.Mock;
+    scrollIntoView.mockClear();
+    scroller.scrollTop = 0;
+    fireEvent.scroll(scroller);
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={{ ...newDetail, messages: [
+            transcriptMessage('new-start'),
+            transcriptMessage('new-background', 'u1'),
+          ] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: /Jump to latest/ })).toBeInTheDocument());
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/v2/__tests__/V2Composer.test.tsx
+++ b/frontend/src/v2/__tests__/V2Composer.test.tsx
@@ -536,6 +536,7 @@ describe('V2Composer send button', () => {
           <V2Thread detail={{ ...detail, messages: [
             transcriptMessage('start'),
             transcriptMessage('own-race', 'u1', 'sent from this tab'),
+            transcriptMessage('background-after-own'),
           ] }} />
         </MemoryRouter>
       </AuthContext.Provider>,
@@ -544,6 +545,35 @@ describe('V2Composer send button', () => {
     expect(scrollIntoView).not.toHaveBeenCalled();
 
     resolveSend(transcriptMessage('own-race', 'u1', 'sent from this tab'));
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+  });
+
+  test('a POST-first own send follows before its socket row arrives', async () => {
+    const detail = makeDetail({
+      messages: [transcriptMessage('start')],
+      sendMessage: jest.fn(() => Promise.resolve(transcriptMessage('post-first', 'u1'))),
+    });
+    const view = renderChat(detail);
+    scrollUp(view);
+    const scrollIntoView = Element.prototype.scrollIntoView as jest.Mock;
+    scrollIntoView.mockClear();
+
+    fireEvent.change(composerInput(), { target: { value: 'post first' } });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+    // The confirmation itself must not manufacture a new-arrival count.
+    expect(view.container.querySelector('.v2-thread__jump-count')).toBeNull();
+
+    view.rerender(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter>
+          <V2Thread detail={{ ...detail, messages: [
+            transcriptMessage('start'),
+            transcriptMessage('post-first', 'u1'),
+          ] }} />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
     await waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
   });
 
@@ -605,25 +635,16 @@ describe('V2Composer send button', () => {
   });
 
   test('switching pods clears the prior composer message id', async () => {
+    let resolveSend: (message: any) => void = () => undefined;
     const oldDetail = makeDetail({
       messages: [transcriptMessage('old-start')],
-      sendMessage: jest.fn(() => Promise.resolve(transcriptMessage('old-own', 'u1'))),
+      sendMessage: jest.fn(() => new Promise((resolve) => { resolveSend = resolve; })),
     });
     const view = renderChat(oldDetail);
     scrollUp(view);
     fireEvent.change(composerInput(), { target: { value: 'old own' } });
     fireEvent.click(screen.getByRole('button', { name: /send message/i }));
     await waitFor(() => expect(oldDetail.sendMessage).toHaveBeenCalledTimes(1));
-    view.rerender(
-      <AuthContext.Provider value={authValue}>
-        <MemoryRouter>
-          <V2Thread detail={{ ...oldDetail, messages: [
-            transcriptMessage('old-start'),
-            transcriptMessage('old-own', 'u1'),
-          ] }} />
-        </MemoryRouter>
-      </AuthContext.Provider>,
-    );
 
     const newDetail = {
       ...oldDetail,
@@ -654,6 +675,11 @@ describe('V2Composer send button', () => {
       </AuthContext.Provider>,
     );
     await waitFor(() => expect(screen.getByRole('button', { name: /Jump to latest/ })).toBeInTheDocument());
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // The old pod's late POST response is also unrelated to this pod.
+    resolveSend(transcriptMessage('old-own', 'u1'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/v2/__tests__/useV2PodDetailPodChange.test.tsx
+++ b/frontend/src/v2/__tests__/useV2PodDetailPodChange.test.tsx
@@ -83,6 +83,8 @@ describe('useV2PodDetail room changes', () => {
       newMessages.resolve([]);
       await newMessages.promise;
     });
+    await waitFor(() => expect(result.current.pod?._id).toBe('new-room'));
+    await waitFor(() => expect(result.current.initialLoadComplete).toBe(true));
     expect(result.current.messages).toEqual([]);
 
     await act(async () => {

--- a/frontend/src/v2/__tests__/useV2PodDetailPodChange.test.tsx
+++ b/frontend/src/v2/__tests__/useV2PodDetailPodChange.test.tsx
@@ -56,4 +56,35 @@ describe('useV2PodDetail room changes', () => {
     });
     await waitFor(() => expect(result.current.messages.map((message) => message.id)).toEqual(['new-message']));
   });
+
+  it('rejects a late send response from the previous room', async () => {
+    const oldPost = deferred();
+    mockApi.get.mockImplementation((url) => {
+      if (url.startsWith('/api/messages/')) return Promise.resolve([]);
+      if (url.includes('/agents')) return Promise.resolve({ agents: [] });
+      const id = url.includes('new-room') ? 'new-room' : 'old-room';
+      return Promise.resolve({ _id: id, name: id, members: [] });
+    });
+    mockApi.post.mockReturnValue(oldPost.promise);
+
+    const { result, rerender } = renderHook(({ podId }) => useV2PodDetail(podId), {
+      initialProps: { podId: 'old-room' },
+    });
+    await waitFor(() => expect(result.current.pod?._id).toBe('old-room'));
+
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.sendMessage('old room send');
+    });
+    act(() => rerender({ podId: 'new-room' }));
+    expect(result.current.messages).toEqual([]);
+
+    await act(async () => {
+      oldPost.resolve({
+        id: 'old-send', pod_id: 'old-room', content: 'old room send', created_at: '2026-09-07T00:00:00Z',
+      });
+      await sendPromise;
+    });
+    expect(result.current.messages).toEqual([]);
+  });
 });

--- a/frontend/src/v2/__tests__/useV2PodDetailPodChange.test.tsx
+++ b/frontend/src/v2/__tests__/useV2PodDetailPodChange.test.tsx
@@ -59,7 +59,9 @@ describe('useV2PodDetail room changes', () => {
 
   it('rejects a late send response from the previous room', async () => {
     const oldPost = deferred();
+    const newMessages = deferred();
     mockApi.get.mockImplementation((url) => {
+      if (url === '/api/messages/new-room?limit=50') return newMessages.promise;
       if (url.startsWith('/api/messages/')) return Promise.resolve([]);
       if (url.includes('/agents')) return Promise.resolve({ agents: [] });
       const id = url.includes('new-room') ? 'new-room' : 'old-room';
@@ -77,6 +79,10 @@ describe('useV2PodDetail room changes', () => {
       sendPromise = result.current.sendMessage('old room send');
     });
     act(() => rerender({ podId: 'new-room' }));
+    await act(async () => {
+      newMessages.resolve([]);
+      await newMessages.promise;
+    });
     expect(result.current.messages).toEqual([]);
 
     await act(async () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -903,12 +903,15 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(thread).toContain('new IntersectionObserver');
     expect(thread).toContain('atBottomRef');
     // Background arrivals must respect the reader's position even when they
-    // share the current user's author id. Only the id returned by this
-    // composer's own send is allowed to bypass the scrolled-up guard; the
-    // follow-version nudge covers socket-before-POST ordering.
+    // share the current user's author id. Arrival counting is separate from
+    // the explicit follow instruction returned by this composer's send; the
+    // follow-version nudge covers socket-before-POST ordering without letting
+    // a confirmation render increment the Jump pill.
     expect(thread).toContain('sentMessageIdRef');
-    expect(thread).toContain('newestMessageId === sentMessageIdRef.current');
     expect(thread).toContain('sendFollowVersion');
+    expect(thread).toContain('if (atBottomRef.current)');
+    expect(thread).toContain('}, [newestMessageId]);');
+    expect(thread).toContain('}, [sendFollowVersion]);');
     expect(thread).not.toContain('newestIsMine');
     // ux-lead gate on #1579: the pill is a 28px r14 white chip on #dde0e6, sans
     // 600 13px — the same family as the aim chip, not a 999px capsule.

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -909,6 +909,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     // a confirmation render increment the Jump pill.
     expect(thread).toContain('sentMessageIdRef');
     expect(thread).toContain('sendFollowVersion');
+    expect(thread).toContain('if (!sendFollowVersion || !sentMessageIdRef.current) return;');
     expect(thread).toContain('if (atBottomRef.current)');
     expect(thread).toContain('}, [newestMessageId]);');
     expect(thread).toContain('}, [sendFollowVersion]);');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -902,6 +902,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(threadMessages).not.toContain('v2-chat__older-btn');
     expect(thread).toContain('new IntersectionObserver');
     expect(thread).toContain('atBottomRef');
+    // Background arrivals must respect the reader's position even when they
+    // share the current user's author id. Only the id returned by this
+    // composer's own send is allowed to bypass the scrolled-up guard; the
+    // follow-version nudge covers socket-before-POST ordering.
+    expect(thread).toContain('sentMessageIdRef');
+    expect(thread).toContain('newestMessageId === sentMessageIdRef.current');
+    expect(thread).toContain('sendFollowVersion');
+    expect(thread).not.toContain('newestIsMine');
     // ux-lead gate on #1579: the pill is a 28px r14 white chip on #dde0e6, sans
     // 600 13px — the same family as the aim chip, not a 999px capsule.
     // The wrap sticks to the scroller's bottom edge with real height; the

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -185,6 +185,13 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   const deliveryHintShownPodsRef = useRef<Set<string>>(new Set());
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const messagesContainerRef = useRef<HTMLDivElement | null>(null);
+  // Keep the id of the last message sent from this composer. Comparing ids,
+  // rather than authors, keeps another tab's message from stealing a reader's
+  // viewport. The version state re-runs the scroll effect when the POST wins
+  // after its socket copy (and therefore the newest id) already arrived.
+  const sentMessageIdRef = useRef<string | null>(null);
+  const [sendFollowVersion, setSendFollowVersion] = useState(0);
+  const activePodIdRef = useRef<string | null>(pod?._id || null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const composerInputRef = useRef<HTMLTextAreaElement | null>(null);
   const mentionDropdownRef = useRef<HTMLDivElement | null>(null);
@@ -213,6 +220,14 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // Per-user thread state for this pod (#1145). `collapsed` arrives resolved;
   // this component must never compute it.
   const threadState = useV2ThreadState(detail?.pod?._id);
+
+  // A late response from a pod we left must not make the first message in the
+  // next pod look like it came from this composer.
+  useLayoutEffect(() => {
+    activePodIdRef.current = pod?._id || null;
+    sentMessageIdRef.current = null;
+    setSendFollowVersion((version) => version + 1);
+  }, [pod?._id]);
 
   // Setting one composer target clears the other. Two chips would be two
   // meanings for one send, and the resolver rejects a message carrying both.
@@ -520,8 +535,9 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // prepends are ignored.
   const newestMessageId = messages.length > 0 ? messages[messages.length - 1].id : null;
   // Direction C history: the reader's position is respected. New messages
-  // pull the view down only when it was already at the bottom (or the message
-  // is mine); otherwise they count up in the Jump-to-latest pill.
+  // pull the view down only when it was already at the bottom (or are the
+  // message returned by this composer's send); otherwise they count up in the
+  // Jump-to-latest pill.
   const atBottomRef = useRef(true);
   const [jumpCount, setJumpCount] = useState(0);
   // The pill mounts once the reader is a viewport up; `· N` only with arrivals.
@@ -547,17 +563,25 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     el.addEventListener('scroll', onScroll, { passive: true });
     return () => el.removeEventListener('scroll', onScroll);
   }, [pod?._id]);
-  const newestIsMine = messages.length > 0 && String(messages[messages.length - 1]?.user_id || '') === String(currentUser?._id || '');
   useEffect(() => {
     if (!newestMessageId) return;
-    if (atBottomRef.current || newestIsMine) {
+    if (atBottomRef.current || newestMessageId === sentMessageIdRef.current) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
       setJumpCount(0);
     } else {
       setJumpCount((count) => count + 1);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [newestMessageId]);
+  }, [newestMessageId, sendFollowVersion]);
+
+  const rememberSentMessage = useCallback((sendPodId: string, created: import('../hooks/useV2PodDetail').V2Message) => {
+    const id = String(created?.id || (created as { _id?: string })?._id || '');
+    if (!id || activePodIdRef.current !== sendPodId) return;
+    sentMessageIdRef.current = id;
+    // If the socket copy won the race, newestMessageId has already been
+    // observed and its effect cannot see this id until it is nudged here.
+    setSendFollowVersion((version) => version + 1);
+  }, []);
 
   // Prepending changes scrollHeight, so without this the viewport jumps. Hold
   // the reader's position by restoring the distance from the BOTTOM, which is
@@ -974,6 +998,8 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   const handleSend = async (override?: string) => {
     const text = (override ?? draft).trim();
     if (!text || sending) return;
+    const sendPodId = pod?._id;
+    if (!sendPodId) return;
     setSending(true);
     setComposerError(null);
     try {
@@ -1005,6 +1031,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
         threadTarget?.id || undefined,
       );
       if (created) {
+        rememberSentMessage(sendPodId, created);
         // A direct-room post is not evidence that the agent is alive or
         // working. Track the reply separately so the user gets a truthful
         // "waiting" state until the agent speaks or the wait expires.
@@ -1152,6 +1179,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           threadTarget?.id || undefined,
         );
         if (created) {
+          rememberSentMessage(pod._id, created);
           setReplyTarget(null);
           setThreadTarget(null);
         }

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -534,10 +534,10 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // which reads as "load older is broken". Key on the newest message's id so
   // prepends are ignored.
   const newestMessageId = messages.length > 0 ? messages[messages.length - 1].id : null;
-  // Direction C history: the reader's position is respected. New messages
-  // pull the view down only when it was already at the bottom (or are the
-  // message returned by this composer's send); otherwise they count up in the
-  // Jump-to-latest pill.
+  // Direction C history: the reader's position is respected. Background
+  // arrivals pull the view down only when it was already at the bottom;
+  // otherwise they count up in the Jump-to-latest pill. Explicit local sends
+  // follow in the separate confirmation effect below.
   const atBottomRef = useRef(true);
   const [jumpCount, setJumpCount] = useState(0);
   // The pill mounts once the reader is a viewport up; `· N` only with arrivals.
@@ -565,21 +565,31 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   }, [pod?._id]);
   useEffect(() => {
     if (!newestMessageId) return;
-    if (atBottomRef.current || newestMessageId === sentMessageIdRef.current) {
+    if (atBottomRef.current) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
       setJumpCount(0);
     } else {
       setJumpCount((count) => count + 1);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [newestMessageId, sendFollowVersion]);
+  }, [newestMessageId]);
+
+  // A successful POST is an explicit local follow instruction, independent
+  // of which socket row won the race or whether another row arrived after it.
+  // Keeping this separate from arrival counting prevents the confirmation
+  // render from incrementing the Jump pill when no new message arrived.
+  useEffect(() => {
+    if (!sendFollowVersion || !sentMessageIdRef.current) return;
+    atBottomRef.current = true;
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    setJumpCount(0);
+  }, [sendFollowVersion]);
 
   const rememberSentMessage = useCallback((sendPodId: string, created: import('../hooks/useV2PodDetail').V2Message) => {
     const id = String(created?.id || (created as { _id?: string })?._id || '');
     if (!id || activePodIdRef.current !== sendPodId) return;
     sentMessageIdRef.current = id;
-    // If the socket copy won the race, newestMessageId has already been
-    // observed and its effect cannot see this id until it is nudged here.
+    // The confirmation version is independent of the socket row's ordering.
     setSendFollowVersion((version) => version + 1);
   }, []);
 

--- a/frontend/src/v2/hooks/useV2PodDetail.ts
+++ b/frontend/src/v2/hooks/useV2PodDetail.ts
@@ -648,6 +648,9 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
         },
         { timeout: SEND_TIMEOUT_MS },
       );
+      // A send started in a pod we have already left must not append its late
+      // response into the newly selected pod's transcript.
+      if (activePodIdRef.current !== podId) return null;
       const normalized = normalizeMessage(created);
       // Dedupe by id — the Socket.io `newMessage` broadcast and this
       // optimistic add both come from the same DB row and race after
@@ -658,6 +661,7 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
       // an older backend's broadcast omits replyTo, which dropped the reply
       // quote until reload (#646).
       setMessages((prev) => {
+        if (activePodIdRef.current !== podId) return prev;
         if (prev.some((m) => m.id && m.id === normalized.id)) {
           const next = prev.map((m) => (
             m.id === normalized.id
@@ -679,8 +683,10 @@ export const useV2PodDetail = (podId: string | null): UseV2PodDetailResult => {
         messagesRef.current = next;
         return next;
       });
+      if (activePodIdRef.current !== podId) return null;
       return normalized;
     } catch (err) {
+      if (activePodIdRef.current !== podId) return null;
       const e = err as { response?: { data?: { error?: string; msg?: string } }; message?: string };
       setSendError(e.response?.data?.error || e.response?.data?.msg || e.message || 'Failed to send message');
       return null;


### PR DESCRIPTION
Background messages—including messages from the same account in another tab—preserve the position of a reader browsing older messages. A successful send from the local composer follows the conversation after confirmation, including socket-before-POST delivery with an intervening newer message. Arrival counting is independent of send confirmation.

Late text or image responses from a pod the user has left are discarded before they can change the newly selected pod's messages, draft, focus, or error state.

Validation: independent code review passed 138 focused tests and a stale-response mutation check at 2f6c4e77. UX approved the send scope: mocked production-browser checks at desktop and true mobile widths cover background authors, send ordering, Jump, near-bottom behavior, and failures; desktop checks using the actual hook cover late text/image success and failure after switching pods. Full frontend suite, typecheck, and build passed before the final test-only corrections. CI remains a separate merge gate.

A pre-existing history-anchor defect remains in a separate follow-up (Connectors TASK-014): an empty older-page fetch can leave an anchor that a later background append consumes. This PR's qualified UX approval does not claim that defect or the complete reading-position workflow is resolved. No API or schema changes.
