### PR TITLE
fix(activity): restore approved controls and settled decisions

### DIFF
--- a/backend/__tests__/unit/routes/activity.read.test.js
+++ b/backend/__tests__/unit/routes/activity.read.test.js
@@ -63,6 +63,18 @@ describe('activity read routes', () => {
     await request(app).get('/api/activity/decision-queue?limit=51').expect(400);
   });
 
+  it('GET /api/activity decision reads reject an oversized loaded-source filter', async () => {
+    const messageIds = Array.from({ length: 201 }, (_, index) => `message-${index}`).join(',');
+    await request(app)
+      .get('/api/activity/decision-queue')
+      .query({ messageIds })
+      .expect(400, { error: 'messageIds must contain at most 200 ids' });
+    await request(app)
+      .get('/api/activity/decision-history')
+      .query({ messageIds })
+      .expect(400, { error: 'messageIds must contain at most 200 ids' });
+  });
+
   it('GET /api/activity/decision-history forwards pod scope and pagination', async () => {
     await request(app)
       .get('/api/activity/decision-history?podId=pod-1&messageIds=42%2C43&limit=50&offset=50')

--- a/backend/__tests__/unit/routes/activity.read.test.js
+++ b/backend/__tests__/unit/routes/activity.read.test.js
@@ -90,6 +90,14 @@ describe('activity read routes', () => {
     await request(app).get('/api/activity/decision-history?limit=51').expect(400);
   });
 
+  it('GET /api/activity/decision-history preserves the membership-gate 403', async () => {
+    ActivityService.getDecisionHistory.mockRejectedValueOnce(new Error('Access denied'));
+
+    await request(app)
+      .get('/api/activity/decision-history?podId=private-pod')
+      .expect(403, { error: 'Access denied' });
+  });
+
   it('POST /api/activity/mark-read with all:true calls markRead', async () => {
     await request(app).post('/api/activity/mark-read').send({ all: true }).expect(200);
     expect(ActivityService.markRead).toHaveBeenCalledWith('user123', expect.objectContaining({ all: true }));

--- a/backend/__tests__/unit/routes/activity.read.test.js
+++ b/backend/__tests__/unit/routes/activity.read.test.js
@@ -50,10 +50,10 @@ describe('activity read routes', () => {
 
   it('GET /api/activity/decision-queue forwards scope and pagination', async () => {
     await request(app)
-      .get('/api/activity/decision-queue?podId=pod-1&limit=50&offset=50')
+      .get('/api/activity/decision-queue?podId=pod-1&messageIds=42%2C43&limit=50&offset=50')
       .expect(200);
     expect(ActivityService.getDecisionQueue).toHaveBeenCalledWith('user123', {
-      podId: 'pod-1', limit: 50, offset: 50,
+      podId: 'pod-1', messageIds: ['42', '43'], limit: 50, offset: 50,
     });
   });
 

--- a/backend/__tests__/unit/routes/activity.read.test.js
+++ b/backend/__tests__/unit/routes/activity.read.test.js
@@ -65,10 +65,10 @@ describe('activity read routes', () => {
 
   it('GET /api/activity/decision-history forwards pod scope and pagination', async () => {
     await request(app)
-      .get('/api/activity/decision-history?podId=pod-1&limit=50&offset=50')
+      .get('/api/activity/decision-history?podId=pod-1&messageIds=42%2C43&limit=50&offset=50')
       .expect(200);
     expect(ActivityService.getDecisionHistory).toHaveBeenCalledWith('user123', {
-      podId: 'pod-1', limit: 50, offset: 50,
+      podId: 'pod-1', messageIds: ['42', '43'], limit: 50, offset: 50,
     });
   });
 

--- a/backend/__tests__/unit/routes/activity.read.test.js
+++ b/backend/__tests__/unit/routes/activity.read.test.js
@@ -11,6 +11,7 @@ jest.mock('../../../services/activityService', () => ({
   getUserFeed: jest.fn(async () => ({ activities: [], hasMore: false })),
   getRecap: jest.fn(async () => ({ needsYou: [], agents: [], board: [] })),
   getDecisionQueue: jest.fn(async () => ({ items: [], count: 0, countsByPod: {}, remaining: 0, hasMore: false })),
+  getDecisionHistory: jest.fn(async () => ({ items: [], count: 0, remaining: 0, hasMore: false })),
   getPodFeed: jest.fn(async () => ({ activities: [], hasMore: false })),
   getPendingApprovals: jest.fn(async () => []),
   acknowledgeMention: jest.fn(async () => ({ success: true })),
@@ -60,6 +61,21 @@ describe('activity read routes', () => {
     await request(app).get('/api/activity/decision-queue?limit=0').expect(400);
     await request(app).get('/api/activity/decision-queue?offset=-1').expect(400);
     await request(app).get('/api/activity/decision-queue?limit=51').expect(400);
+  });
+
+  it('GET /api/activity/decision-history forwards pod scope and pagination', async () => {
+    await request(app)
+      .get('/api/activity/decision-history?podId=pod-1&limit=50&offset=50')
+      .expect(200);
+    expect(ActivityService.getDecisionHistory).toHaveBeenCalledWith('user123', {
+      podId: 'pod-1', limit: 50, offset: 50,
+    });
+  });
+
+  it('GET /api/activity/decision-history rejects unsafe pagination', async () => {
+    await request(app).get('/api/activity/decision-history?limit=0').expect(400);
+    await request(app).get('/api/activity/decision-history?offset=-1').expect(400);
+    await request(app).get('/api/activity/decision-history?limit=51').expect(400);
   });
 
   it('POST /api/activity/mark-read with all:true calls markRead', async () => {

--- a/backend/__tests__/unit/services/activityService.attentionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.attentionQueue.test.js
@@ -86,6 +86,15 @@ describe('ActivityService.getDecisionQueue', () => {
     });
   });
 
+  it('rejects settled history for a viewer outside the requested pod', async () => {
+    mockPodFind.mockReturnValue(chain([]));
+
+    await expect(ActivityService.getDecisionHistory('outsider-1', { podId: 'pod-1' }))
+      .rejects.toThrow('Access denied');
+    expect(mockDecisionFind).not.toHaveBeenCalled();
+    expect(mockDecisionCountDocuments).not.toHaveBeenCalled();
+  });
+
   it('bounds settled history to the loaded source message IDs when supplied', async () => {
     mockPodFind.mockReturnValue(chain([{
       _id: 'pod-1', name: 'Current', createdBy: 'owner', members: ['member-1'],

--- a/backend/__tests__/unit/services/activityService.attentionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.attentionQueue.test.js
@@ -1,6 +1,7 @@
 const mockGetOpenQueue = jest.fn();
 const mockPodFind = jest.fn();
 const mockTaskFind = jest.fn();
+const mockDecisionFind = jest.fn();
 
 jest.mock('../../../models/Pod', () => ({ find: (...args) => mockPodFind(...args) }));
 jest.mock('../../../models/User', () => ({}));
@@ -8,6 +9,7 @@ jest.mock('../../../models/Activity', () => ({}));
 jest.mock('../../../models/Summary', () => ({}));
 jest.mock('../../../models/Post', () => ({}));
 jest.mock('../../../models/Task', () => ({ find: (...args) => mockTaskFind(...args) }));
+jest.mock('../../../models/DecisionRequest', () => ({ find: (...args) => mockDecisionFind(...args) }));
 jest.mock('../../../services/attentionItemService', () => ({
   getOpenQueue: (...args) => mockGetOpenQueue(...args),
 }));
@@ -41,6 +43,48 @@ describe('ActivityService.getDecisionQueue', () => {
     expect(mockGetOpenQueue).toHaveBeenCalledWith('507f191e810c19729de860ea', {
       podId: 'pod-1', limit: 50, offset: 0,
     });
+  });
+
+  it('reads settled decisions durably for a current pod member', async () => {
+    mockPodFind.mockReturnValue(chain([{
+      _id: 'pod-1', name: 'Current', createdBy: 'owner', members: [{ userId: 'member-1' }],
+    }]));
+    mockDecisionFind.mockReturnValue({ sort: () => ({ lean: async () => [{
+      _id: 'decision-1', podId: 'pod-1', status: 'ruled', messageId: '42',
+      threadRootId: '40', agentName: 'scout', title: 'Choose a path', question: 'Which?',
+      options: [{ label: 'A' }, { label: 'B' }],
+      ruling: { value: 'B', byUsername: 'Sam', at: new Date('2026-09-07T00:00:00Z'), messageId: '43' },
+      createdAt: new Date('2026-09-06T00:00:00Z'), updatedAt: new Date('2026-09-07T00:00:00Z'),
+    }] }) });
+
+    const history = await ActivityService.getDecisionHistory('member-1', { podId: 'pod-1' });
+    expect(history).toMatchObject({ count: 1, hasMore: false });
+    expect(history.items).toEqual([expect.objectContaining({
+      id: 'decision-1', kind: 'decision', podId: 'pod-1', messageId: '42',
+      ruling: expect.objectContaining({ value: 'B', by: 'Sam', messageId: '43' }),
+    })]);
+    expect(mockPodFind).toHaveBeenCalledWith(expect.objectContaining({
+      _id: 'pod-1', $or: expect.any(Array),
+    }));
+    expect(mockDecisionFind).toHaveBeenCalledWith({
+      podId: { $in: ['pod-1'] }, status: 'ruled', messageId: { $exists: true },
+    });
+  });
+
+  it('paginates settled decisions within the selected pod instead of global overflow', async () => {
+    mockPodFind.mockReturnValue(chain([{
+      _id: 'pod-1', name: 'Current', createdBy: 'owner', members: ['member-1'],
+    }]));
+    const rows = Array.from({ length: 51 }, (_, index) => ({
+      _id: `decision-${index}`, podId: 'pod-1', status: 'ruled', messageId: String(index),
+      title: `Decision ${index}`, question: 'Which?', options: [{ label: 'A' }, { label: 'B' }],
+      ruling: { value: 'A', byUsername: 'Sam', messageId: `reply-${index}` },
+    }));
+    mockDecisionFind.mockReturnValue({ sort: () => ({ lean: async () => rows }) });
+
+    const history = await ActivityService.getDecisionHistory('member-1', { podId: 'pod-1', limit: 1, offset: 50 });
+    expect(history).toMatchObject({ count: 51, remaining: 0, hasMore: false });
+    expect(history.items).toEqual([expect.objectContaining({ id: 'decision-50', podId: 'pod-1' })]);
   });
 
   it('keeps the recap fallback scoped to the requested pod', async () => {

--- a/backend/__tests__/unit/services/activityService.attentionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.attentionQueue.test.js
@@ -86,6 +86,30 @@ describe('ActivityService.getDecisionQueue', () => {
     });
   });
 
+  it('bounds settled history to the loaded source message IDs when supplied', async () => {
+    mockPodFind.mockReturnValue(chain([{
+      _id: 'pod-1', name: 'Current', createdBy: 'owner', members: ['member-1'],
+    }]));
+    mockDecisionCountDocuments.mockResolvedValue(1);
+    mockDecisionFind.mockReturnValue(decisionChain([{
+      _id: 'decision-1', podId: 'pod-1', status: 'ruled', messageId: '42',
+      title: 'Choose a path', question: 'Which?', options: [{ label: 'A' }, { label: 'B' }],
+      ruling: { value: 'B', byUsername: 'Sam' },
+    }]));
+
+    const history = await ActivityService.getDecisionHistory('member-1', {
+      podId: 'pod-1', messageIds: ['42', '42', '  '],
+    });
+
+    expect(history).toMatchObject({ count: 1, hasMore: false });
+    expect(mockDecisionFind).toHaveBeenCalledWith({
+      podId: { $in: ['pod-1'] }, status: 'ruled', messageId: { $in: ['42'] },
+    });
+    expect(mockDecisionCountDocuments).toHaveBeenCalledWith({
+      podId: { $in: ['pod-1'] }, status: 'ruled', messageId: { $in: ['42'] },
+    });
+  });
+
   it('paginates settled decisions within the selected pod instead of global overflow', async () => {
     mockPodFind.mockReturnValue(chain([{
       _id: 'pod-1', name: 'Current', createdBy: 'owner', members: ['member-1'],

--- a/backend/__tests__/unit/services/activityService.attentionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.attentionQueue.test.js
@@ -2,6 +2,7 @@ const mockGetOpenQueue = jest.fn();
 const mockPodFind = jest.fn();
 const mockTaskFind = jest.fn();
 const mockDecisionFind = jest.fn();
+const mockDecisionCountDocuments = jest.fn();
 
 jest.mock('../../../models/Pod', () => ({ find: (...args) => mockPodFind(...args) }));
 jest.mock('../../../models/User', () => ({}));
@@ -9,7 +10,10 @@ jest.mock('../../../models/Activity', () => ({}));
 jest.mock('../../../models/Summary', () => ({}));
 jest.mock('../../../models/Post', () => ({}));
 jest.mock('../../../models/Task', () => ({ find: (...args) => mockTaskFind(...args) }));
-jest.mock('../../../models/DecisionRequest', () => ({ find: (...args) => mockDecisionFind(...args) }));
+jest.mock('../../../models/DecisionRequest', () => ({
+  find: (...args) => mockDecisionFind(...args),
+  countDocuments: (...args) => mockDecisionCountDocuments(...args),
+}));
 jest.mock('../../../services/attentionItemService', () => ({
   getOpenQueue: (...args) => mockGetOpenQueue(...args),
 }));
@@ -18,6 +22,13 @@ const ActivityService = require('../../../services/activityService');
 const chain = (value) => ({ select: () => ({ lean: async () => value }) });
 const taskChain = (value) => ({
   select: () => ({ sort: () => ({ limit: () => ({ lean: async () => value }) }) }),
+});
+const decisionChain = (value) => ({
+  sort: () => ({
+    skip: () => ({
+      limit: () => ({ lean: async () => value }),
+    }),
+  }),
 });
 
 describe('ActivityService.getDecisionQueue', () => {
@@ -49,13 +60,14 @@ describe('ActivityService.getDecisionQueue', () => {
     mockPodFind.mockReturnValue(chain([{
       _id: 'pod-1', name: 'Current', createdBy: 'owner', members: [{ userId: 'member-1' }],
     }]));
-    mockDecisionFind.mockReturnValue({ sort: () => ({ lean: async () => [{
+    mockDecisionCountDocuments.mockResolvedValue(1);
+    mockDecisionFind.mockReturnValue(decisionChain([{
       _id: 'decision-1', podId: 'pod-1', status: 'ruled', messageId: '42',
       threadRootId: '40', agentName: 'scout', title: 'Choose a path', question: 'Which?',
       options: [{ label: 'A' }, { label: 'B' }],
       ruling: { value: 'B', byUsername: 'Sam', at: new Date('2026-09-07T00:00:00Z'), messageId: '43' },
       createdAt: new Date('2026-09-06T00:00:00Z'), updatedAt: new Date('2026-09-07T00:00:00Z'),
-    }] }) });
+    }]));
 
     const history = await ActivityService.getDecisionHistory('member-1', { podId: 'pod-1' });
     expect(history).toMatchObject({ count: 1, hasMore: false });
@@ -69,6 +81,9 @@ describe('ActivityService.getDecisionQueue', () => {
     expect(mockDecisionFind).toHaveBeenCalledWith({
       podId: { $in: ['pod-1'] }, status: 'ruled', messageId: { $exists: true },
     });
+    expect(mockDecisionCountDocuments).toHaveBeenCalledWith({
+      podId: { $in: ['pod-1'] }, status: 'ruled', messageId: { $exists: true },
+    });
   });
 
   it('paginates settled decisions within the selected pod instead of global overflow', async () => {
@@ -80,7 +95,8 @@ describe('ActivityService.getDecisionQueue', () => {
       title: `Decision ${index}`, question: 'Which?', options: [{ label: 'A' }, { label: 'B' }],
       ruling: { value: 'A', byUsername: 'Sam', messageId: `reply-${index}` },
     }));
-    mockDecisionFind.mockReturnValue({ sort: () => ({ lean: async () => rows }) });
+    mockDecisionCountDocuments.mockResolvedValue(51);
+    mockDecisionFind.mockReturnValue(decisionChain([rows[50]]));
 
     const history = await ActivityService.getDecisionHistory('member-1', { podId: 'pod-1', limit: 1, offset: 50 });
     expect(history).toMatchObject({ count: 51, remaining: 0, hasMore: false });

--- a/backend/__tests__/unit/services/attentionItemService.test.js
+++ b/backend/__tests__/unit/services/attentionItemService.test.js
@@ -156,6 +156,20 @@ describe('attentionItemService', () => {
     expect((await AttentionItemService.getOpenQueue(recipient, { podId: 'pod-1' })).composePodId).toBe('pod-2');
   });
 
+  it('bounds an open queue read to the loaded source message ids when requested', async () => {
+    const recipient = '507f191e810c19729de860ea';
+    mockFind.mockReturnValue({ sort: () => ({ lean: async () => [] }) });
+    mockPodFind.mockReturnValue(chain([]));
+
+    await AttentionItemService.getOpenQueue(recipient, { messageIds: ['42', '42', '  '] });
+
+    expect(mockFind).toHaveBeenCalledWith({
+      recipientUserId: recipient,
+      status: 'open',
+      messageId: { $in: ['42'] },
+    });
+  });
+
   it('does not let projection-resolution storage turn a completed source into a failure', async () => {
     mockUpdateMany.mockRejectedValueOnce(new Error('mongo unavailable'));
     await expect(AttentionItemService.resolve('approval', 'a-1')).resolves.toBeUndefined();

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -132,6 +132,41 @@ router.get('/decision-queue', auth, async (req: Req, res: Res) => {
   }
 });
 
+// Settled decision cards are durable pod history, not recipient-owned open
+// attention. Keep this read separate so the Activity queue remains an honest
+// count of unresolved work while a room can restore its settled card after a
+// hard reload or leave/return navigation.
+router.get('/decision-history', auth, async (req: Req, res: Res) => {
+  try {
+    const podId = req.query?.podId;
+    const rawLimit = req.query?.limit;
+    const rawOffset = req.query?.offset;
+    if (podId !== undefined && typeof podId !== 'string') {
+      return res.status(400).json({ error: 'podId must be a string' });
+    }
+    const limit = rawLimit === undefined ? undefined : Number(rawLimit);
+    const offset = rawOffset === undefined ? undefined : Number(rawOffset);
+    if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 50)) {
+      return res.status(400).json({ error: 'limit must be an integer between 1 and 50' });
+    }
+    if (offset !== undefined && (!Number.isInteger(offset) || offset < 0)) {
+      return res.status(400).json({ error: 'offset must be a non-negative integer' });
+    }
+    const userId = getAuthenticatedUserId(req);
+    const options = {
+      ...(podId ? { podId } : {}),
+      ...(limit === undefined ? {} : { limit }),
+      ...(offset === undefined ? {} : { offset }),
+    };
+    return res.json(await ActivityService.getDecisionHistory(userId, options));
+  } catch (error) {
+    const e = error as { message?: string };
+    if (e.message === 'Access denied') return res.status(403).json({ error: 'Access denied' });
+    console.error('Error fetching decision history:', error);
+    return res.status(500).json({ error: 'Failed to fetch decision history' });
+  }
+});
+
 // Human-only by construction: this route uses `auth`, not dual auth. The
 // service repeats the isBot + pod-membership checks so a future middleware
 // change cannot turn an agent token into a decision authority.

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -34,6 +34,7 @@ interface Res {
 }
 
 const router: ReturnType<typeof express.Router> = express.Router();
+const MAX_MESSAGE_IDS_PER_REQUEST = 200;
 
 // Activity queries and actions fan out to multiple projections. Sixty per
 // minute leaves room for normal use without an unbounded hot loop.
@@ -118,7 +119,10 @@ router.get('/decision-queue', auth, async (req: Req, res: Res) => {
     }
     const messageIds = rawMessageIds === undefined
       ? undefined
-      : [...new Set(rawMessageIds.split(',').map((id) => id.trim()).filter(Boolean))].slice(0, 200);
+      : [...new Set(rawMessageIds.split(',').map((id) => id.trim()).filter(Boolean))];
+    if (messageIds && messageIds.length > MAX_MESSAGE_IDS_PER_REQUEST) {
+      return res.status(400).json({ error: `messageIds must contain at most ${MAX_MESSAGE_IDS_PER_REQUEST} ids` });
+    }
     const limit = rawLimit === undefined ? undefined : Number(rawLimit);
     const offset = rawOffset === undefined ? undefined : Number(rawOffset);
     if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 50)) {
@@ -158,7 +162,10 @@ router.get('/decision-history', auth, async (req: Req, res: Res) => {
     }
     const messageIds = rawMessageIds === undefined
       ? undefined
-      : [...new Set(rawMessageIds.split(',').map((id) => id.trim()).filter(Boolean))].slice(0, 200);
+      : [...new Set(rawMessageIds.split(',').map((id) => id.trim()).filter(Boolean))];
+    if (messageIds && messageIds.length > MAX_MESSAGE_IDS_PER_REQUEST) {
+      return res.status(400).json({ error: `messageIds must contain at most ${MAX_MESSAGE_IDS_PER_REQUEST} ids` });
+    }
     const limit = rawLimit === undefined ? undefined : Number(rawLimit);
     const offset = rawOffset === undefined ? undefined : Number(rawOffset);
     if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 50)) {

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -139,11 +139,18 @@ router.get('/decision-queue', auth, async (req: Req, res: Res) => {
 router.get('/decision-history', auth, async (req: Req, res: Res) => {
   try {
     const podId = req.query?.podId;
+    const rawMessageIds = req.query?.messageIds;
     const rawLimit = req.query?.limit;
     const rawOffset = req.query?.offset;
     if (podId !== undefined && typeof podId !== 'string') {
       return res.status(400).json({ error: 'podId must be a string' });
     }
+    if (rawMessageIds !== undefined && typeof rawMessageIds !== 'string') {
+      return res.status(400).json({ error: 'messageIds must be a comma-separated string' });
+    }
+    const messageIds = rawMessageIds === undefined
+      ? undefined
+      : [...new Set(rawMessageIds.split(',').map((id) => id.trim()).filter(Boolean))].slice(0, 200);
     const limit = rawLimit === undefined ? undefined : Number(rawLimit);
     const offset = rawOffset === undefined ? undefined : Number(rawOffset);
     if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 50)) {
@@ -155,6 +162,7 @@ router.get('/decision-history', auth, async (req: Req, res: Res) => {
     const userId = getAuthenticatedUserId(req);
     const options = {
       ...(podId ? { podId } : {}),
+      ...(messageIds ? { messageIds } : rawMessageIds !== undefined ? { messageIds: [] } : {}),
       ...(limit === undefined ? {} : { limit }),
       ...(offset === undefined ? {} : { offset }),
     };

--- a/backend/routes/activity.ts
+++ b/backend/routes/activity.ts
@@ -107,11 +107,18 @@ router.get('/decision-queue', auth, async (req: Req, res: Res) => {
   try {
     const userId = getAuthenticatedUserId(req);
     const podId = req.query?.podId;
+    const rawMessageIds = req.query?.messageIds;
     const rawLimit = req.query?.limit;
     const rawOffset = req.query?.offset;
     if (podId !== undefined && typeof podId !== 'string') {
       return res.status(400).json({ error: 'podId must be a string' });
     }
+    if (rawMessageIds !== undefined && typeof rawMessageIds !== 'string') {
+      return res.status(400).json({ error: 'messageIds must be a comma-separated string' });
+    }
+    const messageIds = rawMessageIds === undefined
+      ? undefined
+      : [...new Set(rawMessageIds.split(',').map((id) => id.trim()).filter(Boolean))].slice(0, 200);
     const limit = rawLimit === undefined ? undefined : Number(rawLimit);
     const offset = rawOffset === undefined ? undefined : Number(rawOffset);
     if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 50)) {
@@ -122,6 +129,7 @@ router.get('/decision-queue', auth, async (req: Req, res: Res) => {
     }
     const options = {
       ...(podId ? { podId } : {}),
+      ...(messageIds ? { messageIds } : rawMessageIds !== undefined ? { messageIds: [] } : {}),
       ...(limit === undefined ? {} : { limit }),
       ...(offset === undefined ? {} : { offset }),
     };

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -380,6 +380,76 @@ class ActivityService {
       : AttentionItemService.getOpenQueue(userId);
   }
 
+  /**
+   * Read settled DecisionRequest rows for the currently viewed pod. Unlike
+   * the recipient-owned open queue, this projection is pod-scoped because a
+   * ruling is durable workspace history that every current human member can
+   * read after leaving and returning to the room.
+   */
+  static async getDecisionHistory(userId: unknown, options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    const requestedPodId = typeof options.podId === 'string' ? options.podId.trim() : '';
+    const limit = Number.isInteger(options.limit) ? Math.min(Math.max(options.limit as number, 1), 50) : 50;
+    const offset = Number.isInteger(options.offset) ? Math.max(options.offset as number, 0) : 0;
+    const membership = {
+      $or: [
+        { createdBy: userId },
+        { 'members.userId': userId },
+        { members: userId },
+        { 'members._id': userId },
+      ],
+    };
+    const podQuery = requestedPodId ? { _id: requestedPodId, ...membership } : membership;
+    const pods: PodDoc[] = await Pod.find(podQuery).select('_id name createdBy members').lean();
+    if (requestedPodId && pods.length === 0) throw new Error('Access denied');
+    const allowedPods = pods.filter((pod) => (
+      String(pod.createdBy || '') === String(userId)
+      || (pod.members || []).some((member: any) => String(member?.userId || member?._id || member) === String(userId))
+    ));
+    if (requestedPodId && allowedPods.length === 0) throw new Error('Access denied');
+    const podIds = allowedPods.map((pod) => String(pod._id));
+    if (!podIds.length) {
+      return { items: [], count: 0, offset, limit, remaining: 0, hasMore: false };
+    }
+
+    // eslint-disable-next-line global-require
+    const DecisionRequest = require('../models/DecisionRequest');
+    const rows = await DecisionRequest.find({
+      podId: { $in: podIds },
+      status: 'ruled',
+      messageId: { $exists: true },
+    }).sort({ updatedAt: -1 }).lean();
+    const podNames = new Map(allowedPods.map((pod) => [String(pod._id), pod.name]));
+    const items = rows.slice(offset, offset + limit).map((row: any) => ({
+      id: String(row._id),
+      kind: 'decision',
+      podId: String(row.podId),
+      podName: podNames.get(String(row.podId)) || 'Pod',
+      messageId: row.messageId,
+      threadRootId: row.threadRootId,
+      actorName: row.agentName,
+      title: row.title,
+      detail: row.question,
+      options: row.options || [],
+      status: row.status,
+      ruling: row.ruling ? {
+        value: row.ruling.value,
+        by: row.ruling.byUsername,
+        at: row.ruling.at,
+        messageId: row.ruling.messageId,
+      } : null,
+      createdAt: row.createdAt,
+    }));
+    const remaining = Math.max(rows.length - offset - items.length, 0);
+    return {
+      items,
+      count: rows.length,
+      offset,
+      limit,
+      remaining,
+      hasMore: remaining > 0,
+    };
+  }
+
   static async getPodFeed(
     podId: unknown,
     userId: unknown,

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -388,6 +388,10 @@ class ActivityService {
    */
   static async getDecisionHistory(userId: unknown, options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
     const requestedPodId = typeof options.podId === 'string' ? options.podId.trim() : '';
+    const hasMessageFilter = Array.isArray(options.messageIds);
+    const messageIds = hasMessageFilter
+      ? [...new Set((options.messageIds as unknown[]).map((id) => String(id).trim()).filter(Boolean))]
+      : [];
     const limit = Number.isInteger(options.limit) ? Math.min(Math.max(options.limit as number, 1), 50) : 50;
     const offset = Number.isInteger(options.offset) ? Math.max(options.offset as number, 0) : 0;
     const membership = {
@@ -416,7 +420,9 @@ class ActivityService {
     const historyQuery = {
       podId: { $in: podIds },
       status: 'ruled',
-      messageId: { $exists: true },
+      ...(hasMessageFilter
+        ? { messageId: { $in: messageIds } }
+        : { messageId: { $exists: true } }),
     };
     const [count, rows] = await Promise.all([
       DecisionRequest.countDocuments(historyQuery),

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -413,13 +413,21 @@ class ActivityService {
 
     // eslint-disable-next-line global-require
     const DecisionRequest = require('../models/DecisionRequest');
-    const rows = await DecisionRequest.find({
+    const historyQuery = {
       podId: { $in: podIds },
       status: 'ruled',
       messageId: { $exists: true },
-    }).sort({ updatedAt: -1 }).lean();
+    };
+    const [count, rows] = await Promise.all([
+      DecisionRequest.countDocuments(historyQuery),
+      DecisionRequest.find(historyQuery)
+        .sort({ updatedAt: -1 })
+        .skip(offset)
+        .limit(limit)
+        .lean(),
+    ]);
     const podNames = new Map(allowedPods.map((pod) => [String(pod._id), pod.name]));
-    const items = rows.slice(offset, offset + limit).map((row: any) => ({
+    const items = rows.map((row: any) => ({
       id: String(row._id),
       kind: 'decision',
       podId: String(row.podId),
@@ -439,10 +447,10 @@ class ActivityService {
       } : null,
       createdAt: row.createdAt,
     }));
-    const remaining = Math.max(rows.length - offset - items.length, 0);
+    const remaining = Math.max(count - offset - items.length, 0);
     return {
       items,
-      count: rows.length,
+      count,
       offset,
       limit,
       remaining,

--- a/backend/services/attentionItemService.ts
+++ b/backend/services/attentionItemService.ts
@@ -339,6 +339,7 @@ export const resolveMany = async (sourceType: SourceType, sourceIds: unknown[]):
 
 interface OpenQueueOptions {
   podId?: unknown;
+  messageIds?: unknown;
   limit?: number;
   offset?: number;
 }
@@ -355,6 +356,10 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   hasMore: boolean;
 }> => {
   const requestedPodId = typeof options.podId === 'string' ? options.podId.trim() : '';
+  const hasMessageFilter = Array.isArray(options.messageIds);
+  const messageIds = hasMessageFilter
+    ? [...new Set((options.messageIds as unknown[]).map((id) => String(id).trim()).filter(Boolean))]
+    : [];
   const limit = Number.isInteger(options.limit) ? Math.min(Math.max(options.limit as number, 1), 50) : 50;
   const offset = Number.isInteger(options.offset) ? Math.max(options.offset as number, 0) : 0;
   // Route callers carry a real Mongo id. Returning an empty queue for a bad
@@ -366,7 +371,11 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   // Counts include every accessible open item. The selected pod scope is
   // applied before pagination so a scoped list cannot show a positive count
   // with zero rows merely because its rows fell beyond the global page.
-  const rows = await AttentionItem.find({ recipientUserId, status: 'open' }).sort({ createdAt: -1 }).lean();
+  const rows = await AttentionItem.find({
+    recipientUserId,
+    status: 'open',
+    ...(hasMessageFilter ? { messageId: { $in: messageIds } } : {}),
+  }).sort({ createdAt: -1 }).lean();
   const podIds = [...new Set(rows.map((row: any) => String(row.podId)))];
   const pods = await Pod.find({ _id: { $in: podIds } }).select('_id name createdBy members').lean();
   const allowed = new Map(pods.filter((pod: any) => isCurrentMember(pod, recipientUserId)).map((pod: any) => [String(pod._id), pod]));

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -78,6 +78,7 @@
       "emptyTitle": "Nothing open.",
       "emptyDescription": "New mentions and approval requests appear here when they need a response.",
       "showMore": "Show more · {{count}} remaining",
+      "showMoreSettled": "Show more settled · {{count}} remaining",
       "loadingMore": "Loading…",
       "retry": "Retry",
       "kinds": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -119,6 +119,8 @@
     },
     "decision": {
       "ruleOption": "Rule: {{option}}",
+      "ruleOptionRecommended": "Rule: {{option}} (Recommended)",
+      "recommended": "Recommended",
       "working": "Ruling…",
       "other": "Other…",
       "otherPlaceholder": "Write your ruling…",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -78,6 +78,7 @@
       "emptyTitle": "没有未处理事项。",
       "emptyDescription": "需要回复的提及或审批请求会显示在这里。",
       "showMore": "显示更多 · 剩余 {{count}} 条",
+      "showMoreSettled": "展开更多已处理 · 剩余 {{count}} 条",
       "loadingMore": "加载中…",
       "retry": "重试",
       "kinds": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -119,6 +119,8 @@
     },
     "decision": {
       "ruleOption": "裁定：{{option}}",
+      "ruleOptionRecommended": "裁定：{{option}}（推荐）",
+      "recommended": "推荐",
       "working": "正在裁定…",
       "other": "其他…",
       "otherPlaceholder": "写下你的裁定…",

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -121,6 +121,28 @@ describe('V2ActivityPage', () => {
     }));
   });
 
+  test('preserves authored decision order and makes only the first option primary', async () => {
+    const authoredOrder = {
+      ...decisionQueue,
+      items: [{
+        ...decisionQueue.items[1],
+        options: [
+          { label: 'Hold for review', description: 'Wait for a second pass.', recommended: false },
+          { label: 'Ship now', description: 'Release the bounded change.', recommended: true },
+        ],
+      }],
+      count: 1,
+    };
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? authoredOrder : recap }));
+    renderPage();
+
+    const first = await screen.findByRole('button', { name: 'Rule: Hold for review' });
+    const second = screen.getByRole('button', { name: 'Rule: Ship now' });
+    expect(first).toHaveClass('v2-activity__option--primary');
+    expect(second).not.toHaveClass('v2-activity__option--primary');
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   test('changes the read window and opens the source pod from a factual queue row', async () => {
     renderPage();
     await screen.findByText('Review requested');
@@ -251,6 +273,24 @@ describe('V2ActivityPage', () => {
       expect.objectContaining({ headers: expect.any(Object) }),
     ));
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Rule: Ship now' })).not.toBeInTheDocument());
+  });
+
+  test('keeps a successful ruling visible when the queue refresh fails', async () => {
+    let queueReads = 0;
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') {
+        queueReads += 1;
+        return queueReads === 1
+          ? Promise.resolve({ data: decisionQueue })
+          : Promise.reject(new Error('queue down'));
+      }
+      return Promise.resolve({ data: recap });
+    });
+    mockPost.mockResolvedValue({ data: { ok: true, decision: { ruling: { value: 'Ship now', by: 'You' } } } });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Rule: Ship now' }));
+    expect(await screen.findByText('✓ You ruled: Ship now')).toBeInTheDocument();
   });
 
   test('sends an Other ruling verbatim to the same DecisionRequest endpoint', async () => {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -319,6 +319,46 @@ describe('V2ActivityPage', () => {
     expect(screen.queryByRole('button', { name: /Rule:/ })).not.toBeInTheDocument();
   });
 
+  test('loads older settled decisions only when the Activity history control is requested', async () => {
+    const newest = {
+      id: 'decision-newest', kind: 'decision', title: 'Newest decision', detail: 'A newer ruling',
+      podId: 'pod-1', podName: 'Launch pod', messageId: '651', options: [{ label: 'Keep' }], status: 'ruled',
+      ruling: { value: 'Keep', by: 'You' },
+    };
+    const firstPage = [newest, ...Array.from({ length: 49 }, (_, index) => ({
+      ...newest,
+      id: `decision-${index}`,
+      title: `Decision ${index}`,
+      messageId: String(650 - index),
+    }))];
+    const older = {
+      id: 'decision-older', kind: 'decision', title: 'Older decision', detail: 'An older ruling',
+      podId: 'pod-1', podName: 'Launch pod', messageId: '650', options: [{ label: 'Keep' }], status: 'ruled',
+      ruling: { value: 'Keep', by: 'You' },
+    };
+    let historyReads = 0;
+    mockGet.mockImplementation((url: string, config?: any) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
+      if (url === '/api/activity/decision-history') {
+        historyReads += 1;
+        expect(config?.params?.offset).toBe(historyReads === 1 ? 0 : 50);
+        return Promise.resolve({ data: historyReads === 1
+          ? { items: firstPage, count: 51, remaining: 1, hasMore: true }
+          : { items: [older], count: 51, remaining: 0, hasMore: false } });
+      }
+      return Promise.resolve({ data: recap });
+    });
+    renderPage();
+
+    expect(await screen.findByText('Newest decision')).toBeInTheDocument();
+    expect(historyReads).toBe(1);
+    expect(screen.queryByText('Older decision')).not.toBeInTheDocument();
+    const more = screen.getByRole('button', { name: 'Show more settled · 1 remaining' });
+    fireEvent.click(more);
+    expect(await screen.findByText('Older decision')).toBeInTheDocument();
+    await waitFor(() => expect(historyReads).toBe(2));
+  });
+
   test('sends an Other ruling verbatim to the same DecisionRequest endpoint', async () => {
     mockGet.mockImplementation((url: string) => Promise.resolve({
       data: url === '/api/activity/decision-queue' ? decisionQueue : recap,

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -319,6 +319,37 @@ describe('V2ActivityPage', () => {
     expect(screen.queryByRole('button', { name: /Rule:/ })).not.toBeInTheDocument();
   });
 
+  test('restores a settled Activity card beyond the first history page', async () => {
+    const settled = {
+      id: 'decision-history-overflow', kind: 'decision', title: 'Older workspace ruling', detail: 'What should the agent do?',
+      podId: 'pod-1', podName: 'Launch pod', messageId: '900', threadRootId: '895',
+      options: [{ label: 'Ship now' }, { label: 'Hold for review' }], status: 'ruled',
+      ruling: { value: 'Ship now', by: 'You' },
+    };
+    const firstPage = Array.from({ length: 50 }, (_, index) => ({
+      id: `decision-history-${index}`, kind: 'decision', title: `Older ruling ${index}`, detail: 'Another ruling',
+      podId: 'pod-1', podName: 'Launch pod', messageId: `history-${index}`, options: [{ label: 'A' }], status: 'ruled',
+      ruling: { value: 'A', by: 'You' },
+    }));
+    let historyReads = 0;
+    mockGet.mockImplementation((url: string, config?: any) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
+      if (url === '/api/activity/decision-history') {
+        historyReads += 1;
+        if (config?.params?.offset === 0) {
+          return Promise.resolve({ data: { items: firstPage, count: 51, remaining: 1, hasMore: true } });
+        }
+        expect(config?.params?.offset).toBe(50);
+        return Promise.resolve({ data: { items: [settled], count: 51, remaining: 0, hasMore: false } });
+      }
+      return Promise.resolve({ data: recap });
+    });
+
+    renderPage();
+    expect(await screen.findByText('✓ You ruled: Ship now')).toBeInTheDocument();
+    expect(historyReads).toBe(2);
+  });
+
   test('sends an Other ruling verbatim to the same DecisionRequest endpoint', async () => {
     mockGet.mockImplementation((url: string) => Promise.resolve({
       data: url === '/api/activity/decision-queue' ? decisionQueue : recap,

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -88,6 +88,7 @@ describe('V2ActivityPage', () => {
     sessionStorage.clear();
     mockGet.mockImplementation((url: string) => {
       if (url === '/api/activity/decision-queue') return Promise.resolve({ data: decisionQueue });
+      if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [] } });
       return Promise.resolve({ data: recap });
     });
     await act(async () => { await i18n.changeLanguage('en'); });
@@ -109,7 +110,7 @@ describe('V2ActivityPage', () => {
     // Queue rows are only durable source facts; task handoff prose never
     // creates a card. DecisionRequest cards use declared alternatives.
     expect(screen.getByText('Choose the eslint scope')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Rule: Ship now' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rule: Ship now (Recommended)' })).toBeInTheDocument();
     expect(screen.getByText('Release the bounded change.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Other…' })).toBeInTheDocument();
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-queue', expect.anything());
@@ -137,9 +138,11 @@ describe('V2ActivityPage', () => {
     renderPage();
 
     const first = await screen.findByRole('button', { name: 'Rule: Hold for review' });
-    const second = screen.getByRole('button', { name: 'Rule: Ship now' });
+    const second = screen.getByRole('button', { name: 'Rule: Ship now (Recommended)' });
     expect(first).toHaveClass('v2-activity__option--primary');
     expect(second).not.toHaveClass('v2-activity__option--primary');
+    expect(second).toHaveTextContent('Recommended');
+    expect(first).not.toHaveTextContent('Recommended');
     expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
@@ -266,31 +269,54 @@ describe('V2ActivityPage', () => {
     mockPost.mockResolvedValue({ data: { ok: true } });
     renderPage();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Rule: Ship now' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Rule: Ship now (Recommended)' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
       '/api/activity/decisions/decision-024/choose',
       { value: 'Ship now' },
       expect.objectContaining({ headers: expect.any(Object) }),
     ));
-    await waitFor(() => expect(screen.queryByRole('button', { name: 'Rule: Ship now' })).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Rule: Ship now (Recommended)' })).not.toBeInTheDocument());
   });
 
-  test('keeps a successful ruling visible when the queue refresh fails', async () => {
+  test('keeps a successful ruling visible when a successful queue refresh omits the settled row', async () => {
     let queueReads = 0;
     mockGet.mockImplementation((url: string) => {
       if (url === '/api/activity/decision-queue') {
         queueReads += 1;
         return queueReads === 1
           ? Promise.resolve({ data: decisionQueue })
-          : Promise.reject(new Error('queue down'));
+          : Promise.resolve({ data: { items: [], count: 0, composePodId: 'pod-1' } });
       }
+      if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [] } });
       return Promise.resolve({ data: recap });
     });
     mockPost.mockResolvedValue({ data: { ok: true, decision: { ruling: { value: 'Ship now', by: 'You' } } } });
     renderPage();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Rule: Ship now' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Rule: Ship now (Recommended)' }));
     expect(await screen.findByText('✓ You ruled: Ship now')).toBeInTheDocument();
+  });
+
+  test('restores a settled Activity card from durable history after leave and return', async () => {
+    const settled = {
+      id: 'decision-024', kind: 'decision', title: 'Choose the eslint scope', detail: 'What should the agent do?',
+      podId: 'pod-1', podName: 'Launch pod', messageId: '700', threadRootId: '695',
+      options: [{ label: 'Ship now' }, { label: 'Hold for review' }], status: 'ruled',
+      ruling: { value: 'Ship now', by: 'You' },
+    };
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
+      if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [settled] } });
+      return Promise.resolve({ data: recap });
+    });
+
+    const first = renderPage();
+    expect(await screen.findByText('✓ You ruled: Ship now')).toBeInTheDocument();
+    first.unmount();
+
+    renderPage();
+    expect(await screen.findByText('✓ You ruled: Ship now')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rule:/ })).not.toBeInTheDocument();
   });
 
   test('sends an Other ruling verbatim to the same DecisionRequest endpoint', async () => {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -341,10 +341,12 @@ describe('V2ActivityPage', () => {
       if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
       if (url === '/api/activity/decision-history') {
         historyReads += 1;
-        expect(config?.params?.offset).toBe(historyReads === 1 ? 0 : 50);
+        expect(config?.params?.offset).toBe(historyReads === 2 ? 50 : 0);
         return Promise.resolve({ data: historyReads === 1
           ? { items: firstPage, count: 51, remaining: 1, hasMore: true }
-          : { items: [older], count: 51, remaining: 0, hasMore: false } });
+          : historyReads === 2
+            ? { items: [older], count: 51, remaining: 0, hasMore: false }
+            : { items: firstPage, count: 51, remaining: 1, hasMore: true } });
       }
       return Promise.resolve({ data: recap });
     });
@@ -358,6 +360,10 @@ describe('V2ActivityPage', () => {
     expect(await screen.findByText('Older decision')).toBeInTheDocument();
     await waitFor(() => expect(historyReads).toBe(2));
     await waitFor(() => expect(document.querySelector('[data-activity-item-id="decision-older"]')).toHaveFocus());
+    globalThis.window.dispatchEvent(new Event(ATTENTION_CHANGED));
+    await waitFor(() => expect(historyReads).toBe(3));
+    expect(screen.queryByRole('button', { name: 'Show more settled · 1 remaining' })).not.toBeInTheDocument();
+    expect(screen.getByText('Older decision')).toBeInTheDocument();
   });
 
   test('returns focus to the settled-history Retry control after a failed page load', async () => {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -397,6 +397,47 @@ describe('V2ActivityPage', () => {
     await waitFor(() => expect(retry).toHaveFocus());
   });
 
+  test('keeps an unseen older ruling available after a newest ruling arrives', async () => {
+    const firstPage = Array.from({ length: 50 }, (_, index) => ({
+      id: `decision-visible-${index}`, kind: 'decision', title: `Visible decision ${index}`, detail: 'A ruling',
+      podId: 'pod-1', podName: 'Launch pod', messageId: String(800 - index), options: [{ label: 'Keep' }], status: 'ruled',
+      ruling: { value: 'Keep', by: 'You' },
+    }));
+    const priorOlder = {
+      id: 'decision-prior-older', kind: 'decision', title: 'Prior older decision', detail: 'A ruling',
+      podId: 'pod-1', podName: 'Launch pod', messageId: '749', options: [{ label: 'Keep' }], status: 'ruled',
+      ruling: { value: 'Keep', by: 'You' },
+    };
+    const newestArrival = { ...firstPage[0], id: 'decision-arrival', title: 'Newest arrival', messageId: '801' };
+    const unseenOlder = {
+      id: 'decision-unseen-older', kind: 'decision', title: 'Unseen older decision', detail: 'A ruling',
+      podId: 'pod-1', podName: 'Launch pod', messageId: '700', options: [{ label: 'Keep' }], status: 'ruled',
+      ruling: { value: 'Keep', by: 'You' },
+    };
+    let historyReads = 0;
+    mockGet.mockImplementation((url: string, config?: any) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
+      if (url === '/api/activity/decision-history') {
+        historyReads += 1;
+        if (historyReads === 1) return Promise.resolve({ data: { items: firstPage, count: 51, remaining: 1, hasMore: true } });
+        if (historyReads === 2) return Promise.resolve({ data: { items: [priorOlder], count: 51, remaining: 0, hasMore: false } });
+        if (historyReads === 3) return Promise.resolve({ data: { items: [newestArrival, ...firstPage.slice(0, 49)], count: 53, remaining: 3, hasMore: true } });
+        expect(config?.params?.offset).toBe(51);
+        return Promise.resolve({ data: { items: [unseenOlder], count: 53, remaining: 0, hasMore: false } });
+      }
+      return Promise.resolve({ data: recap });
+    });
+    renderPage();
+
+    expect(await screen.findByText('Visible decision 0')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show more settled · 1 remaining' }));
+    expect(await screen.findByText('Prior older decision')).toBeInTheDocument();
+    globalThis.window.dispatchEvent(new Event(ATTENTION_CHANGED));
+    expect(await screen.findByRole('button', { name: 'Show more settled · 1 remaining' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show more settled · 1 remaining' }));
+    expect(await screen.findByText('Unseen older decision')).toBeInTheDocument();
+  });
+
   test('sends an Other ruling verbatim to the same DecisionRequest endpoint', async () => {
     mockGet.mockImplementation((url: string) => Promise.resolve({
       data: url === '/api/activity/decision-queue' ? decisionQueue : recap,

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -370,6 +370,36 @@ describe('V2ActivityPage', () => {
     expect(screen.getByText('Older decision')).toBeInTheDocument();
   });
 
+  test('does not revive More after a newest ruling arrives before older history is requested', async () => {
+    const firstPage = Array.from({ length: 50 }, (_, index) => ({
+      id: `decision-initial-${index}`, kind: 'decision', title: `Initial decision ${index}`, detail: 'A ruling',
+      podId: 'pod-1', podName: 'Launch pod', messageId: String(900 - index), options: [{ label: 'Keep' }], status: 'ruled',
+      ruling: { value: 'Keep', by: 'You' },
+    }));
+    const newestArrival = {
+      ...firstPage[0], id: 'decision-newest-arrival', title: 'Newest arrival', messageId: '901',
+    };
+    let historyReads = 0;
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
+      if (url === '/api/activity/decision-history') {
+        historyReads += 1;
+        return historyReads === 1
+          ? Promise.resolve({ data: { items: firstPage, count: 50, remaining: 0, hasMore: false } })
+          : Promise.resolve({ data: { items: [newestArrival, ...firstPage.slice(0, 49)], count: 51, remaining: 1, hasMore: true } });
+      }
+      return Promise.resolve({ data: recap });
+    });
+    renderPage();
+
+    expect(await screen.findByText('Initial decision 0')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Show more settled/ })).not.toBeInTheDocument();
+    await act(async () => { window.dispatchEvent(new Event(ATTENTION_CHANGED)); });
+    await waitFor(() => expect(historyReads).toBe(2));
+    expect(await screen.findByText('Newest arrival')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Show more settled/ })).not.toBeInTheDocument();
+  });
+
   test('returns focus to the settled-history Retry control after a failed page load', async () => {
     const newest = {
       id: 'decision-newest', kind: 'decision', title: 'Newest decision', detail: 'A newer ruling',

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -319,37 +319,6 @@ describe('V2ActivityPage', () => {
     expect(screen.queryByRole('button', { name: /Rule:/ })).not.toBeInTheDocument();
   });
 
-  test('restores a settled Activity card beyond the first history page', async () => {
-    const settled = {
-      id: 'decision-history-overflow', kind: 'decision', title: 'Older workspace ruling', detail: 'What should the agent do?',
-      podId: 'pod-1', podName: 'Launch pod', messageId: '900', threadRootId: '895',
-      options: [{ label: 'Ship now' }, { label: 'Hold for review' }], status: 'ruled',
-      ruling: { value: 'Ship now', by: 'You' },
-    };
-    const firstPage = Array.from({ length: 50 }, (_, index) => ({
-      id: `decision-history-${index}`, kind: 'decision', title: `Older ruling ${index}`, detail: 'Another ruling',
-      podId: 'pod-1', podName: 'Launch pod', messageId: `history-${index}`, options: [{ label: 'A' }], status: 'ruled',
-      ruling: { value: 'A', by: 'You' },
-    }));
-    let historyReads = 0;
-    mockGet.mockImplementation((url: string, config?: any) => {
-      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
-      if (url === '/api/activity/decision-history') {
-        historyReads += 1;
-        if (config?.params?.offset === 0) {
-          return Promise.resolve({ data: { items: firstPage, count: 51, remaining: 1, hasMore: true } });
-        }
-        expect(config?.params?.offset).toBe(50);
-        return Promise.resolve({ data: { items: [settled], count: 51, remaining: 0, hasMore: false } });
-      }
-      return Promise.resolve({ data: recap });
-    });
-
-    renderPage();
-    expect(await screen.findByText('✓ You ruled: Ship now')).toBeInTheDocument();
-    expect(historyReads).toBe(2);
-  });
-
   test('sends an Other ruling verbatim to the same DecisionRequest endpoint', async () => {
     mockGet.mockImplementation((url: string) => Promise.resolve({
       data: url === '/api/activity/decision-queue' ? decisionQueue : recap,

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -336,6 +336,9 @@ describe('V2ActivityPage', () => {
       podId: 'pod-1', podName: 'Launch pod', messageId: '650', options: [{ label: 'Keep' }], status: 'ruled',
       ruling: { value: 'Keep', by: 'You' },
     };
+    const newestArrival = {
+      ...newest, id: 'decision-newest-arrival', title: 'Newest arrival', messageId: '652',
+    };
     let historyReads = 0;
     mockGet.mockImplementation((url: string, config?: any) => {
       if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
@@ -346,7 +349,7 @@ describe('V2ActivityPage', () => {
           ? { items: firstPage, count: 51, remaining: 1, hasMore: true }
           : historyReads === 2
             ? { items: [older], count: 51, remaining: 0, hasMore: false }
-            : { items: firstPage, count: 51, remaining: 1, hasMore: true } });
+            : { items: [newestArrival, ...firstPage.slice(0, 49)], count: 52, remaining: 2, hasMore: true } });
       }
       return Promise.resolve({ data: recap });
     });
@@ -362,7 +365,8 @@ describe('V2ActivityPage', () => {
     await waitFor(() => expect(document.querySelector('[data-activity-item-id="decision-older"]')).toHaveFocus());
     globalThis.window.dispatchEvent(new Event(ATTENTION_CHANGED));
     await waitFor(() => expect(historyReads).toBe(3));
-    expect(screen.queryByRole('button', { name: 'Show more settled · 1 remaining' })).not.toBeInTheDocument();
+    expect(screen.getByText('Newest arrival')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Show more settled/ })).not.toBeInTheDocument();
     expect(screen.getByText('Older decision')).toBeInTheDocument();
   });
 

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -357,6 +357,34 @@ describe('V2ActivityPage', () => {
     fireEvent.click(more);
     expect(await screen.findByText('Older decision')).toBeInTheDocument();
     await waitFor(() => expect(historyReads).toBe(2));
+    await waitFor(() => expect(document.querySelector('[data-activity-item-id="decision-older"]')).toHaveFocus());
+  });
+
+  test('returns focus to the settled-history Retry control after a failed page load', async () => {
+    const newest = {
+      id: 'decision-newest', kind: 'decision', title: 'Newest decision', detail: 'A newer ruling',
+      podId: 'pod-1', podName: 'Launch pod', messageId: '651', options: [{ label: 'Keep' }], status: 'ruled',
+      ruling: { value: 'Keep', by: 'You' },
+    };
+    let historyReads = 0;
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
+      if (url === '/api/activity/decision-history') {
+        historyReads += 1;
+        return historyReads === 1
+          ? Promise.resolve({ data: { items: [newest], count: 51, remaining: 1, hasMore: true } })
+          : Promise.reject(new Error('history unavailable'));
+      }
+      return Promise.resolve({ data: recap });
+    });
+    renderPage();
+
+    const more = await screen.findByRole('button', { name: 'Show more settled · 1 remaining' });
+    more.focus();
+    fireEvent.click(more);
+    more.blur();
+    const retry = await screen.findByRole('button', { name: 'Retry' });
+    await waitFor(() => expect(retry).toHaveFocus());
   });
 
   test('sends an Other ruling verbatim to the same DecisionRequest endpoint', async () => {

--- a/frontend/src/v2/__tests__/V2DecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2DecisionCard.test.tsx
@@ -32,7 +32,8 @@ describe('V2DecisionCard', () => {
     expect(screen.getByText('Which implementation should ship?')).toBeInTheDocument();
     expect(screen.getByText('Sprint impl')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Ship the rebuilt workspace' })).toHaveClass('v2-decision-card__choice--primary');
-    expect(screen.getByRole('button', { name: 'Keep the legacy chat' })).not.toHaveClass('v2-decision-card__choice--primary');
+    expect(screen.getByRole('button', { name: 'Rule: Keep the legacy chat (Recommended)' })).not.toHaveClass('v2-decision-card__choice--primary');
+    expect(screen.getByRole('button', { name: 'Rule: Keep the legacy chat (Recommended)' })).toHaveTextContent('Recommended');
 
     fireEvent.click(screen.getByRole('button', { name: 'Ship the rebuilt workspace' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
@@ -48,7 +49,7 @@ describe('V2DecisionCard', () => {
     });
     render(<V2DecisionCard decision={decision} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Keep the legacy chat' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Rule: Keep the legacy chat (Recommended)' }));
     expect(await screen.findByRole('status')).toHaveTextContent('Lily ruled: Keep the legacy chat');
     expect(screen.queryByRole('button', { name: 'Ship the rebuilt workspace' })).not.toBeInTheDocument();
   });

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -95,7 +95,7 @@ describe('V2Thread decision cards', () => {
     expect(screen.getByText('Choose the workspace cutover')).toBeInTheDocument();
     expect(screen.queryByText('Choose one of the following approaches in prose.')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Ship the rebuilt workspace' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Rule: Ship the rebuilt workspace (Recommended)' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(
       '/api/activity/decisions/decision-42/choose',
       { value: 'Ship the rebuilt workspace' },
@@ -162,5 +162,31 @@ describe('V2Thread decision cards', () => {
     );
     expect(await screen.findByTestId('decision-card')).toBeInTheDocument();
     expect(screen.getByText('Overflow decision')).toBeInTheDocument();
+  });
+
+  test('keeps authored option order while labeling a later recommended option', async () => {
+    const authored = {
+      id: 'decision-authored-order', kind: 'decision', podId: 'pod-1', messageId: '42',
+      title: 'Choose the workspace cutover', detail: 'Which implementation should ship?',
+      options: [{ label: 'Hold for review' }, { label: 'Ship the rebuilt workspace', recommended: true }],
+    };
+    mockGet.mockImplementation((url) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [authored] } });
+      if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [] } });
+      return Promise.resolve({ data: {} });
+    });
+
+    render(
+      <AuthContext.Provider value={auth}>
+        <MemoryRouter><V2Thread detail={detail} /></MemoryRouter>
+      </AuthContext.Provider>,
+    );
+
+    const first = await screen.findByRole('button', { name: 'Hold for review' });
+    const second = screen.getByRole('button', { name: 'Rule: Ship the rebuilt workspace (Recommended)' });
+    expect(first).toHaveClass('v2-decision-card__choice--primary');
+    expect(second).not.toHaveClass('v2-decision-card__choice--primary');
+    expect(second).toHaveTextContent('Recommended');
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import V2Thread from '../components/V2Thread';
 import { AuthContext } from '../../context/AuthContext';
@@ -87,7 +87,7 @@ describe('V2Thread decision cards', () => {
 
     expect(await screen.findByTestId('decision-card')).toBeInTheDocument();
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-queue', expect.objectContaining({
-      params: { podId: 'pod-1' },
+      params: { podId: 'pod-1', limit: 50, offset: 0 },
     }));
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-history', expect.objectContaining({
       params: { podId: 'pod-1', limit: 50, offset: 0 },
@@ -141,7 +141,54 @@ describe('V2Thread decision cards', () => {
     expect(screen.queryByTestId('decision-card')).not.toBeInTheDocument();
   });
 
+  test('keeps a settled card visible when a later history refresh fails', async () => {
+    const settled = {
+      id: 'decision-42', kind: 'decision', podId: 'pod-1', messageId: '42',
+      title: 'Choose the workspace cutover', detail: 'Which implementation should ship?',
+      options: [{ label: 'Ship the rebuilt workspace' }, { label: 'Keep the legacy chat' }],
+      status: 'ruled', ruling: {
+        value: 'Ship the rebuilt workspace', by: 'Lily', messageId: 'ruling-42', at: '2026-09-05T12:01:00.000Z',
+      },
+    };
+    let historyReads = 0;
+    mockGet.mockImplementation((url) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [] } });
+      if (url === '/api/activity/decision-history') {
+        historyReads += 1;
+        return historyReads === 1
+          ? Promise.resolve({ data: { items: [settled] } })
+          : Promise.reject(new Error('history unavailable'));
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    jest.useFakeTimers();
+    try {
+      render(
+        <AuthContext.Provider value={auth}>
+          <MemoryRouter><V2Thread detail={detail} /></MemoryRouter>
+        </AuthContext.Provider>,
+      );
+      expect(await screen.findByTestId('decision-ruling-row')).toHaveTextContent('Ship the rebuilt workspace');
+      expect(historyReads).toBe(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(15_000);
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(historyReads).toBe(2));
+      expect(screen.getByTestId('decision-ruling-row')).toHaveTextContent('Lily');
+      expect(screen.queryByTestId('decision-card')).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   test('discovers a decision in the selected pod beyond the global queue page', async () => {
+    const firstPage = Array.from({ length: 50 }, (_, index) => ({
+      id: `decision-filler-${index}`, kind: 'decision', podId: 'pod-1', messageId: `filler-${index}`,
+      title: `Filler ${index}`, detail: 'Another decision', options: [{ label: 'Keep looking' }],
+    }));
     const target = {
       id: 'decision-overflow', kind: 'decision', podId: 'pod-1', messageId: '42',
       title: 'Overflow decision', detail: 'Which implementation should ship?',
@@ -149,8 +196,12 @@ describe('V2Thread decision cards', () => {
     };
     mockGet.mockImplementation((url, config) => {
       if (url === '/api/activity/decision-queue') {
-        expect(config).toEqual(expect.objectContaining({ params: { podId: 'pod-1' } }));
-        return Promise.resolve({ data: { items: [target], count: 1, remaining: 0 } });
+        const offset = config?.params?.offset;
+        if (offset === 0) {
+          return Promise.resolve({ data: { items: firstPage, count: 51, remaining: 1, hasMore: true } });
+        }
+        expect(offset).toBe(50);
+        return Promise.resolve({ data: { items: [target], count: 51, remaining: 0, hasMore: false } });
       }
       if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [] } });
       return Promise.resolve({ data: {} });

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -249,6 +249,55 @@ describe('V2Thread decision cards', () => {
     expect(screen.getByText('Overflow decision')).toBeInTheDocument();
   });
 
+  test('chunks loaded source ids so decisions at both ends of a long transcript remain discoverable', async () => {
+    const messages = Array.from({ length: 202 }, (_, index) => ({
+      ...detail.messages[0],
+      id: String(index),
+    }));
+    messages[0] = { ...messages[0], id: 'source-first' };
+    messages[201] = { ...messages[201], id: 'source-last' };
+    const wideDetail = { ...detail, messages };
+    const first = {
+      id: 'decision-first', kind: 'decision', podId: 'pod-1', messageId: 'source-first',
+      title: 'First source decision', detail: 'Which first-end choice?',
+      options: [{ label: 'Keep first' }],
+    };
+    const last = {
+      id: 'decision-last', kind: 'decision', podId: 'pod-1', messageId: 'source-last',
+      title: 'Last source decision', detail: 'Which last-end choice?',
+      options: [{ label: 'Keep last' }],
+    };
+    const requests = new Map<string, string[]>();
+    mockGet.mockImplementation((url, config) => {
+      if (url !== '/api/activity/decision-queue' && url !== '/api/activity/decision-history') return Promise.resolve({ data: {} });
+      const ids = String(config?.params?.messageIds || '').split(',').filter(Boolean);
+      expect(ids.length).toBeLessThanOrEqual(200);
+      expect(new Set(ids).size).toBe(ids.length);
+      const key = url.endsWith('decision-queue') ? 'queue' : 'history';
+      requests.set(`${key}-${requests.size}`, ids);
+      const items = key === 'queue'
+        ? [first, last].filter((item) => ids.includes(item.messageId))
+        : [];
+      return Promise.resolve({ data: { items, hasMore: false } });
+    });
+
+    render(
+      <AuthContext.Provider value={auth}>
+        <MemoryRouter><V2Thread detail={wideDetail} /></MemoryRouter>
+      </AuthContext.Provider>,
+    );
+
+    expect(await screen.findAllByTestId('decision-card')).toHaveLength(2);
+    expect(screen.getByText('First source decision')).toBeInTheDocument();
+    expect(screen.getByText('Last source decision')).toBeInTheDocument();
+    const queueRequests = [...requests.entries()].filter(([key]) => key.startsWith('queue-'));
+    const historyRequests = [...requests.entries()].filter(([key]) => key.startsWith('history-'));
+    expect(queueRequests).toHaveLength(2);
+    expect(historyRequests).toHaveLength(2);
+    expect(queueRequests[0][1]).toContain('source-first');
+    expect(queueRequests[1][1]).toContain('source-last');
+  });
+
   test('keeps authored option order while labeling a later recommended option', async () => {
     const authored = {
       id: 'decision-authored-order', kind: 'decision', podId: 'pod-1', messageId: '42',

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -184,6 +184,27 @@ describe('V2Thread decision cards', () => {
     }
   });
 
+  test('returns focus to a failed custom answer instead of skipping to the composer', async () => {
+    mockPost.mockRejectedValueOnce(new Error('temporary failure'));
+    render(
+      <AuthContext.Provider value={auth}>
+        <MemoryRouter><V2Thread detail={detail} /></MemoryRouter>
+      </AuthContext.Provider>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Other…' }));
+    const input = screen.getByRole('textbox', { name: 'Write your ruling…' });
+    fireEvent.change(input, { target: { value: 'Hold for customer evidence' } });
+    const send = screen.getByRole('button', { name: 'Send ruling' });
+    send.focus();
+    fireEvent.click(send);
+    (document.activeElement as HTMLElement | null)?.blur();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/could not be saved/i);
+    await waitFor(() => expect(input).toHaveFocus());
+    expect(send).not.toBeDisabled();
+  });
+
   test('keeps a pending card visible when a later queue refresh fails', async () => {
     const pending = {
       id: 'decision-42', kind: 'decision', podId: 'pod-1', messageId: '42',

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -69,6 +69,7 @@ describe('V2Thread decision cards', () => {
           options: [{ label: 'Ship the rebuilt workspace', recommended: true }],
         }] } });
       }
+      if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [] } });
       return Promise.resolve({ data: {} });
     });
     mockPost.mockResolvedValue({ data: { decision: { ruling: {
@@ -88,6 +89,9 @@ describe('V2Thread decision cards', () => {
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-queue', expect.objectContaining({
       params: { podId: 'pod-1' },
     }));
+    expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-history', expect.objectContaining({
+      params: { podId: 'pod-1', limit: 50, offset: 0 },
+    }));
     expect(screen.getByText('Choose the workspace cutover')).toBeInTheDocument();
     expect(screen.queryByText('Choose one of the following approaches in prose.')).not.toBeInTheDocument();
 
@@ -103,5 +107,60 @@ describe('V2Thread decision cards', () => {
     expect(ruling).toHaveTextContent('Ship the rebuilt workspace');
     expect(screen.queryByTestId('decision-card')).not.toBeInTheDocument();
     expect(onDecisionSettled).toHaveBeenCalledTimes(1);
+  });
+
+  test('restores a settled card from durable history after leave and return', async () => {
+    const settled = {
+      id: 'decision-42', kind: 'decision', podId: 'pod-1', messageId: '42',
+      title: 'Choose the workspace cutover', detail: 'Which implementation should ship?',
+      options: [{ label: 'Ship the rebuilt workspace' }, { label: 'Keep the legacy chat' }],
+      status: 'ruled', ruling: {
+        value: 'Ship the rebuilt workspace', by: 'Lily', messageId: 'ruling-42', at: '2026-09-05T12:01:00.000Z',
+      },
+    };
+    mockGet.mockImplementation((url) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [] } });
+      if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [settled] } });
+      return Promise.resolve({ data: {} });
+    });
+
+    const first = render(
+      <AuthContext.Provider value={auth}>
+        <MemoryRouter><V2Thread detail={detail} /></MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    expect(await screen.findByTestId('decision-ruling-row')).toHaveTextContent('Ship the rebuilt workspace');
+    first.unmount();
+
+    render(
+      <AuthContext.Provider value={auth}>
+        <MemoryRouter><V2Thread detail={detail} /></MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    expect(await screen.findByTestId('decision-ruling-row')).toHaveTextContent('Lily');
+    expect(screen.queryByTestId('decision-card')).not.toBeInTheDocument();
+  });
+
+  test('discovers a decision in the selected pod beyond the global queue page', async () => {
+    const target = {
+      id: 'decision-overflow', kind: 'decision', podId: 'pod-1', messageId: '42',
+      title: 'Overflow decision', detail: 'Which implementation should ship?',
+      options: [{ label: 'Ship this one' }, { label: 'Keep looking' }],
+    };
+    mockGet.mockImplementation((url, config) => {
+      if (url === '/api/activity/decision-queue') {
+        expect(config).toEqual(expect.objectContaining({ params: { podId: 'pod-1' } }));
+        return Promise.resolve({ data: { items: [target], count: 1, remaining: 0 } });
+      }
+      if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [] } });
+      return Promise.resolve({ data: {} });
+    });
+    render(
+      <AuthContext.Provider value={auth}>
+        <MemoryRouter><V2Thread detail={detail} /></MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    expect(await screen.findByTestId('decision-card')).toBeInTheDocument();
+    expect(screen.getByText('Overflow decision')).toBeInTheDocument();
   });
 });

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -85,6 +85,9 @@ describe('V2Thread decision cards', () => {
     );
 
     expect(await screen.findByTestId('decision-card')).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-queue', expect.objectContaining({
+      params: { podId: 'pod-1' },
+    }));
     expect(screen.getByText('Choose the workspace cutover')).toBeInTheDocument();
     expect(screen.queryByText('Choose one of the following approaches in prose.')).not.toBeInTheDocument();
 

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -87,7 +87,7 @@ describe('V2Thread decision cards', () => {
 
     expect(await screen.findByTestId('decision-card')).toBeInTheDocument();
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-queue', expect.objectContaining({
-      params: { podId: 'pod-1', limit: 50, offset: 0 },
+      params: { podId: 'pod-1', limit: 50, offset: 0, messageIds: '42' },
     }));
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-history', expect.objectContaining({
       params: { podId: 'pod-1', limit: 50, offset: 0, messageIds: '42' },
@@ -224,11 +224,7 @@ describe('V2Thread decision cards', () => {
     }
   });
 
-  test('discovers a decision in the selected pod beyond the global queue page', async () => {
-    const firstPage = Array.from({ length: 50 }, (_, index) => ({
-      id: `decision-filler-${index}`, kind: 'decision', podId: 'pod-1', messageId: `filler-${index}`,
-      title: `Filler ${index}`, detail: 'Another decision', options: [{ label: 'Keep looking' }],
-    }));
+  test('discovers a loaded decision despite unrelated queue overflow', async () => {
     const target = {
       id: 'decision-overflow', kind: 'decision', podId: 'pod-1', messageId: '42',
       title: 'Overflow decision', detail: 'Which implementation should ship?',
@@ -236,11 +232,9 @@ describe('V2Thread decision cards', () => {
     };
     mockGet.mockImplementation((url, config) => {
       if (url === '/api/activity/decision-queue') {
+        expect(config?.params?.messageIds).toBe('42');
         const offset = config?.params?.offset;
-        if (offset === 0) {
-          return Promise.resolve({ data: { items: firstPage, count: 51, remaining: 1, hasMore: true } });
-        }
-        expect(offset).toBe(50);
+        expect(offset).toBe(0);
         return Promise.resolve({ data: { items: [target], count: 51, remaining: 0, hasMore: false } });
       }
       if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [] } });

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -90,7 +90,7 @@ describe('V2Thread decision cards', () => {
       params: { podId: 'pod-1', limit: 50, offset: 0 },
     }));
     expect(mockGet).toHaveBeenCalledWith('/api/activity/decision-history', expect.objectContaining({
-      params: { podId: 'pod-1', limit: 50, offset: 0 },
+      params: { podId: 'pod-1', limit: 50, offset: 0, messageIds: '42' },
     }));
     expect(screen.getByText('Choose the workspace cutover')).toBeInTheDocument();
     expect(screen.queryByText('Choose one of the following approaches in prose.')).not.toBeInTheDocument();
@@ -179,6 +179,46 @@ describe('V2Thread decision cards', () => {
       await waitFor(() => expect(historyReads).toBe(2));
       expect(screen.getByTestId('decision-ruling-row')).toHaveTextContent('Lily');
       expect(screen.queryByTestId('decision-card')).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('keeps a pending card visible when a later queue refresh fails', async () => {
+    const pending = {
+      id: 'decision-42', kind: 'decision', podId: 'pod-1', messageId: '42',
+      actorName: 'Sprint impl', title: 'Choose the workspace cutover', detail: 'Which implementation should ship?',
+      options: [{ label: 'Ship the rebuilt workspace' }, { label: 'Keep the legacy chat' }],
+    };
+    let queueReads = 0;
+    mockGet.mockImplementation((url) => {
+      if (url === '/api/activity/decision-queue') {
+        queueReads += 1;
+        return queueReads === 1
+          ? Promise.resolve({ data: { items: [pending] } })
+          : Promise.reject(new Error('queue unavailable'));
+      }
+      if (url === '/api/activity/decision-history') return Promise.resolve({ data: { items: [] } });
+      return Promise.resolve({ data: {} });
+    });
+
+    jest.useFakeTimers();
+    try {
+      render(
+        <AuthContext.Provider value={auth}>
+          <MemoryRouter><V2Thread detail={detail} /></MemoryRouter>
+        </AuthContext.Provider>,
+      );
+      expect(await screen.findByTestId('decision-card')).toBeInTheDocument();
+      expect(queueReads).toBe(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(15_000);
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(queueReads).toBe(2));
+      expect(screen.getByTestId('decision-card')).toBeInTheDocument();
+      expect(screen.getByText('Choose the workspace cutover')).toBeInTheDocument();
     } finally {
       jest.useRealTimers();
     }

--- a/frontend/src/v2/__tests__/V2ThreadHistory.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadHistory.test.tsx
@@ -124,7 +124,7 @@ describe('V2ThreadMessages history edge and jump pill (direction C)', () => {
   });
 
   test('groups a settled ruling by its rendered human identity, preserving the author and ruled marker', () => {
-    const previous = msg('1');
+    const previous = msg('1', { user_id: 'u-agent', user: { username: 'Scout' } });
     const source = msg('2', { user_id: 'u-agent', user: { username: 'Scout' } });
     const { container } = renderThread({
       messages: [previous, source],

--- a/frontend/src/v2/__tests__/V2ThreadHistory.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadHistory.test.tsx
@@ -122,4 +122,18 @@ describe('V2ThreadMessages history edge and jump pill (direction C)', () => {
     fireEvent.click(pill);
     expect(onJump).toHaveBeenCalledTimes(1);
   });
+
+  test('groups a settled ruling by its rendered human identity, preserving the author and ruled marker', () => {
+    const previous = msg('1');
+    const source = msg('2', { user_id: 'u-agent', user: { username: 'Scout' } });
+    const { container } = renderThread({
+      messages: [previous, source],
+      settledDecisionByMessageId: new Map([['2', { value: 'Ship it', by: 'Sam' }]]),
+    });
+
+    const ruling = container.querySelector('[data-testid="decision-ruling-row"]');
+    expect(ruling).not.toHaveClass('v2-msg--grouped');
+    expect(ruling.querySelector('.v2-msg__author')).toHaveTextContent('Sam');
+    expect(ruling.querySelector('.v2-msg__ruled')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -406,7 +406,8 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('.v2-activity__option-description');
     expect(activityPage).toContain('(option, index)');
     expect(activityPage).not.toContain('.sort((a, b) => Number(Boolean(b.recommended))');
-    expect(thread).toContain('params: { podId }');
+    expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId)");
+    expect(thread).toContain('params: { podId, limit: DECISION_PAGE_SIZE, offset }');
     expect(thread).toContain("'/api/activity/decision-history'");
     expect(thread).toContain('settledDecisionByMessageId');
   });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -1337,7 +1337,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(activityPage).toContain('settledHistory');
       expect(activityPage).toContain('setSettledQueueDecisions');
       expect(activityPage).toContain('const loadMoreHistory = async () =>');
-      expect(activityPage).toContain('historyOffsetRef.current = historyItems.length');
+      expect(activityPage).toContain('const loadedExtent = Math.max(historyItems.length, previousHistoryExtent)');
+      expect(activityPage).toContain('historyOffsetRef.current = loadedExtent');
+      expect(activityPage).toContain('historyCount - previousHistoryExtent');
       expect(activityPage).toContain('showMoreSettled');
       expect(activityPage).toContain('offset: 0');
     });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -1339,7 +1339,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(activityPage).toContain('const loadMoreHistory = async () =>');
       expect(activityPage).toContain('const loadedExtent = Math.max(historyItems.length, previousHistoryExtent)');
       expect(activityPage).toContain('historyOffsetRef.current = loadedExtent');
-      expect(activityPage).toContain('historyCount - previousHistoryExtent');
+      expect(activityPage).toContain('historyCount - existingIds.size');
       expect(activityPage).toContain('showMoreSettled');
       expect(activityPage).toContain('offset: 0');
     });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -403,7 +403,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('v2-activity__queue-action--bordered');
     const borderedAction = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--bordered');
     expect(borderedAction).toContain('border: 1px solid var(--v2-border)');
-    expect(ruleBody(v2, '.v2-root .v2-activity__compose-picker-button')).toContain('border: 1px solid var(--v2-border)');
+    expect(ruleBody(v2, '.v2-root .v2-activity__compose .v2-activity__compose-picker-button')).toContain('border: 1px solid var(--v2-border)');
     const otherOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option.v2-activity__queue-action--secondary');
     expect(otherOption).toContain('color: var(--v2-accent-text)');
     expect(v2).toContain('.v2-activity__option-description');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -1334,6 +1334,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(activityPage).toContain("'/api/activity/decision-history'");
       expect(activityPage).toContain('settledHistory');
       expect(activityPage).toContain('setSettledQueueDecisions');
+      expect(activityPage).toContain('const loadMoreHistory = async () =>');
+      expect(activityPage).toContain('historyOffsetRef.current = historyItems.length');
+      expect(activityPage).toContain('showMoreSettled');
+      expect(activityPage).toContain('offset: 0');
     });
 
     test('chat and workspace-inspector surfaces do not paint with accent-soft', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -409,10 +409,12 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('.v2-activity__option-description');
     expect(activityPage).toContain('(option, index)');
     expect(activityPage).not.toContain('.sort((a, b) => Number(Boolean(b.recommended))');
-    expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId, {");
-    expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId, {");
-    expect(thread).toContain('podId, limit: DECISION_PAGE_SIZE, offset, ...extraParams');
-    expect(thread).toContain("messageIds: loadedMessageIdsRef.current.join(',')");
+    expect(thread).toContain("loadDecisionPages<T>(");
+    expect(thread).toContain("'/api/activity/decision-queue'");
+    expect(thread).toContain("'/api/activity/decision-history'");
+    expect(thread).toContain('DECISION_MESSAGE_ID_BATCH_SIZE = 200');
+    expect(thread).toContain('loadDecisionPagesForMessageIds<ThreadDecision>');
+    expect(thread).toContain('loadedMessageIdsRef.current = [...new Set(messages');
     expect(thread).toContain('if (pendingData)');
     expect(thread).toContain("'/api/activity/decision-history'");
     expect(thread).toContain('settledDecisionByMessageId');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -407,6 +407,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(activityPage).toContain('(option, index)');
     expect(activityPage).not.toContain('.sort((a, b) => Number(Boolean(b.recommended))');
     expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId)");
+    expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId)");
     expect(thread).toContain('params: { podId, limit: DECISION_PAGE_SIZE, offset }');
     expect(thread).toContain("'/api/activity/decision-history'");
     expect(thread).toContain('settledDecisionByMessageId');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -407,6 +407,8 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(activityPage).toContain('(option, index)');
     expect(activityPage).not.toContain('.sort((a, b) => Number(Boolean(b.recommended))');
     expect(thread).toContain('params: { podId }');
+    expect(thread).toContain("'/api/activity/decision-history'");
+    expect(thread).toContain('settledDecisionByMessageId');
   });
 
   test('the mobile inspector is a drawer, never display:none — the header avatars button must do something', () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -384,10 +384,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toContain('.v2-activity__queue-more:disabled');
   });
 
-  test('DecisionRequest options are full-width content with one recommended primary choice', () => {
+  test('DecisionRequest options preserve authored order with one cobalt primary choice', () => {
     // The first build left options inside the narrow actions column. Generic
-    // queue-button CSS then made every non-recommended option blue while the
-    // recommended one looked secondary — exactly backwards for a fork card.
+    // queue-button CSS once made every non-recommended option blue while the
+    // first authored option looked secondary — exactly backwards for a fork card.
     const decisionActions = ruleBody(v2, '.v2-activity__queue-row--decision .v2-activity__queue-actions');
     expect(decisionActions).toContain('grid-column: 1 / -1');
     expect(decisionActions).toContain('justify-content: flex-start');
@@ -397,12 +397,16 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(neutralOption).toContain('background: var(--v2-surface)');
     expect(neutralOption).toContain('border-radius: var(--v2-radius-sm)');
 
-    const recommendedOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option--recommended');
-    expect(recommendedOption).toContain('background: var(--v2-ink)');
-    expect(recommendedOption).toContain('color: var(--v2-on-ink)');
+    const primaryOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option--primary');
+    expect(primaryOption).toContain('background: var(--v2-accent)');
+    expect(primaryOption).toContain('color: var(--v2-on-ink)');
+    expect(v2).toContain('v2-activity__queue-action--bordered');
     const otherOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option.v2-activity__queue-action--secondary');
     expect(otherOption).toContain('color: var(--v2-accent-text)');
     expect(v2).toContain('.v2-activity__option-description');
+    expect(activityPage).toContain('(option, index)');
+    expect(activityPage).not.toContain('.sort((a, b) => Number(Boolean(b.recommended))');
+    expect(thread).toContain('params: { podId }');
   });
 
   test('the mobile inspector is a drawer, never display:none — the header avatars button must do something', () => {
@@ -1068,14 +1072,17 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button')).toContain('background: var(--v2-ink)');
     expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--secondary')).toContain('background: var(--v2-surface-hover)');
     expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--thread')).toContain('background: transparent');
+    const bordered = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--bordered');
+    expect(bordered).toContain('border-color: var(--v2-border)');
+    expect(bordered).toContain('background: var(--v2-surface)');
   });
 
   test('DecisionRequest options remain 44px touch targets when they wrap at 390px', () => {
     // Options are agent-authored data, not compact task metadata. Keep the
-    // recommended state and the free-text escape hatch visible in the CSS
+    // primary state and the free-text escape hatch visible in the CSS
     // source because jsdom has no layout engine to catch a narrow regression.
-    expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option--recommended'))
-      .toContain('background: var(--v2-ink)');
+    expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option--primary'))
+      .toContain('background: var(--v2-accent)');
     expect(ruleBody(v2, '.v2-activity__decision-other')).toContain('flex-basis: 100%');
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root \.v2-activity__queue-actions button \{ min-height: 44px; \}/);
   });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -401,12 +401,15 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(primaryOption).toContain('background: var(--v2-accent)');
     expect(primaryOption).toContain('color: var(--v2-on-ink)');
     expect(v2).toContain('v2-activity__queue-action--bordered');
+    const borderedAction = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--bordered');
+    expect(borderedAction).toContain('border: 1px solid var(--v2-border)');
+    expect(ruleBody(v2, '.v2-root .v2-activity__compose-picker-button')).toContain('border: 1px solid var(--v2-border)');
     const otherOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option.v2-activity__queue-action--secondary');
     expect(otherOption).toContain('color: var(--v2-accent-text)');
     expect(v2).toContain('.v2-activity__option-description');
     expect(activityPage).toContain('(option, index)');
     expect(activityPage).not.toContain('.sort((a, b) => Number(Boolean(b.recommended))');
-    expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId)");
+    expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId, {");
     expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId, {");
     expect(thread).toContain('podId, limit: DECISION_PAGE_SIZE, offset, ...extraParams');
     expect(thread).toContain("messageIds: loadedMessageIdsRef.current.join(',')");
@@ -1079,7 +1082,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--secondary')).toContain('background: var(--v2-surface-hover)');
     expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--thread')).toContain('background: transparent');
     const bordered = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--bordered');
-    expect(bordered).toContain('border-color: var(--v2-border)');
+    expect(bordered).toContain('border: 1px solid var(--v2-border)');
     expect(bordered).toContain('background: var(--v2-surface)');
   });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -1328,6 +1328,7 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     test('Activity hydrates settled decisions from the durable history projection', () => {
       expect(activityPage).toContain("'/api/activity/decision-history'");
       expect(activityPage).toContain('settledHistory');
+      expect(activityPage).toContain('loadDecisionHistoryPages(headers, podId)');
       expect(activityPage).toContain('setSettledQueueDecisions');
     });
 

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -1323,6 +1323,12 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(ruled).toContain('var(--v2-font-mono)');
     });
 
+    test('Activity hydrates settled decisions from the durable history projection', () => {
+      expect(activityPage).toContain("'/api/activity/decision-history'");
+      expect(activityPage).toContain('settledHistory');
+      expect(activityPage).toContain('setSettledQueueDecisions');
+    });
+
     test('chat and workspace-inspector surfaces do not paint with accent-soft', () => {
       const prefixes = [
         '.v2-chat',

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -407,8 +407,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(activityPage).toContain('(option, index)');
     expect(activityPage).not.toContain('.sort((a, b) => Number(Boolean(b.recommended))');
     expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId)");
-    expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId)");
-    expect(thread).toContain('params: { podId, limit: DECISION_PAGE_SIZE, offset }');
+    expect(thread).toContain("loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId, {");
+    expect(thread).toContain('podId, limit: DECISION_PAGE_SIZE, offset, ...extraParams');
+    expect(thread).toContain("messageIds: loadedMessageIdsRef.current.join(',')");
+    expect(thread).toContain('if (pendingData)');
     expect(thread).toContain("'/api/activity/decision-history'");
     expect(thread).toContain('settledDecisionByMessageId');
   });
@@ -1328,7 +1330,6 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     test('Activity hydrates settled decisions from the durable history projection', () => {
       expect(activityPage).toContain("'/api/activity/decision-history'");
       expect(activityPage).toContain('settledHistory');
-      expect(activityPage).toContain('loadDecisionHistoryPages(headers, podId)');
       expect(activityPage).toContain('setSettledQueueDecisions');
     });
 

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -532,6 +532,11 @@ const V2ActivityPage: React.FC = () => {
     const requestedScope = podId;
     const requestedGeneration = queueGenerationRef.current;
     const offset = historyOffsetRef.current;
+    const trigger = historyMoreButtonRef.current;
+    const shouldRestoreFocus = () => {
+      const active = document.activeElement;
+      return active === document.body || active === trigger || active === historyMoreButtonRef.current;
+    };
     setHistoryLoadingMore(true);
     setHistoryMoreError(false);
     try {
@@ -543,6 +548,11 @@ const V2ActivityPage: React.FC = () => {
       if (queueScopeRef.current !== requestedScope || queueGenerationRef.current !== requestedGeneration) return;
       const items = Array.isArray(response.data?.items) ? response.data.items : [];
       const settled = items.filter((item) => item.kind === 'decision' && item.id && item.ruling?.value);
+      const existingSettledIds = new Set(Object.keys(settledQueueDecisions));
+      const existingQueueIds = new Set(queue.map((item) => `${item.kind}:${item.id}`));
+      const firstAddedId = settled.find((item) => (
+        !existingSettledIds.has(String(item.id)) && !existingQueueIds.has(`${item.kind}:${item.id}`)
+      ))?.id;
       if (settled.length > 0) {
         setRuledDecisions((current) => {
           const next = { ...current };
@@ -575,10 +585,22 @@ const V2ActivityPage: React.FC = () => {
           : 0;
       setHistoryRemaining(remaining);
       setHistoryMoreError(false);
-      globalThis.window.requestAnimationFrame(() => historyMoreButtonRef.current?.focus());
+      globalThis.window.requestAnimationFrame(() => {
+        if (!shouldRestoreFocus()) return;
+        if (historyMoreButtonRef.current) {
+          historyMoreButtonRef.current.focus();
+          return;
+        }
+        if (firstAddedId) {
+          document.querySelector<HTMLElement>(`[data-activity-item-id="${CSS.escape(String(firstAddedId))}"]`)?.focus();
+        }
+      });
     } catch {
       if (queueScopeRef.current === requestedScope && queueGenerationRef.current === requestedGeneration) {
         setHistoryMoreError(true);
+        globalThis.window.requestAnimationFrame(() => {
+          if (shouldRestoreFocus()) historyMoreButtonRef.current?.focus();
+        });
       }
     } finally {
       if (queueGenerationRef.current === requestedGeneration) setHistoryLoadingMore(false);

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -366,11 +366,21 @@ const V2ActivityPage: React.FC = () => {
           // for another page.
           const loadedExtent = Math.max(historyItems.length, previousHistoryExtent);
           historyOffsetRef.current = loadedExtent;
-          setHistoryRemaining(sameScope && previousHistoryExtent > historyItems.length
-            ? Math.max(historyCount - previousHistoryExtent, 0)
-            : typeof historyResponse.data?.remaining === 'number'
+          if (sameScope && previousHistoryExtent > 0) {
+            // A new ruling can arrive ahead of an already-loaded older page.
+            // Count the union of durable cards we already rendered and this
+            // refreshed first page; using only the previous offset would
+            // report the new row as an unseen older row.
+            const existingIds = new Set(Object.values(settledQueueDecisions)
+              .filter((item) => podId === 'all' || item.podId === podId)
+              .map((item) => String(item.id)));
+            settledHistory.forEach((item) => existingIds.add(String(item.id)));
+            setHistoryRemaining(Math.max(historyCount - existingIds.size, 0));
+          } else {
+            setHistoryRemaining(typeof historyResponse.data?.remaining === 'number'
               ? historyResponse.data.remaining
               : Math.max(historyCount - historyItems.length, 0));
+          }
           setHistoryMoreError(false);
         }
         if (settledHistory.length > 0) {

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -83,6 +83,33 @@ interface DecisionHistoryResponse {
   hasMore?: boolean;
 }
 
+const DECISION_HISTORY_PAGE_SIZE = 50;
+
+const loadDecisionHistoryPages = async (
+  headers: Record<string, string>,
+  podId: string,
+): Promise<DecisionHistoryResponse> => {
+  const items: DecisionHistoryResponse['items'] = [];
+  let offset = 0;
+  // Keep a malformed hasMore response from creating an unbounded poll. The
+  // server caps each page at 50; 100 pages is ample for a pod history.
+  for (let page = 0; page < 100; page += 1) {
+    const response = await axios.get<DecisionHistoryResponse>('/api/activity/decision-history', {
+      headers,
+      params: {
+        limit: DECISION_HISTORY_PAGE_SIZE,
+        offset,
+        ...(podId !== 'all' ? { podId } : {}),
+      },
+    });
+    const pageItems = Array.isArray(response.data?.items) ? response.data.items : [];
+    items.push(...pageItems);
+    if (!response.data?.hasMore || pageItems.length === 0) break;
+    offset += pageItems.length;
+  }
+  return { items, count: items.length, remaining: 0, hasMore: false };
+};
+
 interface MovedLine {
   id: string;
   author: string;
@@ -322,10 +349,7 @@ const V2ActivityPage: React.FC = () => {
         '/api/activity/decision-queue',
         { headers, params: { limit: 50, offset: 0, ...(podId !== 'all' ? { podId } : {}) } },
       ).catch(() => null),
-      axios.get<DecisionHistoryResponse>('/api/activity/decision-history', {
-        headers,
-        params: { limit: 50, offset: 0, ...(podId !== 'all' ? { podId } : {}) },
-      }).catch(() => null),
+      loadDecisionHistoryPages(headers, podId).catch(() => null),
     ])
       .then(async ([recapResponse, queueResponse, historyResponse]) => {
         if (!active) return;
@@ -334,8 +358,8 @@ const V2ActivityPage: React.FC = () => {
         // Activity read so a settled card survives a hard reload and the
         // Activity → pod → Activity Back path, even when the open queue has
         // already dropped the recipient-owned row.
-        const historyItems = Array.isArray(historyResponse?.data?.items)
-          ? historyResponse.data.items
+        const historyItems = Array.isArray(historyResponse?.items)
+          ? historyResponse.items
           : [];
         const settledHistory = historyItems.filter((item) => (
           item.kind === 'decision' && item.id && item.ruling?.value

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -175,6 +175,9 @@ const V2ActivityPage: React.FC = () => {
   const [queueRemaining, setQueueRemaining] = useState(0);
   const [queueLoadingMore, setQueueLoadingMore] = useState(false);
   const [queueMoreError, setQueueMoreError] = useState(false);
+  const [historyRemaining, setHistoryRemaining] = useState(0);
+  const [historyLoadingMore, setHistoryLoadingMore] = useState(false);
+  const [historyMoreError, setHistoryMoreError] = useState(false);
   const [queueFailed, setQueueFailed] = useState(false);
   const [queueHydrated, setQueueHydrated] = useState(false);
   const actionFocusGenerationRef = useRef(0);
@@ -184,6 +187,8 @@ const V2ActivityPage: React.FC = () => {
   const revalidationScopeRef = useRef<string | null>(null);
   const queueMoreButtonRef = useRef<HTMLButtonElement | null>(null);
   const queueMoreFailureOffsetRef = useRef<number | null>(null);
+  const historyMoreButtonRef = useRef<HTMLButtonElement | null>(null);
+  const historyOffsetRef = useRef(0);
   const pendingRefreshFocusRef = useRef<string | null>(null);
   const [replyOpenIds, setReplyOpenIds] = useState<Set<string>>(new Set());
   const [replyDrafts, setReplyDrafts] = useState<Record<string, string>>({});
@@ -207,6 +212,10 @@ const V2ActivityPage: React.FC = () => {
     restoredSnapshotRef.current = snapshot;
     setRuledDecisions({});
     setSettledQueueDecisions({});
+    setHistoryRemaining(0);
+    setHistoryMoreError(false);
+    setHistoryLoadingMore(false);
+    historyOffsetRef.current = 0;
     if (snapshot) {
       setWindow(snapshot.window || 'today');
       setPodId(snapshot.podId || 'all');
@@ -292,6 +301,10 @@ const V2ActivityPage: React.FC = () => {
       setQueue([]);
       setQueueCount(null);
       setQueueRemaining(0);
+      setHistoryRemaining(0);
+      setHistoryMoreError(false);
+      setHistoryLoadingMore(false);
+      historyOffsetRef.current = 0;
       setQueueFailed(false);
       revalidationExtentRef.current = 0;
       revalidationScopeRef.current = null;
@@ -309,6 +322,7 @@ const V2ActivityPage: React.FC = () => {
     setError(null);
     setQueueMoreError(false);
     setQueueLoadingMore(false);
+    setHistoryLoadingMore(false);
     const token = localStorage.getItem('token');
     const headers = { 'x-auth-token': token ?? '' };
     // Recap and attention are independent facts. A failed queue read must
@@ -340,6 +354,16 @@ const V2ActivityPage: React.FC = () => {
         const settledHistory = historyItems.filter((item) => (
           item.kind === 'decision' && item.id && item.ruling?.value
         ));
+        if (historyResponse) {
+          const historyCount = typeof historyResponse.data?.count === 'number'
+            ? historyResponse.data.count
+            : historyItems.length;
+          historyOffsetRef.current = historyItems.length;
+          setHistoryRemaining(typeof historyResponse.data?.remaining === 'number'
+            ? historyResponse.data.remaining
+            : Math.max(historyCount - historyItems.length, 0));
+          setHistoryMoreError(false);
+        }
         if (settledHistory.length > 0) {
           setRuledDecisions((current) => {
             const next = { ...current };
@@ -500,6 +524,64 @@ const V2ActivityPage: React.FC = () => {
       }
     } finally {
       if (queueGenerationRef.current === requestedGeneration) setQueueLoadingMore(false);
+    }
+  };
+
+  const loadMoreHistory = async () => {
+    if (historyLoadingMore || historyRemaining <= 0) return;
+    const requestedScope = podId;
+    const requestedGeneration = queueGenerationRef.current;
+    const offset = historyOffsetRef.current;
+    setHistoryLoadingMore(true);
+    setHistoryMoreError(false);
+    try {
+      const token = localStorage.getItem('token');
+      const response = await axios.get<DecisionHistoryResponse>('/api/activity/decision-history', {
+        headers: { 'x-auth-token': token ?? '' },
+        params: { limit: 50, offset, ...(requestedScope !== 'all' ? { podId: requestedScope } : {}) },
+      });
+      if (queueScopeRef.current !== requestedScope || queueGenerationRef.current !== requestedGeneration) return;
+      const items = Array.isArray(response.data?.items) ? response.data.items : [];
+      const settled = items.filter((item) => item.kind === 'decision' && item.id && item.ruling?.value);
+      if (settled.length > 0) {
+        setRuledDecisions((current) => {
+          const next = { ...current };
+          settled.forEach((item) => {
+            next[String(item.id)] = {
+              value: String(item.ruling?.value),
+              ...(item.ruling?.by ? { by: item.ruling.by } : {}),
+            };
+          });
+          return next;
+        });
+        setSettledQueueDecisions((current) => {
+          const next = { ...current };
+          settled.forEach((item) => {
+            next[String(item.id)] = {
+              ...item,
+              detail: item.detail || '',
+              podName: item.podName || '',
+              timestamp: item.timestamp ?? item.createdAt ?? null,
+            };
+          });
+          return next;
+        });
+      }
+      historyOffsetRef.current = offset + items.length;
+      const remaining = typeof response.data?.remaining === 'number'
+        ? response.data.remaining
+        : items.length > 0 && typeof response.data?.count === 'number'
+          ? Math.max(response.data.count - historyOffsetRef.current, 0)
+          : 0;
+      setHistoryRemaining(remaining);
+      setHistoryMoreError(false);
+      globalThis.window.requestAnimationFrame(() => historyMoreButtonRef.current?.focus());
+    } catch {
+      if (queueScopeRef.current === requestedScope && queueGenerationRef.current === requestedGeneration) {
+        setHistoryMoreError(true);
+      }
+    } finally {
+      if (queueGenerationRef.current === requestedGeneration) setHistoryLoadingMore(false);
     }
   };
 
@@ -1046,6 +1128,21 @@ const V2ActivityPage: React.FC = () => {
                   : queueMoreError
                     ? t('activity.needsYou.retry', { defaultValue: 'Retry' })
                     : t('activity.needsYou.showMore', { count: queueRemaining, defaultValue: `Show more · ${queueRemaining} remaining` })}
+              </button>
+            )}
+            {(historyRemaining > 0 || historyMoreError) && (
+              <button
+                type="button"
+                ref={historyMoreButtonRef}
+                className="v2-activity__queue-more"
+                onClick={loadMoreHistory}
+                disabled={historyLoadingMore}
+              >
+                {historyLoadingMore
+                  ? t('activity.needsYou.loadingMore', { defaultValue: 'Loading…' })
+                  : historyMoreError
+                    ? t('activity.needsYou.retry', { defaultValue: 'Retry' })
+                    : t('activity.needsYou.showMoreSettled', { count: historyRemaining, defaultValue: `Show more settled · ${historyRemaining} remaining` })}
               </button>
             )}
             {visibleQueue.length === 0 && queueMoreError && !queueFailed && (

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -155,7 +155,8 @@ const V2ActivityPage: React.FC = () => {
   const [rulingId, setRulingId] = useState<string | null>(null);
   const [otherDecisionId, setOtherDecisionId] = useState<string | null>(null);
   const [otherDecisionValue, setOtherDecisionValue] = useState('');
-  const [ruledDecisions, setRuledDecisions] = useState<Record<string, { value: string; by: string }>>({});
+  const [ruledDecisions, setRuledDecisions] = useState<Record<string, { value: string; by?: string }>>({});
+  const [settledQueueDecisions, setSettledQueueDecisions] = useState<Record<string, NeedsYouItem>>({});
   const [queue, setQueue] = useState<NeedsYouItem[]>([]);
   const queueRef = useRef<NeedsYouItem[]>([]);
   const [queueCount, setQueueCount] = useState<number | null>(null);
@@ -193,6 +194,8 @@ const V2ActivityPage: React.FC = () => {
     snapshotAccountRef.current = accountId;
     const snapshot = accountId ? readActivitySnapshot(accountId) : null;
     restoredSnapshotRef.current = snapshot;
+    setRuledDecisions({});
+    setSettledQueueDecisions({});
     if (snapshot) {
       setWindow(snapshot.window || 'today');
       setPodId(snapshot.podId || 'all');
@@ -487,6 +490,12 @@ const V2ActivityPage: React.FC = () => {
     return recap?.pods || [];
   }, [recap]);
   const composePodName = scopedPods.find((pod) => pod.id === composePodId)?.name || t('activity.allPods');
+  const visibleQueue = useMemo(() => {
+    const settled = Object.values(settledQueueDecisions)
+      .filter((item) => podId === 'all' || item.podId === podId)
+      .filter((item) => !queue.some((open) => open.id === item.id));
+    return [...queue, ...settled];
+  }, [podId, queue, settledQueueDecisions]);
 
   const openPod = (targetPodId: string | null, messageId?: number | string) => {
     if (!targetPodId) return;
@@ -578,23 +587,35 @@ const V2ActivityPage: React.FC = () => {
     setActionErrorItemId(null);
     try {
       const token = localStorage.getItem('token');
-      const response = await axios.post<{ ok?: boolean }>(
+      const response = await axios.post<{
+        ok?: boolean;
+        decision?: { ruling?: { value?: string; by?: string } | null };
+      }>(
         `/api/activity/decisions/${encodeURIComponent(item.id)}/choose`,
         { value },
         { headers: { 'x-auth-token': token ?? '' } },
       );
       if (!response.data?.ok) throw new Error('Decision ruling failed');
+      const settled = response.data.decision?.ruling;
+      const ruling = { value: settled?.value || value.trim(), ...(settled?.by ? { by: settled.by } : {}) };
+      setRuledDecisions((current) => ({
+        ...current,
+        [item.id]: ruling,
+      }));
+      setSettledQueueDecisions((current) => ({ ...current, [item.id]: item }));
       notifyAttentionChanged();
       setOtherDecisionId(null);
       setOtherDecisionValue('');
       setReloadKey((value) => value + 1);
     } catch (error) {
       const standing = axios.isAxiosError(error) ? error.response?.data?.decision?.ruling : null;
-      if (standing?.value && standing?.by) {
+      if (standing?.value) {
+        const ruling = { value: standing.value, ...(standing.by ? { by: standing.by } : {}) };
         setRuledDecisions((current) => ({
           ...current,
-          [item.id]: { value: standing.value, by: standing.by },
+          [item.id]: ruling,
         }));
+        setSettledQueueDecisions((current) => ({ ...current, [item.id]: item }));
       } else {
         setActionErrorItemId(item.id);
         setActionError(t('activity.decision.actionFailed'));
@@ -693,6 +714,7 @@ const V2ActivityPage: React.FC = () => {
 
   const isDayZero = podId === 'all'
     && queueCount === 0
+    && visibleQueue.length === 0
     && recap?.agents.length === 0
     && recap.board.length === 0;
 
@@ -845,7 +867,7 @@ const V2ActivityPage: React.FC = () => {
                   </div>
                 </article>
               </div>
-            ) : queue.length === 0 ? (
+            ) : visibleQueue.length === 0 ? (
               <div className="v2-activity__empty v2-activity__empty--plain">
                 <span>{queueCount === 0
                   ? t('activity.needsYou.emptyTitle')
@@ -853,7 +875,7 @@ const V2ActivityPage: React.FC = () => {
               </div>
             ) : (
               <div className="v2-activity__queue">
-                {queue.map((item) => (
+                {visibleQueue.map((item) => (
                   <article key={item.id} data-activity-item-id={item.id} tabIndex={-1} className={`v2-activity__queue-row v2-activity__queue-row--${item.kind}${item.kind === 'decision' && ruledDecisions[item.id] ? ' v2-activity__queue-row--settled' : ''}`}>
                     <span className="v2-activity__queue-mark" aria-hidden="true">
                       {item.kind === 'mention' ? '@' : item.kind === 'approval' ? '!' : item.kind === 'handoff' ? '↗' : '?'}
@@ -878,17 +900,17 @@ const V2ActivityPage: React.FC = () => {
                       )}
                       {item.kind === 'mention' && (
                         <>
-                          {!replyOpenIds.has(item.id) ? <button type="button" onClick={() => setReplyOpenIds((current) => new Set(current).add(item.id))}>{t('activity.reply.open')}</button> : <div className="v2-activity__reply" data-testid="queue-reply">
+                          {!replyOpenIds.has(item.id) ? <button type="button" className="v2-activity__queue-action--bordered" onClick={() => setReplyOpenIds((current) => new Set(current).add(item.id))}>{t('activity.reply.open')}</button> : <div className="v2-activity__reply" data-testid="queue-reply">
                             <textarea aria-label={t('activity.reply.placeholder')} className="v2-activity__reply-input" rows={2} placeholder={t('activity.reply.placeholder')} value={replyDrafts[item.id] || ''} onChange={(e) => setReplyDrafts((prev) => ({ ...prev, [item.id]: e.target.value }))} onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') sendReply(item); }} disabled={replyingId === item.id} />
                             <button type="button" onClick={() => sendReply(item)} disabled={replyingId === item.id || !(replyDrafts[item.id] || '').trim()}>{replyingId === item.id ? t('activity.reply.working') : repliedIds.has(item.id) ? t('activity.reply.sent') : t('activity.reply.send')}</button>
                           </div>}
-                          <button type="button" className="v2-activity__queue-action--thread" onClick={() => acknowledgeMention(item)} disabled={acknowledgingAttentionId === item.id}>
+                          <button type="button" className="v2-activity__queue-action--thread v2-activity__queue-action--bordered" onClick={() => acknowledgeMention(item)} disabled={acknowledgingAttentionId === item.id}>
                             {acknowledgingAttentionId === item.id ? t('activity.mention.working') : t('activity.mention.markHandled')}
                           </button>
                         </>
                       )}
                       {item.kind === 'handoff' && (
-                        <button type="button" className="v2-activity__queue-action--thread" onClick={() => markHandoffHandled(item)} disabled={acknowledgingAttentionId === item.id}>
+                        <button type="button" className="v2-activity__queue-action--thread v2-activity__queue-action--bordered" onClick={() => markHandoffHandled(item)} disabled={acknowledgingAttentionId === item.id}>
                           {acknowledgingAttentionId === item.id ? t('activity.handoff.working', { defaultValue: 'Saving…' }) : t('activity.handoff.markHandled', { defaultValue: 'Mark handled' })}
                         </button>
                       )}
@@ -900,24 +922,22 @@ const V2ActivityPage: React.FC = () => {
                             </span>
                           ) : (
                             <>
-                              {[...(item.options || [])]
-                                .sort((a, b) => Number(Boolean(b.recommended)) - Number(Boolean(a.recommended)))
-                                .map((option) => (
-                                  <div className="v2-activity__option-choice" key={option.label}>
-                                    <button
-                                      type="button"
-                                      className={`v2-activity__option${option.recommended ? ' v2-activity__option--recommended' : ''}`}
-                                      onClick={() => ruleDecision(item, option.label)}
-                                      disabled={rulingId === item.id}
-                                      aria-label={t('activity.decision.ruleOption', { option: option.label })}
-                                    >
-                                      {rulingId === item.id ? t('activity.decision.working') : option.label}
-                                    </button>
-                                    {option.description && (
-                                      <span className="v2-activity__option-description">{option.description}</span>
-                                    )}
-                                  </div>
-                                ))}
+                              {(item.options || []).map((option, index) => (
+                                <div className="v2-activity__option-choice" key={option.label}>
+                                  <button
+                                    type="button"
+                                    className={`v2-activity__option${index === 0 ? ' v2-activity__option--primary' : ''}`}
+                                    onClick={() => ruleDecision(item, option.label)}
+                                    disabled={rulingId === item.id}
+                                    aria-label={t('activity.decision.ruleOption', { option: option.label })}
+                                  >
+                                    {rulingId === item.id ? t('activity.decision.working') : option.label}
+                                  </button>
+                                  {option.description && (
+                                    <span className="v2-activity__option-description">{option.description}</span>
+                                  )}
+                                </div>
+                              ))}
                               <button
                                 type="button"
                                 className="v2-activity__queue-action--secondary v2-activity__option"
@@ -948,7 +968,7 @@ const V2ActivityPage: React.FC = () => {
                           )}
                         </>
                       )}
-                      <button type="button" className="v2-activity__queue-action--thread" onClick={() => openPod(item.podId, item.messageId)} disabled={!item.podId}>
+                      <button type="button" className="v2-activity__queue-action--thread v2-activity__queue-action--bordered" onClick={() => openPod(item.podId, item.messageId)} disabled={!item.podId}>
                         {item.messageId === undefined || item.messageId === null || item.messageId === '' ? t('activity.openPod') : t('activity.open')}
                       </button>
                     </div>
@@ -959,7 +979,7 @@ const V2ActivityPage: React.FC = () => {
                 ))}
               </div>
             )}
-            {queue.length > 0 && (queueRemaining > 0 || queueMoreError) && (
+            {visibleQueue.length > 0 && (queueRemaining > 0 || queueMoreError) && (
               <button
                 type="button"
                 ref={queueMoreButtonRef}
@@ -974,7 +994,7 @@ const V2ActivityPage: React.FC = () => {
                     : t('activity.needsYou.showMore', { count: queueRemaining, defaultValue: `Show more · ${queueRemaining} remaining` })}
               </button>
             )}
-            {queue.length === 0 && queueMoreError && !queueFailed && (
+            {visibleQueue.length === 0 && queueMoreError && !queueFailed && (
               <button type="button" className="v2-activity__queue-more" onClick={() => setReloadKey((value) => value + 1)}>{t('activity.needsYou.retry', { defaultValue: 'Retry' })}</button>
             )}
           </section>

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -72,6 +72,17 @@ interface QueueResponse {
   hasMore?: boolean;
 }
 
+interface DecisionHistoryResponse {
+  items?: Array<NeedsYouItem & {
+    status?: 'pending' | 'ruled';
+    ruling?: { value?: string; by?: string } | null;
+    createdAt?: string | null;
+  }>;
+  count?: number;
+  remaining?: number;
+  hasMore?: boolean;
+}
+
 interface MovedLine {
   id: string;
   author: string;
@@ -311,10 +322,48 @@ const V2ActivityPage: React.FC = () => {
         '/api/activity/decision-queue',
         { headers, params: { limit: 50, offset: 0, ...(podId !== 'all' ? { podId } : {}) } },
       ).catch(() => null),
+      axios.get<DecisionHistoryResponse>('/api/activity/decision-history', {
+        headers,
+        params: { limit: 50, offset: 0, ...(podId !== 'all' ? { podId } : {}) },
+      }).catch(() => null),
     ])
-      .then(async ([recapResponse, queueResponse]) => {
+      .then(async ([recapResponse, queueResponse, historyResponse]) => {
         if (!active) return;
         setRecap(recapResponse.data);
+        // Decision history is a durable pod projection. Hydrate it on every
+        // Activity read so a settled card survives a hard reload and the
+        // Activity → pod → Activity Back path, even when the open queue has
+        // already dropped the recipient-owned row.
+        const historyItems = Array.isArray(historyResponse?.data?.items)
+          ? historyResponse.data.items
+          : [];
+        const settledHistory = historyItems.filter((item) => (
+          item.kind === 'decision' && item.id && item.ruling?.value
+        ));
+        if (settledHistory.length > 0) {
+          setRuledDecisions((current) => {
+            const next = { ...current };
+            settledHistory.forEach((item) => {
+              next[String(item.id)] = {
+                value: String(item.ruling?.value),
+                ...(item.ruling?.by ? { by: item.ruling.by } : {}),
+              };
+            });
+            return next;
+          });
+          setSettledQueueDecisions((current) => {
+            const next = { ...current };
+            settledHistory.forEach((item) => {
+              next[String(item.id)] = {
+                ...item,
+                detail: item.detail || '',
+                podName: item.podName || '',
+                timestamp: item.timestamp ?? item.createdAt ?? null,
+              };
+            });
+            return next;
+          });
+        }
         const rawItems = queueResponse?.data?.items;
         const availablePods = recapResponse.data.pods || [];
         const setComposeDefault = (candidate = '') => {
@@ -325,7 +374,7 @@ const V2ActivityPage: React.FC = () => {
         };
         if (!Array.isArray(rawItems) || typeof queueResponse?.data?.count !== 'number'
           || (podId !== 'all' && !queueResponse?.data?.countsByPod)) {
-          setQueueFailed(previousQueue.length === 0);
+          setQueueFailed(previousQueue.length === 0 && settledHistory.length === 0);
           setQueueMoreError(true);
           setComposeDefault();
           return;
@@ -929,9 +978,14 @@ const V2ActivityPage: React.FC = () => {
                                     className={`v2-activity__option${index === 0 ? ' v2-activity__option--primary' : ''}`}
                                     onClick={() => ruleDecision(item, option.label)}
                                     disabled={rulingId === item.id}
-                                    aria-label={t('activity.decision.ruleOption', { option: option.label })}
+                                    aria-label={t(option.recommended
+                                      ? 'activity.decision.ruleOptionRecommended'
+                                      : 'activity.decision.ruleOption', { option: option.label })}
                                   >
-                                    {rulingId === item.id ? t('activity.decision.working') : option.label}
+                                    {rulingId === item.id ? t('activity.decision.working') : <>
+                                      {option.label}
+                                      {option.recommended && <span className="v2-activity__option-recommended"> · {t('activity.decision.recommended')}</span>}
+                                    </>}
                                   </button>
                                   {option.description && (
                                     <span className="v2-activity__option-description">{option.description}</span>

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -294,6 +294,7 @@ const V2ActivityPage: React.FC = () => {
     queueScopeRef.current = podId;
     const sameScope = previousScope === podId;
     const previousQueue = sameScope ? queueRef.current : [];
+    const previousHistoryExtent = sameScope ? historyOffsetRef.current : 0;
     if (!sameScope) {
       // Retained rows are evidence for their own scope only. If the new
       // request fails, showing them under the newly selected pod is false.
@@ -358,10 +359,18 @@ const V2ActivityPage: React.FC = () => {
           const historyCount = typeof historyResponse.data?.count === 'number'
             ? historyResponse.data.count
             : historyItems.length;
-          historyOffsetRef.current = historyItems.length;
-          setHistoryRemaining(typeof historyResponse.data?.remaining === 'number'
-            ? historyResponse.data.remaining
-            : Math.max(historyCount - historyItems.length, 0));
+          // A refresh revalidates the first page but must not collapse an
+          // explicitly loaded history extent back to its first-page boundary.
+          // Keep the prior extent as the cursor; older rows remain durable in
+          // settledQueueDecisions and can be fetched only when the reader asks
+          // for another page.
+          const loadedExtent = Math.max(historyItems.length, previousHistoryExtent);
+          historyOffsetRef.current = loadedExtent;
+          setHistoryRemaining(sameScope && previousHistoryExtent > historyItems.length
+            ? Math.max(historyCount - previousHistoryExtent, 0)
+            : typeof historyResponse.data?.remaining === 'number'
+              ? historyResponse.data.remaining
+              : Math.max(historyCount - historyItems.length, 0));
           setHistoryMoreError(false);
         }
         if (settledHistory.length > 0) {

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -83,33 +83,6 @@ interface DecisionHistoryResponse {
   hasMore?: boolean;
 }
 
-const DECISION_HISTORY_PAGE_SIZE = 50;
-
-const loadDecisionHistoryPages = async (
-  headers: Record<string, string>,
-  podId: string,
-): Promise<DecisionHistoryResponse> => {
-  const items: DecisionHistoryResponse['items'] = [];
-  let offset = 0;
-  // Keep a malformed hasMore response from creating an unbounded poll. The
-  // server caps each page at 50; 100 pages is ample for a pod history.
-  for (let page = 0; page < 100; page += 1) {
-    const response = await axios.get<DecisionHistoryResponse>('/api/activity/decision-history', {
-      headers,
-      params: {
-        limit: DECISION_HISTORY_PAGE_SIZE,
-        offset,
-        ...(podId !== 'all' ? { podId } : {}),
-      },
-    });
-    const pageItems = Array.isArray(response.data?.items) ? response.data.items : [];
-    items.push(...pageItems);
-    if (!response.data?.hasMore || pageItems.length === 0) break;
-    offset += pageItems.length;
-  }
-  return { items, count: items.length, remaining: 0, hasMore: false };
-};
-
 interface MovedLine {
   id: string;
   author: string;
@@ -349,7 +322,10 @@ const V2ActivityPage: React.FC = () => {
         '/api/activity/decision-queue',
         { headers, params: { limit: 50, offset: 0, ...(podId !== 'all' ? { podId } : {}) } },
       ).catch(() => null),
-      loadDecisionHistoryPages(headers, podId).catch(() => null),
+      axios.get<DecisionHistoryResponse>('/api/activity/decision-history', {
+        headers,
+        params: { limit: 50, offset: 0, ...(podId !== 'all' ? { podId } : {}) },
+      }).catch(() => null),
     ])
       .then(async ([recapResponse, queueResponse, historyResponse]) => {
         if (!active) return;
@@ -358,8 +334,8 @@ const V2ActivityPage: React.FC = () => {
         // Activity read so a settled card survives a hard reload and the
         // Activity → pod → Activity Back path, even when the open queue has
         // already dropped the recipient-owned row.
-        const historyItems = Array.isArray(historyResponse?.items)
-          ? historyResponse.items
+        const historyItems = Array.isArray(historyResponse?.data?.items)
+          ? historyResponse.data.items
           : [];
         const settledHistory = historyItems.filter((item) => (
           item.kind === 'decision' && item.id && item.ruling?.value

--- a/frontend/src/v2/components/V2DecisionCard.tsx
+++ b/frontend/src/v2/components/V2DecisionCard.tsx
@@ -107,8 +107,14 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
                 className={index === 0 ? 'v2-decision-card__choice v2-decision-card__choice--primary' : 'v2-decision-card__choice'}
                 onClick={() => { void choose(option.label); }}
                 disabled={saving}
+                aria-label={option.recommended
+                  ? t('activity.decision.ruleOptionRecommended', { option: option.label })
+                  : undefined}
               >
-                {saving ? t('activity.decision.working') : option.label}
+                {saving ? t('activity.decision.working') : <>
+                  {option.label}
+                  {option.recommended && <span className="v2-decision-card__recommended"> · {t('activity.decision.recommended')}</span>}
+                </>}
               </button>
               {option.description && <span>{option.description}</span>}
             </div>

--- a/frontend/src/v2/components/V2DecisionCard.tsx
+++ b/frontend/src/v2/components/V2DecisionCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useV2Api } from '../hooks/useV2Api';
 
@@ -41,6 +41,22 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
   const [otherValue, setOtherValue] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const otherInputRef = useRef<HTMLInputElement | null>(null);
+  const otherSubmitRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!error || !otherOpen) return undefined;
+    const frame = globalThis.window.requestAnimationFrame(() => {
+      const active = document.activeElement;
+      // A disabled submit button can blur to body while the request settles.
+      // Restore the custom-answer field in that case, but respect a reader
+      // who deliberately moved to another control during the failed request.
+      if (active === document.body || active === otherInputRef.current || active === otherSubmitRef.current) {
+        otherInputRef.current?.focus({ preventScroll: true });
+      }
+    });
+    return () => globalThis.window.cancelAnimationFrame(frame);
+  }, [error, otherOpen]);
 
   const choose = async (value: string) => {
     const trimmed = value.trim();
@@ -130,12 +146,13 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
           {otherOpen && (
             <div className="v2-decision-card__other-form">
               <input
+                ref={otherInputRef}
                 aria-label={t('activity.decision.otherPlaceholder')}
                 value={otherValue}
                 onChange={(event) => setOtherValue(event.target.value)}
                 disabled={saving}
               />
-              <button type="button" onClick={() => { void choose(otherValue); }} disabled={saving || !otherValue.trim()}>
+              <button ref={otherSubmitRef} type="button" onClick={() => { void choose(otherValue); }} disabled={saving || !otherValue.trim()}>
                 {saving ? t('activity.decision.working') : t('activity.decision.sendOther')}
               </button>
             </div>

--- a/frontend/src/v2/components/V2DecisionCard.tsx
+++ b/frontend/src/v2/components/V2DecisionCard.tsx
@@ -43,9 +43,10 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
   const [error, setError] = useState<string | null>(null);
   const otherInputRef = useRef<HTMLInputElement | null>(null);
   const otherSubmitRef = useRef<HTMLButtonElement | null>(null);
+  const otherSubmissionRef = useRef(false);
 
   useEffect(() => {
-    if (!error || !otherOpen) return undefined;
+    if (!error || !otherOpen || !otherSubmissionRef.current) return undefined;
     const frame = globalThis.window.requestAnimationFrame(() => {
       const active = document.activeElement;
       // A disabled submit button can blur to body while the request settles.
@@ -152,7 +153,12 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
                 onChange={(event) => setOtherValue(event.target.value)}
                 disabled={saving}
               />
-              <button ref={otherSubmitRef} type="button" onClick={() => { void choose(otherValue); }} disabled={saving || !otherValue.trim()}>
+              <button
+                ref={otherSubmitRef}
+                type="button"
+                onClick={() => { otherSubmissionRef.current = true; void choose(otherValue); }}
+                disabled={saving || !otherValue.trim()}
+              >
                 {saving ? t('activity.decision.working') : t('activity.decision.sendOther')}
               </button>
             </div>

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -90,6 +90,8 @@ interface ThreadDecision extends V2DecisionCardData {
   kind: 'decision';
   podId: string;
   messageId: string;
+  status?: 'pending' | 'ruled';
+  ruling?: V2DecisionRuling | null;
 }
 
 const TypingIndicator: React.FC<{ agents: TypingAgentEntry[] }> = ({ agents }) => {
@@ -280,16 +282,22 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     const podId = pod?._id;
     if (!podId) {
       setDecisions([]);
+      setSettledDecisionByMessageId(new Map());
       return undefined;
     }
     let active = true;
     const load = async () => {
       try {
-        const data = await api.get<{ items?: ThreadDecision[] }>('/api/activity/decision-queue', {
-          params: { podId },
-        });
+        const [pendingData, historyData] = await Promise.all([
+          api.get<{ items?: ThreadDecision[] }>('/api/activity/decision-queue', {
+            params: { podId },
+          }),
+          api.get<{ items?: ThreadDecision[] }>('/api/activity/decision-history', {
+            params: { podId, limit: 50, offset: 0 },
+          }).catch(() => ({ items: [] })),
+        ]);
         if (!active) return;
-        setDecisions((data?.items || []).filter((item) => (
+        setDecisions((pendingData?.items || []).filter((item) => (
           item.kind === 'decision'
           && item.podId === podId
           && typeof item.messageId === 'string'
@@ -297,9 +305,19 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           && Array.isArray(item.options)
           && item.options.length > 0
         )));
+        const settled = (historyData?.items || []).filter((item) => (
+          item.kind === 'decision'
+          && item.podId === podId
+          && typeof item.messageId === 'string'
+          && item.ruling?.value
+        ));
+        setSettledDecisionByMessageId(new Map(
+          settled.map((item) => [String(item.messageId), item.ruling as V2DecisionRuling]),
+        ));
       } catch {
         // A queue read is additive decoration: preserve a working thread when
         // attention is temporarily unavailable rather than inventing cards.
+        // Keep any durable settled map already rendered during this mount.
         if (active) setDecisions([]);
       }
     };

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -100,6 +100,7 @@ interface DecisionPage<T> {
 }
 
 const DECISION_PAGE_SIZE = 50;
+const DECISION_MESSAGE_ID_BATCH_SIZE = 200;
 
 const loadDecisionPages = async <T,>(
   api: ReturnType<typeof useV2Api>,
@@ -124,6 +125,30 @@ const loadDecisionPages = async <T,>(
     offset += pageItems.length;
   }
   return { items };
+};
+
+const loadDecisionPagesForMessageIds = async <T,>(
+  api: ReturnType<typeof useV2Api>,
+  endpoint: string,
+  podId: string,
+  messageIds: string[],
+): Promise<{ items: T[] }> => {
+  const uniqueMessageIds = [...new Set(messageIds.filter(Boolean))];
+  const batches: string[][] = [];
+  for (let index = 0; index < uniqueMessageIds.length; index += DECISION_MESSAGE_ID_BATCH_SIZE) {
+    batches.push(uniqueMessageIds.slice(index, index + DECISION_MESSAGE_ID_BATCH_SIZE));
+  }
+  // An empty transcript still sends one explicit empty filter. This keeps the
+  // read authoritative (and preserves the existing empty-state behavior),
+  // while every non-empty filter stays under the server's documented cap.
+  if (batches.length === 0) batches.push([]);
+  const pages = await Promise.all(batches.map((batch) => loadDecisionPages<T>(
+    api,
+    endpoint,
+    podId,
+    { messageIds: batch.join(',') },
+  )));
+  return { items: pages.flatMap((page) => page.items) };
 };
 
 const TypingIndicator: React.FC<{ agents: TypingAgentEntry[] }> = ({ agents }) => {
@@ -307,9 +332,9 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   const [decisions, setDecisions] = useState<ThreadDecision[]>([]);
   const [settledDecisionByMessageId, setSettledDecisionByMessageId] = useState<Map<string, V2DecisionRuling>>(new Map());
   const loadedMessageIdsRef = useRef<string[]>([]);
-  loadedMessageIdsRef.current = messages
+  loadedMessageIdsRef.current = [...new Set(messages
     .map((message) => String(message.id || ''))
-    .filter(Boolean);
+    .filter(Boolean))];
 
   // A DecisionRequest posts an ordinary message for its timeline position and
   // materializes its typed choices in the attention queue. Join those two
@@ -325,12 +350,8 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     const load = async () => {
       try {
         const [pendingData, historyData] = await Promise.all([
-          loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId, {
-            messageIds: loadedMessageIdsRef.current.join(','),
-          }).catch(() => null),
-          loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId, {
-            messageIds: loadedMessageIdsRef.current.join(','),
-          }).catch(() => null),
+          loadDecisionPagesForMessageIds<ThreadDecision>(api, '/api/activity/decision-queue', podId, loadedMessageIdsRef.current).catch(() => null),
+          loadDecisionPagesForMessageIds<ThreadDecision>(api, '/api/activity/decision-history', podId, loadedMessageIdsRef.current).catch(() => null),
         ]);
         if (!active) return;
         // A failed queue read is not authoritative. Preserve pending cards

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -94,6 +94,35 @@ interface ThreadDecision extends V2DecisionCardData {
   ruling?: V2DecisionRuling | null;
 }
 
+interface DecisionPage<T> {
+  items?: T[];
+  hasMore?: boolean;
+}
+
+const DECISION_PAGE_SIZE = 50;
+
+const loadDecisionPages = async <T,>(
+  api: ReturnType<typeof useV2Api>,
+  endpoint: string,
+  podId: string,
+): Promise<{ items: T[] }> => {
+  const items: T[] = [];
+  let offset = 0;
+  // A malformed response must not create an unbounded request loop. The
+  // server caps each page at 50; 100 pages is ample for a room while still
+  // bounding a broken hasMore implementation.
+  for (let page = 0; page < 100; page += 1) {
+    const data = await api.get<DecisionPage<T>>(endpoint, {
+      params: { podId, limit: DECISION_PAGE_SIZE, offset },
+    });
+    const pageItems = Array.isArray(data?.items) ? data.items : [];
+    items.push(...pageItems);
+    if (!data?.hasMore || pageItems.length === 0) break;
+    offset += pageItems.length;
+  }
+  return { items };
+};
+
 const TypingIndicator: React.FC<{ agents: TypingAgentEntry[] }> = ({ agents }) => {
   const { t, i18n } = useTranslation();
   if (!agents || agents.length === 0) return null;
@@ -289,12 +318,8 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     const load = async () => {
       try {
         const [pendingData, historyData] = await Promise.all([
-          api.get<{ items?: ThreadDecision[] }>('/api/activity/decision-queue', {
-            params: { podId },
-          }),
-          api.get<{ items?: ThreadDecision[] }>('/api/activity/decision-history', {
-            params: { podId, limit: 50, offset: 0 },
-          }).catch(() => ({ items: [] })),
+          loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId).catch(() => null),
+          loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId).catch(() => null),
         ]);
         if (!active) return;
         setDecisions((pendingData?.items || []).filter((item) => (
@@ -305,15 +330,20 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           && Array.isArray(item.options)
           && item.options.length > 0
         )));
-        const settled = (historyData?.items || []).filter((item) => (
-          item.kind === 'decision'
-          && item.podId === podId
-          && typeof item.messageId === 'string'
-          && item.ruling?.value
-        ));
-        setSettledDecisionByMessageId(new Map(
-          settled.map((item) => [String(item.messageId), item.ruling as V2DecisionRuling]),
-        ));
+        // A successful empty history page is authoritative and clears rows
+        // that are no longer ruled. A failed history read is not authoritative
+        // and must preserve settled cards already rendered in this mount.
+        if (historyData) {
+          const settled = (historyData.items || []).filter((item) => (
+            item.kind === 'decision'
+            && item.podId === podId
+            && typeof item.messageId === 'string'
+            && item.ruling?.value
+          ));
+          setSettledDecisionByMessageId(new Map(
+            settled.map((item) => [String(item.messageId), item.ruling as V2DecisionRuling]),
+          ));
+        }
       } catch {
         // A queue read is additive decoration: preserve a working thread when
         // attention is temporarily unavailable rather than inventing cards.

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -285,7 +285,9 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     let active = true;
     const load = async () => {
       try {
-        const data = await api.get<{ items?: ThreadDecision[] }>('/api/activity/decision-queue');
+        const data = await api.get<{ items?: ThreadDecision[] }>('/api/activity/decision-queue', {
+          params: { podId },
+        });
         if (!active) return;
         setDecisions((data?.items || []).filter((item) => (
           item.kind === 'decision'

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -325,7 +325,9 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     const load = async () => {
       try {
         const [pendingData, historyData] = await Promise.all([
-          loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId).catch(() => null),
+          loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId, {
+            messageIds: loadedMessageIdsRef.current.join(','),
+          }).catch(() => null),
           loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId, {
             messageIds: loadedMessageIdsRef.current.join(','),
           }).catch(() => null),

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -105,6 +105,7 @@ const loadDecisionPages = async <T,>(
   api: ReturnType<typeof useV2Api>,
   endpoint: string,
   podId: string,
+  extraParams: Record<string, string> = {},
 ): Promise<{ items: T[] }> => {
   const items: T[] = [];
   let offset = 0;
@@ -113,7 +114,9 @@ const loadDecisionPages = async <T,>(
   // bounding a broken hasMore implementation.
   for (let page = 0; page < 100; page += 1) {
     const data = await api.get<DecisionPage<T>>(endpoint, {
-      params: { podId, limit: DECISION_PAGE_SIZE, offset },
+      params: {
+        podId, limit: DECISION_PAGE_SIZE, offset, ...extraParams,
+      },
     });
     const pageItems = Array.isArray(data?.items) ? data.items : [];
     items.push(...pageItems);
@@ -303,6 +306,10 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   const [agentStates, setAgentStates] = useState<AgentStateRow[]>([]);
   const [decisions, setDecisions] = useState<ThreadDecision[]>([]);
   const [settledDecisionByMessageId, setSettledDecisionByMessageId] = useState<Map<string, V2DecisionRuling>>(new Map());
+  const loadedMessageIdsRef = useRef<string[]>([]);
+  loadedMessageIdsRef.current = messages
+    .map((message) => String(message.id || ''))
+    .filter(Boolean);
 
   // A DecisionRequest posts an ordinary message for its timeline position and
   // materializes its typed choices in the attention queue. Join those two
@@ -319,17 +326,24 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
       try {
         const [pendingData, historyData] = await Promise.all([
           loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-queue', podId).catch(() => null),
-          loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId).catch(() => null),
+          loadDecisionPages<ThreadDecision>(api, '/api/activity/decision-history', podId, {
+            messageIds: loadedMessageIdsRef.current.join(','),
+          }).catch(() => null),
         ]);
         if (!active) return;
-        setDecisions((pendingData?.items || []).filter((item) => (
-          item.kind === 'decision'
-          && item.podId === podId
-          && typeof item.messageId === 'string'
-          && item.messageId.length > 0
-          && Array.isArray(item.options)
-          && item.options.length > 0
-        )));
+        // A failed queue read is not authoritative. Preserve pending cards
+        // already rendered in this mount rather than making an open decision
+        // disappear during a transient 429/network failure.
+        if (pendingData) {
+          setDecisions(pendingData.items.filter((item) => (
+            item.kind === 'decision'
+            && item.podId === podId
+            && typeof item.messageId === 'string'
+            && item.messageId.length > 0
+            && Array.isArray(item.options)
+            && item.options.length > 0
+          )));
+        }
         // A successful empty history page is authoritative and clears rows
         // that are no longer ruled. A failed history read is not authoritative
         // and must preserve settled cards already rendered in this mount.
@@ -354,7 +368,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     void load();
     const timer = window.setInterval(load, 15_000);
     return () => { active = false; window.clearInterval(timer); };
-  }, [api, pod?._id]);
+  }, [api, pod?._id, detailInitialLoadComplete]);
 
   const decisionByMessageId = useMemo(() => new Map(
     decisions.map((decision) => [String(decision.messageId), decision]),

--- a/frontend/src/v2/components/V2ThreadMessages.tsx
+++ b/frontend/src/v2/components/V2ThreadMessages.tsx
@@ -218,10 +218,17 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
       {threadView.map((item, index, view) => {
         const renderMessage = (message: V2Message, previous: ThreadViewItem | undefined) => {
           const settledRuling = settledDecisionByMessageId.get(String(message.id));
+          const renderedMessage = settledRuling ? rulingMessage(message, settledRuling) : message;
+          const previousMessage = previous && previous.kind === 'message'
+            ? (() => {
+              const previousRuling = settledDecisionByMessageId.get(String(previous.message.id));
+              return previousRuling ? rulingMessage(previous.message, previousRuling) : previous.message;
+            })()
+            : undefined;
           return (
             <React.Fragment key={message.id}>
               <V2MessageRow
-                message={settledRuling ? rulingMessage(message, settledRuling) : message}
+                message={renderedMessage}
                 decision={settledRuling ? undefined : decisionByMessageId.get(String(message.id))}
                 isDecisionRuling={Boolean(settledRuling)}
                 onDecisionRuled={onDecisionRuled}
@@ -233,10 +240,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
                 onReply={onReply}
                 onThread={onThread}
                 onQuoteNavigate={onQuoteNavigate}
-                grouped={isGroupedWithPrevious(
-                  message,
-                  previous && previous.kind === 'message' ? previous.message : undefined,
-                )}
+                grouped={isGroupedWithPrevious(renderedMessage, previousMessage)}
               />
               {agentDeliveryHint?.messageId === message.id && (
                 <div className="v2-chat__delivery-hint" role="status">

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8918,6 +8918,27 @@ body.modern-ui.v2-canvas {
   background: var(--v2-ink-hover);
 }
 
+/* The generic composer button treatment above is for Send. The destination
+   picker is a neutral selector and needs a stronger selector so it cannot
+   inherit Send's ink fill. */
+.v2-root .v2-activity__compose .v2-activity__compose-picker-button {
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+}
+
+.v2-root .v2-activity__compose .v2-activity__compose-picker-button:hover:not(:disabled) {
+  border-color: var(--v2-border-strong);
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
+.v2-root .v2-activity__compose .v2-activity__compose-picker-button:focus-visible {
+  outline: none;
+  box-shadow: var(--v2-focus-ring);
+  border-color: var(--v2-accent);
+}
+
 .v2-activity__section-heading {
   display: flex;
   align-items: baseline;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8819,7 +8819,7 @@ body.modern-ui.v2-canvas {
   padding: 0 24px 0 8px;
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius-sm);
-  background: var(--v2-surface-hover);
+  background: var(--v2-surface);
   color: var(--v2-text-primary);
   font: inherit;
   font-size: var(--v2-fs-meta);
@@ -8889,6 +8889,11 @@ body.modern-ui.v2-canvas {
   outline: none;
   box-shadow: var(--v2-focus-ring);
   border-color: var(--v2-accent);
+}
+
+.v2-root .v2-activity__compose-picker-button:hover:not(:disabled) {
+  border-color: var(--v2-border-strong);
+  background: var(--v2-surface-hover);
 }
 
 .v2-activity__compose-hint {
@@ -9177,10 +9182,26 @@ body.modern-ui.v2-canvas {
   color: var(--v2-accent-text);
 }
 
+/* Activity's navigation and acknowledgement controls are secondary actions:
+   keep them visibly distinct from the ink send/approve actions while making
+   their hit targets as clear as the approved board. */
+.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--bordered {
+  padding-inline: 12px;
+  border-color: var(--v2-border);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+}
+
+.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--bordered:hover:not(:disabled) {
+  border-color: var(--v2-border-strong);
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
 /* DecisionRequest alternatives are content, not row actions: a decision gets
-   its own full-width action line below the question. A neutral base prevents
-   an arbitrary non-recommended choice from inheriting the queue's primary
-   CTA treatment; the recommended choice is the only emphasized pill. */
+   its own full-width action line below the question. Preserve the asking
+   agent's option order; only the first authored option receives the cobalt
+   primary treatment. */
 .v2-activity__queue-row--decision .v2-activity__queue-actions {
   grid-column: 1 / -1;
   justify-content: flex-start;
@@ -9224,9 +9245,15 @@ body.modern-ui.v2-canvas {
   color: var(--v2-text-primary);
 }
 
-.v2-root .v2-activity__queue-actions button.v2-activity__option--recommended {
-  border-color: var(--v2-ink);
-  background: var(--v2-ink);
+.v2-root .v2-activity__queue-actions button.v2-activity__option--primary {
+  border-color: var(--v2-accent);
+  background: var(--v2-accent);
+  color: var(--v2-on-ink);
+}
+
+.v2-root .v2-activity__queue-actions button.v2-activity__option--primary:hover:not(:disabled) {
+  border-color: var(--v2-accent-strong);
+  background: var(--v2-accent-strong);
   color: var(--v2-on-ink);
 }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9283,7 +9283,7 @@ body.modern-ui.v2-canvas {
 
 .v2-activity__option-recommended,
 .v2-decision-card__recommended {
-  font: 500 10px/14px var(--v2-font-mono);
+  font: 500 11px/14px var(--v2-font-mono);
   opacity: 0.9;
 }
 

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9281,6 +9281,12 @@ body.modern-ui.v2-canvas {
   line-height: 1.35;
 }
 
+.v2-activity__option-recommended,
+.v2-decision-card__recommended {
+  font: 500 10px/14px var(--v2-font-mono);
+  opacity: 0.9;
+}
+
 .v2-activity__decision-other {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9187,13 +9187,13 @@ body.modern-ui.v2-canvas {
    their hit targets as clear as the approved board. */
 .v2-root .v2-activity__queue-actions button.v2-activity__queue-action--bordered {
   padding-inline: 12px;
-  border-color: var(--v2-border);
+  border: 1px solid var(--v2-border);
   background: var(--v2-surface);
   color: var(--v2-text-primary);
 }
 
 .v2-root .v2-activity__queue-actions button.v2-activity__queue-action--bordered:hover:not(:disabled) {
-  border-color: var(--v2-border-strong);
+  border: 1px solid var(--v2-border-strong);
   background: var(--v2-surface-hover);
   color: var(--v2-text-primary);
 }


### PR DESCRIPTION
Decision requests and their resolved state could disappear after refresh or navigation, while Activity controls had drifted from the approved Signal design. This restores the approved controls and renders durable decision history in Activity and pod threads, preserving authored option order and explicit recommendation labels.

Thread reads are authorized for current pod members and batched by loaded source message IDs. Activity loads older resolved decisions on demand, preserves reading position and drafts, and reconciles newly arrived rulings without a false remaining count. Failed submissions and history loads retain state and restore keyboard focus unless the reader has moved elsewhere.

Implements TASK-098 and milestones 2–3 of the Signal recovery brief in #1596.

## Validation

- Writer: 165 focused frontend tests; 39 focused backend tests; full frontend 102 suites / 772 tests; frontend typecheck and production build passed.
- Sprint Review cleared ffa99e4b3cea0dedc0ec13c5d8138a598f55c4db, including the first-page count mutation. Prior mutation evidence covers batching at both ends of >200 loaded messages, membership denial, failed-read preservation, and stale-scope rejection.
- UX Lead approved production-built 61d619ae at 1440 and 390 pixels, carried through the test-only changes to the current head. Coverage includes recommendation treatment, durable state, history arrivals/pagination, reading position, retry focus, and deliberate focus movement. These browser checks used mocked requests; they are not live-production proof.
- Current-head CI must pass before merge. After merge and deployment through Deploy Dev, verify the real composer-default decision in Commonly: source64684 → Sam’s choice64685 → agent follow-through64686 → durable resolved card and the resulting behavior. That live check gates task/goal completion.
