### PR TITLE
Preserve resolved decision cards and source links in pod threads

### DIFF
--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -3720,3 +3720,21 @@ looks like the absence of a problem.
 - Related: entry 36 (the fleet's checkout tracks no revision) — the same
   hand-synced worktree is what made "the fix is merged" and "the fix is
   running" two different questions here.
+
+## 55. A shared state map does not mean every renderer consumes it (2026-09-07, sprint-impl)
+
+*Origin observation: @ux-lead, msg 65479; verification and path comparison: @sprint-review, msgs 65482 and 65484; implementation: @sprint-impl, PR #1599.*
+
+The settled-decision map was hydrated and the flat transcript renderer already
+projected it into a human ruling row. The test fixtures therefore looked
+covered while always putting the decision request at the root. In production,
+the real request (64684) was a reply under 64679. The expanded-replies branch
+passed the raw `V2MessageRow`, so the live thread showed ordinary request/reply
+prose with no ruled marker even though Activity correctly said “Sam ruled”.
+
+**Lesson:** shared state is not shared behavior. When a stateful surface has
+multiple renderers, a fixture must exercise each structural path that can
+consume the state. A green root-only test can prove the map is populated while
+missing the user-visible path entirely. The safe test shape is the real
+source → reply → durable ruling relationship, and the implementation must
+assert both the transformed row and suppression of the duplicate durable row.

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -242,6 +242,67 @@ describe('V2Thread decision cards', () => {
     }
   });
 
