### PR TITLE
fix(activity): restore bounded post destination picker

### DIFF
--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -1094,6 +1094,20 @@ describe('V2ActivityPage', () => {
     expect(picker).toHaveFocus();
   });
 
+  test('keeps the trigger focused when Escape closes an open destination menu', async () => {
+    const activityRecap = { ...recap, pods: [...recap.pods, { id: 'pod-2', name: 'GTM Programs' }] };
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? decisionQueue : activityRecap }));
+    renderPage();
+    await screen.findByRole('heading', { name: 'Tell your agents' });
+    const picker = document.querySelector<HTMLButtonElement>('.v2-activity__compose-picker-button');
+    expect(picker).not.toBeNull();
+    picker.focus();
+    fireEvent.click(picker);
+    fireEvent.keyDown(picker, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(picker).toHaveFocus();
+  });
+
   test('closes the destination menu on an outside mouse or touch press', async () => {
     const activityRecap = { ...recap, pods: [...recap.pods, { id: 'pod-2', name: 'GTM Programs' }] };
     mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? decisionQueue : activityRecap }));

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -1079,6 +1079,38 @@ describe('V2ActivityPage', () => {
     expect(compose).toHaveValue('Keep this draft');
   });
 
+  test('closes the destination menu on Escape without blurring its trigger', async () => {
+    const activityRecap = { ...recap, pods: [...recap.pods, { id: 'pod-2', name: 'GTM Programs' }] };
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? decisionQueue : activityRecap }));
+    renderPage();
+    await screen.findByRole('heading', { name: 'Tell your agents' });
+    const picker = document.querySelector<HTMLButtonElement>('.v2-activity__compose-picker-button');
+    expect(picker).not.toBeNull();
+    fireEvent.click(picker);
+    const option = within(screen.getByRole('listbox')).getByRole('option', { name: 'GTM Programs' });
+    option.focus();
+    fireEvent.keyDown(option, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(picker).toHaveFocus();
+  });
+
+  test('closes the destination menu on an outside mouse or touch press', async () => {
+    const activityRecap = { ...recap, pods: [...recap.pods, { id: 'pod-2', name: 'GTM Programs' }] };
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? decisionQueue : activityRecap }));
+    renderPage();
+    await screen.findByRole('heading', { name: 'Tell your agents' });
+    const picker = document.querySelector<HTMLButtonElement>('.v2-activity__compose-picker-button');
+    expect(picker).not.toBeNull();
+    fireEvent.click(picker);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    fireEvent.click(picker);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    fireEvent.touchStart(document.body);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
   test('keeps an overflow pod selection visible and returns focus to its trigger', async () => {
     const extraPods = [2, 3, 4].map((id) => ({ id: `pod-${id}`, name: `Pod ${id}` }));
     mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? decisionQueue : { ...recap, pods: [...recap.pods, ...extraPods] } }));

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -1060,6 +1060,25 @@ describe('V2ActivityPage', () => {
     await waitFor(() => expect(picker).toHaveFocus());
   });
 
+  test('supports keyboard destination selection without losing the draft', async () => {
+    const activityRecap = { ...recap, pods: [...recap.pods, { id: 'pod-2', name: 'GTM Programs' }] };
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? decisionQueue : activityRecap }));
+    renderPage();
+    const compose = await screen.findByRole('textbox', { name: i18n.t('activity.compose.placeholder') });
+    fireEvent.change(compose, { target: { value: 'Keep this draft' } });
+    const picker = document.querySelector<HTMLButtonElement>('.v2-activity__compose-picker-button');
+    expect(picker).not.toBeNull();
+    fireEvent.keyDown(picker, { key: 'ArrowDown' });
+    const options = within(screen.getByRole('listbox')).getAllByRole('option');
+    await waitFor(() => expect(options[0]).toHaveFocus());
+    fireEvent.keyDown(options[0], { key: 'ArrowDown' });
+    await waitFor(() => expect(options[1]).toHaveFocus());
+    fireEvent.keyDown(options[1], { key: 'Enter' });
+    await waitFor(() => expect(picker).toHaveFocus());
+    expect(picker).toHaveTextContent('GTM Programs');
+    expect(compose).toHaveValue('Keep this draft');
+  });
+
   test('keeps an overflow pod selection visible and returns focus to its trigger', async () => {
     const extraPods = [2, 3, 4].map((id) => ({ id: `pod-${id}`, name: `Pod ${id}` }));
     mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? decisionQueue : { ...recap, pods: [...recap.pods, ...extraPods] } }));

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -404,6 +404,12 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     const borderedAction = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__queue-action--bordered');
     expect(borderedAction).toContain('border: 1px solid var(--v2-border)');
     expect(ruleBody(v2, '.v2-root .v2-activity__compose .v2-activity__compose-picker-button')).toContain('border: 1px solid var(--v2-border)');
