### PR TITLE
Keep Activity destination options readable and usable on phones

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -408,12 +408,14 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(composeMenu).toContain('max-height: 240px');
     expect(composeMenu).toContain('overflow-y: auto');
     const composeOption = ruleBody(v2, '.v2-root .v2-activity__compose .v2-activity__compose-picker-option');
+    expect(composeOption).toContain('min-height: 30px');
     expect(composeOption).toContain('background: transparent');
     expect(composeOption).toContain('color: var(--v2-text-primary)');
     const composeOptionHover = ruleBody(v2, '.v2-root .v2-activity__compose .v2-activity__compose-picker-menu button.v2-activity__compose-picker-option:hover:not(:disabled)');
     expect(composeOptionHover).toContain('background: var(--v2-surface-hover)');
     expect(composeOptionHover).toContain('color: var(--v2-text-primary)');
     expect(composeOptionHover).toContain('border-color: transparent');
+    expect(v2).toMatch(/@media \(max-width: 640px\) \{[\s\S]*?\.v2-root \.v2-activity__compose \.v2-activity__compose-picker-menu \.v2-activity__compose-picker-option \{ min-height: 44px; \}/);
     const otherOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option.v2-activity__queue-action--secondary');
     expect(otherOption).toContain('color: var(--v2-accent-text)');
     expect(v2).toContain('.v2-activity__option-description');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -410,6 +410,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     const composeOption = ruleBody(v2, '.v2-root .v2-activity__compose .v2-activity__compose-picker-option');
     expect(composeOption).toContain('background: transparent');
     expect(composeOption).toContain('color: var(--v2-text-primary)');
+    const composeOptionHover = ruleBody(v2, '.v2-root .v2-activity__compose .v2-activity__compose-picker-menu button.v2-activity__compose-picker-option:hover:not(:disabled)');
+    expect(composeOptionHover).toContain('background: var(--v2-surface-hover)');
+    expect(composeOptionHover).toContain('color: var(--v2-text-primary)');
+    expect(composeOptionHover).toContain('border-color: transparent');
     const otherOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option.v2-activity__queue-action--secondary');
     expect(otherOption).toContain('color: var(--v2-accent-text)');
     expect(v2).toContain('.v2-activity__option-description');

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -8940,8 +8940,17 @@ body.modern-ui.v2-canvas {
   font-weight: 500;
 }
 
-.v2-root .v2-activity__compose .v2-activity__compose-picker-option:hover,
 .v2-root .v2-activity__compose .v2-activity__compose-picker-option.is-active {
+  border-color: transparent;
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
+}
+
+/* The generic composer hover rule includes :not(:disabled) and a button
+   element, so it outranks the picker option's class-only hover selector.
+   Match that specificity here to keep the light Signal option treatment in
+   the real hovered and selected+hovered states without changing Send. */
+.v2-root .v2-activity__compose .v2-activity__compose-picker-menu button.v2-activity__compose-picker-option:hover:not(:disabled) {
   border-color: transparent;
   background: var(--v2-surface-hover);
   color: var(--v2-text-primary);

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9541,6 +9541,10 @@ body.modern-ui.v2-canvas {
   .v2-activity__compose-picker { flex: 1 1 auto; min-width: 0; width: 100%; }
   .v2-root .v2-activity__compose-picker-button { width: 100%; max-width: none; text-align: left; }
   .v2-root .v2-activity__compose button { min-height: 44px; padding: 0 18px; }
+  /* The picker option rule is more specific than the generic composer
+     button floor above; repeat the menu scope so every option keeps a 44px
+     touch target on phones. */
+  .v2-root .v2-activity__compose .v2-activity__compose-picker-menu .v2-activity__compose-picker-option { min-height: 44px; }
   .v2-activity__section-heading { flex-wrap: wrap; }
   .v2-activity__section-heading > p { flex-basis: 100%; }
   .v2-activity__agent-grid { grid-template-columns: minmax(0, 1fr); }


### PR DESCRIPTION
Activity destination options inherited the composer's dark hover fill, leaving dark labels unreadable. Their 30px desktop row rule also overrode the existing 44px phone control minimum.

Scope the option hover treatment so it keeps the existing light Signal surface, and restore 44px option targets at widths up to 640px while preserving 30px desktop rows. Send styling, selection, draft retention and the bounded scrolling menu are unchanged.

Validation: 102 frontend suites / 780 tests plus three SEO checks reported green by the implementation owner. Independent Chromium measurements on c08be6af confirm 44px phone targets, 30px desktop targets and 16.11:1 hover/selected-hover contrast. UX independently verified the production-built UI with 120 destinations at 390px and 1440px: all phone options measure 44px, the last option remains reachable within the 240px menu, five interaction states remain readable, and dismissal preserves the draft. CI passed, including E2E and service tests against real databases. Live verification follows deployment.