+  test('preserves deliberate composer focus through settled hydration', async () => {
+    const settled = {
+      id: 'decision-42', kind: 'decision', podId: 'pod-1', messageId: '42',
+      title: 'Choose the workspace cutover', detail: 'Which implementation should ship?',
+      options: [{ label: 'Ship the rebuilt workspace' }], status: 'ruled',
+      ruling: {
+        value: 'Ship the rebuilt workspace', by: 'Lily', messageId: '43', at: '2026-09-05T12:01:00.000Z',
+      },
+    };
+    const pending = { ...settled, status: 'pending', ruling: undefined };
+    let historyReads = 0;
+    mockGet.mockImplementation((url) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [pending] } });
+      if (url === '/api/activity/decision-history') {
+        historyReads += 1;
+        return historyReads === 1
+          ? Promise.resolve({ data: { items: [] } })
+          : Promise.resolve({ data: { items: [settled] } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    const settledDetail = {
+      ...detail,
+      messages: [
+        ...detail.messages,
+        {
+          id: '43', pod_id: 'pod-1', user_id: 'human-1',
+          user: { username: 'lily', isBot: false }, content: 'Ship the rebuilt workspace',
+          message_type: 'text', created_at: '2026-09-05T12:01:00.000Z',
+          thread_root_id: '42',
+        },
+      ],
+    };
+
+    jest.useFakeTimers();
+    try {
+      const { container } = render(
+        <AuthContext.Provider value={auth}>
+          <MemoryRouter initialEntries={['/v2/pods/pod-1#message-42']}>
+            <V2Thread detail={settledDetail} />
+          </MemoryRouter>
+        </AuthContext.Provider>,
+      );
+      expect(await screen.findByTestId('decision-card')).toBeInTheDocument();
+      await waitFor(() => expect(container.querySelector('#message-42')).toHaveClass('v2-msg--landed'));
+      const composer = container.querySelector('textarea');
+      expect(composer).toBeTruthy();
+      composer.focus();
+
+      await act(async () => {
+        jest.advanceTimersByTime(15_000);
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(historyReads).toBe(2));
+      expect(composer).toHaveFocus();
+      expect(container.querySelector('#message-43')).not.toHaveClass('v2-msg--landed');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   test('returns focus to a failed custom answer instead of skipping to the composer', async () => {
     mockPost.mockRejectedValueOnce(new Error('temporary failure'));
     render(

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -184,6 +184,64 @@ describe('V2Thread decision cards', () => {
     }
   });
 
+  test('preserves Activity landing when hydration replaces the focused source row', async () => {
+    const settled = {
+      id: 'decision-42', kind: 'decision', podId: 'pod-1', messageId: '42',
+      title: 'Choose the workspace cutover', detail: 'Which implementation should ship?',
+      options: [{ label: 'Ship the rebuilt workspace' }], status: 'ruled',
+      ruling: {
+        value: 'Ship the rebuilt workspace', by: 'Lily', messageId: '43', at: '2026-09-05T12:01:00.000Z',
+      },
+    };
+    const pending = { ...settled, status: 'pending', ruling: undefined };
+    let historyReads = 0;
+    mockGet.mockImplementation((url) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [pending] } });
+      if (url === '/api/activity/decision-history') {
+        historyReads += 1;
+        return historyReads === 1
+          ? Promise.resolve({ data: { items: [] } })
+          : Promise.resolve({ data: { items: [settled] } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    const settledDetail = {
+      ...detail,
+      messages: [
+        ...detail.messages,
+        {
+          id: '43', pod_id: 'pod-1', user_id: 'human-1',
+          user: { username: 'lily', isBot: false }, content: 'Ship the rebuilt workspace',
+          message_type: 'text', created_at: '2026-09-05T12:01:00.000Z',
+          thread_root_id: '42',
+        },
+      ],
+    };
+
+    jest.useFakeTimers();
+    try {
+      const { container } = render(
+        <AuthContext.Provider value={auth}>
+          <MemoryRouter initialEntries={['/v2/pods/pod-1#message-42']}>
+            <V2Thread detail={settledDetail} />
+          </MemoryRouter>
+        </AuthContext.Provider>,
+      );
+      expect(await screen.findByTestId('decision-card')).toBeInTheDocument();
+      await waitFor(() => expect(container.querySelector('#message-42')).toHaveClass('v2-msg--landed'));
+      await waitFor(() => expect(historyReads).toBe(1));
+
+      await act(async () => {
+        jest.advanceTimersByTime(15_000);
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(container.querySelector('#message-43')).toHaveClass('v2-msg--landed'));
+      expect(document.activeElement).toBe(container.querySelector('#message-43'));
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   test('returns focus to a failed custom answer instead of skipping to the composer', async () => {
     mockPost.mockRejectedValueOnce(new Error('temporary failure'));
     render(

--- a/frontend/src/v2/__tests__/V2ThreadRestyle.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadRestyle.test.tsx
@@ -198,6 +198,50 @@ describe('direction C threading restyle (PR 2b)', () => {
     expect(container.querySelector('.v2-thread-block--open')).toBeNull();
   });
 
+  test('expanded settled source replies render one ruled answer instead of a duplicate durable reply', () => {
+    const root = msg(20);
+    const source = msg(21, { thread_root_id: '20', content: 'Choose a path' });
+    const durableRuling = msg(22, { thread_root_id: '20', content: 'Ship it', user: { username: 'Sam' } });
+    const replies = [source, durableRuling];
+    const { container } = renderThread({
+      messages: [root, ...replies],
+      threadView: [
+        { kind: 'message', message: root },
+        { kind: 'card', rootId: '20', replyCount: replies.length, participants: [], lastActivityAt: null, replies },
+      ],
+      settledDecisionByMessageId: new Map([['21', { value: 'Ship it', by: 'Sam', messageId: '22' }]]),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand thread, 2 replies' }));
+    const block = container.querySelector('.v2-thread-block--open');
+    expect(block.querySelectorAll('.v2-thread-replies .v2-msg')).toHaveLength(1);
+    expect(block.querySelector('[data-testid="decision-ruling-row"]')).toHaveTextContent('Ship it');
+    expect(block.querySelectorAll('#message-22')).toHaveLength(1);
+    Element.prototype.scrollIntoView = jest.fn();
+    expect(landOnMessage('21')).toBe(true);
+    const sourceTarget = block.querySelector('#message-22');
+    expect(sourceTarget).toHaveClass('v2-msg--landed');
+    expect(landOnMessage('22')).toBe(true);
+    expect(block.querySelector('#message-22')).toBe(sourceTarget);
+  });
+
+  test('settled root keeps source and durable links on the same visible ruling', () => {
+    const root = msg(30, { content: 'Choose a path' });
+    const durableRuling = msg(31, { content: 'Ship it', user: { username: 'Sam' } });
+    const { container } = renderThread({
+      messages: [root, durableRuling],
+      threadView: [{ kind: 'message', message: root }],
+      settledDecisionByMessageId: new Map([['30', { value: 'Ship it', by: 'Sam', messageId: '31' }]]),
+    });
+    const ruling = container.querySelector('[data-testid="decision-ruling-row"]');
+    expect(ruling).toBe(container.querySelector('#message-31'));
+    Element.prototype.scrollIntoView = jest.fn();
+    expect(landOnMessage('30')).toBe(true);
+    expect(landOnMessage('31')).toBe(true);
+    expect(container.querySelectorAll('[data-testid="decision-ruling-row"]')).toHaveLength(1);
+    expect(container.querySelector('#message-31')).toBe(ruling);
+  });
+
   test('landing on a reply folded behind the chip reveals the whole thread instead of fetching history', () => {
     const onRevealed = jest.fn();
     const { container, rerender } = renderThread({ revealMessageId: '22', onRevealed });

--- a/frontend/src/v2/components/V2MessageRow.tsx
+++ b/frontend/src/v2/components/V2MessageRow.tsx
@@ -77,6 +77,10 @@ const messageMarkdownComponents = {
 
 interface V2MessageRowProps {
   message: V2Message;
+  // A settled decision replaces its source request/reply with the durable
+  // ruling row. Keep the source id as a secondary landing anchor so Activity
+  // links to the request still land on that one visible answer.
+  sourceMessageId?: string | number;
   // DecisionRequest data is deliberately joined by the thread container,
   // not parsed from the agent's prose. The message is the durable timeline
   // anchor; the queue owns the choices and resolution state.
@@ -331,7 +335,12 @@ const LONG_PRESS_MS = 500;
 // Jump to a message already in the transcript and mark it landed for a beat.
 export const landOnMessage = (id: string | number | null | undefined): boolean => {
   if (id === null || id === undefined) return false;
-  const el = typeof document !== 'undefined' ? document.getElementById(`message-${id}`) : null;
+  let el = typeof document !== 'undefined' ? document.getElementById(`message-${id}`) : null;
+  if (!el && typeof document !== 'undefined') {
+    const target = String(id);
+    el = Array.from(document.querySelectorAll<HTMLElement>('[data-source-message-id]'))
+      .find((candidate) => candidate.dataset.sourceMessageId === target) || null;
+  }
   if (!el) return false;
   el.scrollIntoView({ behavior: 'smooth', block: 'center' });
   // The landed row is the keyboard target as well as the visual target. Keep
@@ -344,7 +353,7 @@ export const landOnMessage = (id: string | number | null | undefined): boolean =
   return true;
 };
 
-const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisionRuled, isDecisionRuling = false, isLead, agentDisplayNames, agentTags, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, onQuoteNavigate, grouped, insideThreadRoot }) => {
+const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, sourceMessageId, decision, onDecisionRuled, isDecisionRuling = false, isLead, agentDisplayNames, agentTags, agentAuthorKeys, onAuthorClick, onOpenFile, onReply, onThread, onQuoteNavigate, grouped, insideThreadRoot }) => {
   const { currentUser } = useAuth();
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -404,7 +413,7 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
 
   if (decision) {
     return (
-      <div id={`message-${message.id}`} tabIndex={-1} className="v2-message-row v2-message-row--decision">
+      <div id={`message-${message.id}`} data-source-message-id={sourceMessageId != null ? String(sourceMessageId) : undefined} tabIndex={-1} className="v2-message-row v2-message-row--decision">
         <V2DecisionCard
           decision={{ ...decision, actorName: decision.actorName || author }}
           onRuled={onDecisionRuled}
@@ -545,6 +554,7 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, decision, onDecisi
   return (
     <div
       id={`message-${message.id}`}
+      data-source-message-id={sourceMessageId != null ? String(sourceMessageId) : undefined}
       tabIndex={-1}
       data-testid={isDecisionRuling ? 'decision-ruling-row' : undefined}
       className={`v2-msg v2-message-row${mentionsMe ? ' v2-msg--mention' : ''}${grouped ? ' v2-msg--grouped' : ''}${actionsRevealed ? ' v2-msg--reveal' : ''}${runtimeTag ? ' v2-msg--agent' : ''}`}

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -823,6 +823,12 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
   // decision-card producer may use either canonical `#message-<id>` or the
   // legacy `?message=<id>` form; both must share one retry/reveal lifecycle.
   const landedTargetRef = useRef<string | null>(null);
+  // Hydrating a settled ruling can replace a focused decision-card DOM node.
+  // Remember the exact node so we can restore landing only when that
+  // replacement caused the blur; deliberate focus movement must win.
+  const landedElementRef = useRef<HTMLElement | null>(null);
+  const landedElementShapeRef = useRef<string | null>(null);
+  const landedDecisionFingerprintRef = useRef<string | null>(null);
   // A URL target remains in the address bar after landing. Keep automatic
   // prepends paused until the reader deliberately uses the edge control, so
   // the focused row cannot be pushed out while a landing is settling.
@@ -839,6 +845,9 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     // thread. Clear the landing guards and bump the effect so this gesture
     // reopens the fold instead of being treated as an already-landed hash.
     landedTargetRef.current = null;
+    landedElementRef.current = null;
+    landedElementShapeRef.current = null;
+    landedDecisionFingerprintRef.current = null;
     revealTriedRef.current = null;
     releasedLandingTargetRef.current = null;
     releasedHistorySearchTargetRef.current = null;
@@ -873,6 +882,9 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
     const target = landingTarget;
     if (!target) {
       landedTargetRef.current = null;
+      landedElementRef.current = null;
+      landedElementShapeRef.current = null;
+      landedDecisionFingerprintRef.current = null;
       releasedLandingTargetRef.current = null;
       return;
     }
@@ -880,8 +892,49 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
       releasedLandingTargetRef.current = null;
     }
     if (!initialLoadComplete) return;
-    if (landedTargetRef.current === target) return;
-    if (landOnMessage(target)) { landedTargetRef.current = target; return; }
+    const settledRuling = settledDecisionByMessageId.get(target);
+    const durableLoaded = !!settledRuling?.messageId
+      && messages.some((message) => String(message.id) === String(settledRuling.messageId));
+    const decisionFingerprint = settledRuling
+      ? `${target}:${settledRuling.messageId || ''}:${settledRuling.value}:${settledRuling.at || ''}:${durableLoaded ? 'loaded' : 'fallback'}`
+      : 'none';
+    if (landedTargetRef.current === target) {
+      const activeElement = typeof document !== 'undefined' ? document.activeElement : null;
+      const landingNodeReplaced = activeElement === document.body
+        && !!landedElementRef.current
+        && !document.body.contains(landedElementRef.current);
+      const currentShape = landedElementRef.current?.className
+        .replace(/\bv2-msg--landed\b/g, '')
+        .trim();
+      const landingShapeChanged = !!landedElementShapeRef.current
+        && currentShape !== landedElementShapeRef.current;
+      if (landedDecisionFingerprintRef.current === decisionFingerprint
+        && !landingNodeReplaced && !landingShapeChanged) return;
+      const focusedElsewhere = !!activeElement
+        && activeElement !== document.body
+        && activeElement !== landedElementRef.current;
+      if (focusedElsewhere || (!landingNodeReplaced && !landingShapeChanged)) {
+        // The reader moved focus (or the node stayed mounted); do not steal it
+        // merely because a polling map got a new object identity.
+        landedDecisionFingerprintRef.current = decisionFingerprint;
+        landedElementShapeRef.current = currentShape || null;
+        return;
+      }
+      landedTargetRef.current = null;
+      landedElementRef.current = null;
+      landedElementShapeRef.current = null;
+    }
+    if (landOnMessage(target)) {
+      landedTargetRef.current = target;
+      landedDecisionFingerprintRef.current = decisionFingerprint;
+      landedElementRef.current = typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+      landedElementShapeRef.current = landedElementRef.current?.className
+        .replace(/\bv2-msg--landed\b/g, '')
+        .trim() || null;
+      return;
+    }
     const folded = threadView.some((item) => item.kind === 'card'
       && (item.rootId === target || item.replies.some((reply) => String(reply.id) === target)));
     if (folded && revealTriedRef.current !== target) {
@@ -899,7 +952,7 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           || historySearch.status === 'not-found'))) {
       void searchOlderForMessage(target);
     }
-  }, [landingTarget, initialLoadComplete, messages, threadView, revealTick, loadingOlder, loading, historySearch.targetId, historySearch.status, searchOlderForMessage]);
+  }, [landingTarget, initialLoadComplete, messages, threadView, decisionByMessageId, settledDecisionByMessageId, revealTick, loadingOlder, loading, historySearch.targetId, historySearch.status, searchOlderForMessage]);
 
   // Reaching the top loads the previous page; the edge line is the sentinel.
   useEffect(() => {

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -892,41 +892,15 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
       releasedLandingTargetRef.current = null;
     }
     if (!initialLoadComplete) return;
-    const settledRuling = settledDecisionByMessageId.get(target);
-    const durableLoaded = !!settledRuling?.messageId
-      && messages.some((message) => String(message.id) === String(settledRuling.messageId));
-    const decisionFingerprint = settledRuling
-      ? `${target}:${settledRuling.messageId || ''}:${settledRuling.value}:${settledRuling.at || ''}:${durableLoaded ? 'loaded' : 'fallback'}`
-      : 'none';
-    if (landedTargetRef.current === target) {
-      const activeElement = typeof document !== 'undefined' ? document.activeElement : null;
-      const landingNodeReplaced = activeElement === document.body
-        && !!landedElementRef.current
-        && !document.body.contains(landedElementRef.current);
-      const currentShape = landedElementRef.current?.className
-        .replace(/\bv2-msg--landed\b/g, '')
-        .trim();
-      const landingShapeChanged = !!landedElementShapeRef.current
-        && currentShape !== landedElementShapeRef.current;
-      if (landedDecisionFingerprintRef.current === decisionFingerprint
-        && !landingNodeReplaced && !landingShapeChanged) return;
-      const focusedElsewhere = !!activeElement
-        && activeElement !== document.body
-        && activeElement !== landedElementRef.current;
-      if (focusedElsewhere || (!landingNodeReplaced && !landingShapeChanged)) {
-        // The reader moved focus (or the node stayed mounted); do not steal it
-        // merely because a polling map got a new object identity.
-        landedDecisionFingerprintRef.current = decisionFingerprint;
-        landedElementShapeRef.current = currentShape || null;
-        return;
-      }
-      landedTargetRef.current = null;
-      landedElementRef.current = null;
-      landedElementShapeRef.current = null;
-    }
+    if (landedTargetRef.current === target) return;
     if (landOnMessage(target)) {
       landedTargetRef.current = target;
-      landedDecisionFingerprintRef.current = decisionFingerprint;
+      const settledRuling = settledDecisionByMessageId.get(target);
+      const durableLoaded = !!settledRuling?.messageId
+        && messages.some((message) => String(message.id) === String(settledRuling.messageId));
+      landedDecisionFingerprintRef.current = settledRuling
+        ? `${target}:${settledRuling.messageId || ''}:${settledRuling.value}:${settledRuling.at || ''}:${durableLoaded ? 'loaded' : 'fallback'}`
+        : 'none';
       landedElementRef.current = typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
         ? document.activeElement
         : null;
@@ -952,7 +926,56 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
           || historySearch.status === 'not-found'))) {
       void searchOlderForMessage(target);
     }
-  }, [landingTarget, initialLoadComplete, messages, threadView, decisionByMessageId, settledDecisionByMessageId, revealTick, loadingOlder, loading, historySearch.targetId, historySearch.status, searchOlderForMessage]);
+  }, [landingTarget, initialLoadComplete, messages, threadView, revealTick, loadingOlder, loading, historySearch.targetId, historySearch.status, searchOlderForMessage]);
+
+  // A settled decision can replace the row that was landed from Activity after
+  // the initial transcript render. Keep this recovery separate from the
+  // reveal-vs-fetch producer above: map updates must not re-enter that effect,
+  // or a folded target is mistaken for a history miss and fetches older pages.
+  useEffect(() => {
+    const target = landingTarget;
+    if (!target || !initialLoadComplete || landedTargetRef.current !== target) return;
+    const settledRuling = settledDecisionByMessageId.get(target);
+    const durableLoaded = !!settledRuling?.messageId
+      && messages.some((message) => String(message.id) === String(settledRuling.messageId));
+    const decisionFingerprint = settledRuling
+      ? `${target}:${settledRuling.messageId || ''}:${settledRuling.value}:${settledRuling.at || ''}:${durableLoaded ? 'loaded' : 'fallback'}`
+      : 'none';
+    const activeElement = typeof document !== 'undefined' ? document.activeElement : null;
+    const landingNodeReplaced = activeElement === document.body
+      && !!landedElementRef.current
+      && !document.body.contains(landedElementRef.current);
+    const currentShape = landedElementRef.current?.className
+      .replace(/\bv2-msg--landed\b/g, '')
+      .trim();
+    const landingShapeChanged = !!landedElementShapeRef.current
+      && currentShape !== landedElementShapeRef.current;
+    if (landedDecisionFingerprintRef.current === decisionFingerprint
+      && !landingNodeReplaced && !landingShapeChanged) return;
+    const focusedElsewhere = !!activeElement
+      && activeElement !== document.body
+      && activeElement !== landedElementRef.current;
+    if (focusedElsewhere || (!landingNodeReplaced && !landingShapeChanged)) {
+      // The reader moved focus (or the node stayed mounted); do not steal it
+      // merely because a polling map got a new object identity.
+      landedDecisionFingerprintRef.current = decisionFingerprint;
+      landedElementShapeRef.current = currentShape || null;
+      return;
+    }
+    landedTargetRef.current = null;
+    landedElementRef.current = null;
+    landedElementShapeRef.current = null;
+    if (landOnMessage(target)) {
+      landedTargetRef.current = target;
+      landedDecisionFingerprintRef.current = decisionFingerprint;
+      landedElementRef.current = typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+      landedElementShapeRef.current = landedElementRef.current?.className
+        .replace(/\bv2-msg--landed\b/g, '')
+        .trim() || null;
+    }
+  }, [landingTarget, initialLoadComplete, messages, decisionByMessageId, settledDecisionByMessageId]);
 
   // Reaching the top loads the previous page; the edge line is the sentinel.
   useEffect(() => {

--- a/frontend/src/v2/components/V2Thread.tsx
+++ b/frontend/src/v2/components/V2Thread.tsx
@@ -952,12 +952,9 @@ const V2Thread: React.FC<V2ThreadProps> = ({ detail, firstRunVisible = false, in
       && currentShape !== landedElementShapeRef.current;
     if (landedDecisionFingerprintRef.current === decisionFingerprint
       && !landingNodeReplaced && !landingShapeChanged) return;
-    const focusedElsewhere = !!activeElement
-      && activeElement !== document.body
-      && activeElement !== landedElementRef.current;
-    if (focusedElsewhere || (!landingNodeReplaced && !landingShapeChanged)) {
-      // The reader moved focus (or the node stayed mounted); do not steal it
-      // merely because a polling map got a new object identity.
+    if (!landingNodeReplaced && !landingShapeChanged) {
+      // A stable node means the reader either moved focus or the polling map
+      // changed without changing the projected row; do not steal focus.
       landedDecisionFingerprintRef.current = decisionFingerprint;
       landedElementShapeRef.current = currentShape || null;
       return;

--- a/frontend/src/v2/components/V2ThreadMessages.tsx
+++ b/frontend/src/v2/components/V2ThreadMessages.tsx
@@ -198,6 +198,32 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
     };
   };
 
+  // A settled ruling keeps the ordinary reply id it created when the choice
+  // was acknowledged. When that source request is rendered inside an
+  // expanded thread, replace the request with the ruling and omit the
+  // durable reply row so the answer appears once with the ruled marker.
+  const renderedReplyEntries = (replies: V2Message[]) => {
+    const visibleReplyIds = new Set(replies.map((reply) => String(reply.id)));
+    const settledRulingReplyIds = new Set(
+      Array.from(settledDecisionByMessageId.entries())
+        .filter(([sourceId, ruling]) => visibleReplyIds.has(String(sourceId)) && ruling.messageId)
+        .map(([, ruling]) => String(ruling.messageId)),
+    );
+    return replies
+      .filter((reply) => (
+        !settledRulingReplyIds.has(String(reply.id))
+        || settledDecisionByMessageId.has(String(reply.id))
+      ))
+      .map((reply) => {
+        const settledRuling = settledDecisionByMessageId.get(String(reply.id));
+        return {
+          sourceId: String(reply.id),
+          message: settledRuling ? rulingMessage(reply, settledRuling) : reply,
+          ruling: settledRuling,
+        };
+      });
+  };
+
   return (
     <div className="v2-chat__messages" ref={messagesContainerRef}>
       {/* History edge: one mono line. Loads on scroll (observer in V2Thread);
@@ -229,6 +255,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
             <React.Fragment key={message.id}>
               <V2MessageRow
                 message={renderedMessage}
+                sourceMessageId={settledRuling ? message.id : undefined}
                 decision={settledRuling ? undefined : decisionByMessageId.get(String(message.id))}
                 isDecisionRuling={Boolean(settledRuling)}
                 onDecisionRuled={onDecisionRuled}
@@ -300,11 +327,13 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
                     {t('podChat.thread.moreReplies', { count: hiddenReplies })}
                   </button>
                 )}
-                {shownReplies.map((reply, replyIndex) => (
+                {renderedReplyEntries(shownReplies).map(({ sourceId, message: reply, ruling }, replyIndex, renderedReplies) => (
                   <V2MessageRow
                     key={reply.id}
                     message={reply}
-                    decision={decisionByMessageId.get(String(reply.id))}
+                    sourceMessageId={ruling ? sourceId : undefined}
+                    decision={ruling ? undefined : decisionByMessageId.get(sourceId)}
+                    isDecisionRuling={Boolean(ruling)}
                     onDecisionRuled={onDecisionRuled}
                     agentDisplayNames={agentDisplayNames}
                     agentTags={agentTags}
@@ -314,7 +343,7 @@ const V2ThreadMessages: React.FC<V2ThreadMessagesProps> = ({
                     onReply={onReply}
                     onThread={onThread}
                     onQuoteNavigate={onQuoteNavigate}
-                    grouped={isGroupedWithPrevious(reply, shownReplies[replyIndex - 1])}
+                    grouped={isGroupedWithPrevious(reply, renderedReplies[replyIndex - 1]?.message)}
                     insideThreadRoot={item.rootId}
                   />
                 ))}


### PR DESCRIPTION
Expanded decision requests inside pod threads previously remained raw request prose after Activity showed the recorded ruling. Render the same durable human answer in both root and reply positions, suppress its duplicate raw row, and retain both source-request and durable-answer links on the visible ruling.

When decision history arrives after Activity has already landed on the source, preserve the landing through the replacement while respecting deliberate focus movement. Keep that recovery separate from folded-thread reveal and older-history lookup. The AX audit records why root-only fixtures missed the reply path.

Validation at final head 7c549726: independent code approval and full frontend run (102 suites / 776 tests); UX approval after a fresh production build and 10 reveal/hydration/focus cases at desktop1440 and mobile390, with zero HTTP writes. UX also ran the full frontend suite and three Node tests. Source-alias, duplicate-suppression, durable-identity and hydration probes remain covered. Exact-head CI gates merge; verification of the genuine request64684 → recorded choice64685 → agent action64686, plus durable rendering after reload/navigation, gates task completion after deployment.

Follow-up to #1597, deployed as 713e1f6c. The Activity composer dropdown correction is a separate follow-up.