+    const composeMenu = ruleBody(v2, '.v2-root .v2-activity__compose .v2-activity__compose-picker-menu');
+    expect(composeMenu).toContain('max-height: 240px');
+    expect(composeMenu).toContain('overflow-y: auto');
+    const composeOption = ruleBody(v2, '.v2-root .v2-activity__compose .v2-activity__compose-picker-option');
+    expect(composeOption).toContain('background: transparent');
+    expect(composeOption).toContain('color: var(--v2-text-primary)');
     const otherOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option.v2-activity__queue-action--secondary');
     expect(otherOption).toContain('color: var(--v2-accent-text)');
     expect(v2).toContain('.v2-activity__option-description');

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -196,6 +196,7 @@ const V2ActivityPage: React.FC = () => {
   const [composeDraft, setComposeDraft] = useState('');
   const [composeMenuOpen, setComposeMenuOpen] = useState(false);
   const composePickerButtonRef = useRef<HTMLButtonElement | null>(null);
+  const composePickerOptionRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const scopeMenuButtonRef = useRef<HTMLButtonElement | null>(null);
   const [composing, setComposing] = useState(false);
   const [composeError, setComposeError] = useState<string | null>(null);
@@ -662,6 +663,19 @@ const V2ActivityPage: React.FC = () => {
     return recap?.pods || [];
   }, [recap]);
   const composePodName = scopedPods.find((pod) => pod.id === composePodId)?.name || t('activity.allPods');
+  const selectComposePod = (nextPodId: string) => {
+    setComposePodId(nextPodId);
+    setComposeMenuOpen(false);
+    globalThis.window.requestAnimationFrame(() => composePickerButtonRef.current?.focus());
+  };
+  const focusComposePickerOption = (index: number) => {
+    if (scopedPods.length === 0) return;
+    const boundedIndex = (index + scopedPods.length) % scopedPods.length;
+    const option = scopedPods[boundedIndex];
+    if (!option) return;
+    setComposeMenuOpen(true);
+    globalThis.window.requestAnimationFrame(() => composePickerOptionRefs.current[option.id]?.focus());
+  };
   const visibleQueue = useMemo(() => {
     const settled = Object.values(settledQueueDecisions)
       .filter((item) => podId === 'all' || item.podId === podId)
@@ -945,22 +959,55 @@ const V2ActivityPage: React.FC = () => {
                     aria-haspopup="listbox"
                     aria-expanded={composeMenuOpen}
                     onClick={() => setComposeMenuOpen((open) => !open)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Escape' && composeMenuOpen) {
+                        event.preventDefault();
+                        setComposeMenuOpen(false);
+                        return;
+                      }
+                      if (event.key === 'ArrowDown') {
+                        event.preventDefault();
+                        focusComposePickerOption(0);
+                      } else if (event.key === 'ArrowUp') {
+                        event.preventDefault();
+                        focusComposePickerOption(scopedPods.length - 1);
+                      }
+                    }}
                     disabled={composing || scopedPods.length === 0}
                   >
                     {composePodName}
                   </button>
                   {composeMenuOpen && <div className="v2-activity__compose-picker-menu" role="listbox" aria-label={t('activity.compose.podLabel')}>
-                    {scopedPods.map((pod) => (
+                    {scopedPods.map((pod, index) => (
                       <button
                         key={pod.id}
                         type="button"
                         role="option"
+                        ref={(element) => { composePickerOptionRefs.current[pod.id] = element; }}
                         aria-selected={pod.id === composePodId}
                         className={`v2-activity__compose-picker-option${pod.id === composePodId ? ' is-active' : ''}`}
-                        onClick={() => {
-                          setComposePodId(pod.id);
-                          setComposeMenuOpen(false);
-                          globalThis.window.requestAnimationFrame(() => composePickerButtonRef.current?.focus());
+                        onClick={() => selectComposePod(pod.id)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'ArrowDown') {
+                            event.preventDefault();
+                            focusComposePickerOption(index + 1);
+                          } else if (event.key === 'ArrowUp') {
+                            event.preventDefault();
+                            focusComposePickerOption(index - 1);
+                          } else if (event.key === 'Home') {
+                            event.preventDefault();
+                            focusComposePickerOption(0);
+                          } else if (event.key === 'End') {
+                            event.preventDefault();
+                            focusComposePickerOption(scopedPods.length - 1);
+                          } else if (event.key === 'Escape') {
+                            event.preventDefault();
+                            setComposeMenuOpen(false);
+                            composePickerButtonRef.current?.focus();
+                          } else if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            selectComposePod(pod.id);
+                          }
                         }}
                       >
                         {pod.name}

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -195,6 +195,7 @@ const V2ActivityPage: React.FC = () => {
   const [composePodId, setComposePodId] = useState('');
   const [composeDraft, setComposeDraft] = useState('');
   const [composeMenuOpen, setComposeMenuOpen] = useState(false);
+  const composePickerRef = useRef<HTMLDivElement | null>(null);
   const composePickerButtonRef = useRef<HTMLButtonElement | null>(null);
   const composePickerOptionRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const scopeMenuButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -269,6 +270,22 @@ const V2ActivityPage: React.FC = () => {
       globalThis.window.removeEventListener('focus', refresh);
     };
   }, []);
+
+  useEffect(() => {
+    if (!composeMenuOpen) return undefined;
+    const closeOnOutsidePress = (event: MouseEvent | TouchEvent) => {
+      const target = event.target;
+      if (target instanceof Node && composePickerRef.current && !composePickerRef.current.contains(target)) {
+        setComposeMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', closeOnOutsidePress);
+    document.addEventListener('touchstart', closeOnOutsidePress);
+    return () => {
+      document.removeEventListener('mousedown', closeOnOutsidePress);
+      document.removeEventListener('touchstart', closeOnOutsidePress);
+    };
+  }, [composeMenuOpen]);
 
   useEffect(() => {
     const snapshot = restoredSnapshotRef.current;
@@ -951,7 +968,7 @@ const V2ActivityPage: React.FC = () => {
               <h2 id="activity-compose-title" className="v2-activity__compose-label">{t('activity.compose.label')}</h2>
               <div className="v2-activity__compose-pod">
                 <span>{t('activity.compose.podLabel')}</span>
-                <div className="v2-activity__compose-picker">
+                <div ref={composePickerRef} className="v2-activity__compose-picker">
                   <button
                     type="button"
                     ref={composePickerButtonRef}
@@ -962,6 +979,7 @@ const V2ActivityPage: React.FC = () => {
                     onKeyDown={(event) => {
                       if (event.key === 'Escape' && composeMenuOpen) {
                         event.preventDefault();
+                        event.stopPropagation();
                         setComposeMenuOpen(false);
                         return;
                       }
@@ -1002,6 +1020,7 @@ const V2ActivityPage: React.FC = () => {
                             focusComposePickerOption(scopedPods.length - 1);
                           } else if (event.key === 'Escape') {
                             event.preventDefault();
+                            event.stopPropagation();
                             setComposeMenuOpen(false);
                             composePickerButtonRef.current?.focus();
                           } else if (event.key === 'Enter' || event.key === ' ') {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8918,6 +8918,35 @@ body.modern-ui.v2-canvas {
   background: var(--v2-ink-hover);
 }
 
+/* The destination menu is a light, bounded list even though its options are
+   buttons nested under the composer. Keep this selector stronger than the
+   generic Send-button rule above so a large pod list cannot become a black,
+   unbounded wall of buttons. */
+.v2-root .v2-activity__compose .v2-activity__compose-picker-menu {
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.v2-root .v2-activity__compose .v2-activity__compose-picker-option {
+  min-height: 30px;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--v2-text-primary);
+  text-align: left;
+  font: inherit;
+  font-size: var(--v2-fs-meta);
+  font-weight: 500;
+}
+
+.v2-root .v2-activity__compose .v2-activity__compose-picker-option:hover,
+.v2-root .v2-activity__compose .v2-activity__compose-picker-option.is-active {
+  border-color: transparent;
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
 /* The generic composer button treatment above is for Send. The destination
    picker is a neutral selector and needs a stronger selector so it cannot
    inherit Send's ink fill. */


### PR DESCRIPTION
Activity’s Post in menu inherited dark button styling and rendered every pod in an unbounded list. With 108 pods, the live menu was 3,322px tall and extended offscreen. Use the existing light Signal treatment and a 240px internal scroller, while preserving the selected destination and unsent draft.

Support Arrow/Home/End selection, Escape with focus retained or restored to the trigger, and outside mouse/touch dismissal. Keep the existing top-level scope menu and Send button styling intact.

Validation: freshly built integrated head334cdb74 passed the actual open-menu checks with120 pods at1440×900 and390×844, including last-option reach, both Escape paths, outside dismissal, selection and draft preservation. Phone menu bottom528 remained inside the844px viewport. Independent code review confirmed the style cascade and dismissal behavior. The final a5470294 delta adds only a trigger-Escape regression; UI code is identical. Relevant tests, full frontend102 suites/779 tests plus3 Node tests passed at334; exact final-head CI gates merge. Live verification follows deployment.

This branch includes source-thread fix #1599 from main(eab498a3).
