### PR TITLE
fix(activity): restore readable decision option layout

### DIFF
--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -141,7 +141,8 @@ describe('V2ActivityPage', () => {
     const second = screen.getByRole('button', { name: 'Rule: Ship now (Recommended)' });
     expect(first).toHaveClass('v2-activity__option--primary');
     expect(second).not.toHaveClass('v2-activity__option--primary');
-    expect(second).toHaveTextContent('Recommended');
+    expect(second).not.toHaveTextContent('Recommended');
+    expect(within(second.parentElement as HTMLElement).getByText('Recommended')).toBeInTheDocument();
     expect(first).not.toHaveTextContent('Recommended');
     expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
@@ -152,17 +153,22 @@ describe('V2ActivityPage', () => {
       items: [{
         ...decisionQueue.items[1],
         title: 'Scope of the five-post daily X cap',
-        detail: 'Choose how the daily publication cap should apply across the GTM workspace.',
+        detail: '@Sam should we keep the five-post daily cap across every account post, or change it to count only squad-drafted sends?',
         options: [
           {
-            label: 'Keep the five-post cap for every workspace day',
-            description: 'Preserve the current limit so the publishing rhythm stays predictable for the team.',
+            label: 'Keep account-wide cap',
+            description: 'Recommended default: retain five total X posts per day, including casual replies. Simple to count and limits total volume; casual use reduces squad capacity.',
             recommended: false,
           },
           {
-            label: 'Raise the cap for approved launch windows',
-            description: 'Allow a bounded exception when a launch needs additional posts, with the existing audit trail.',
+            label: 'Change to squad-drafted only',
+            description: 'Change the current rule to five squad-drafted sends per day, excluding Sam’s casual replies. Preserves squad capacity but permits more than five total posts and requires identifying draft origin.',
             recommended: true,
+          },
+          {
+            label: 'Use a rolling seven-day cap for all sends',
+            description: 'Spread the same total volume across a longer window while retaining one auditable limit.',
+            recommended: false,
           },
         ],
       }],
@@ -171,13 +177,19 @@ describe('V2ActivityPage', () => {
     mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? longCopyQueue : recap }));
     renderPage();
 
-    const first = await screen.findByRole('button', { name: 'Rule: Keep the five-post cap for every workspace day' });
-    const second = screen.getByRole('button', { name: 'Rule: Raise the cap for approved launch windows (Recommended)' });
+    const first = await screen.findByRole('button', { name: 'Rule: Keep account-wide cap' });
+    const second = screen.getByRole('button', { name: 'Rule: Change to squad-drafted only (Recommended)' });
+    const third = screen.getByRole('button', { name: 'Rule: Use a rolling seven-day cap for all sends' });
     expect(first).toHaveClass('v2-activity__option--primary');
     expect(second).not.toHaveClass('v2-activity__option--primary');
+    expect(third).not.toHaveClass('v2-activity__option--primary');
     expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(screen.getByText('Preserve the current limit so the publishing rhythm stays predictable for the team.')).toBeInTheDocument();
-    expect(screen.getByText('Allow a bounded exception when a launch needs additional posts, with the existing audit trail.')).toBeInTheDocument();
+    expect(second.compareDocumentPosition(third) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText('Recommended default: retain five total X posts per day, including casual replies. Simple to count and limits total volume; casual use reduces squad capacity.')).toBeInTheDocument();
+    expect(screen.getByText('Change the current rule to five squad-drafted sends per day, excluding Sam’s casual replies. Preserves squad capacity but permits more than five total posts and requires identifying draft origin.')).toBeInTheDocument();
+    expect(second).not.toHaveTextContent('Recommended');
+    expect(within(second.parentElement as HTMLElement).getByText('Recommended')).toBeInTheDocument();
+    expect(second).toHaveAttribute('aria-describedby', expect.stringContaining('description'));
   });
 
   test('changes the read window and opens the source pod from a factual queue row', async () => {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -146,6 +146,40 @@ describe('V2ActivityPage', () => {
     expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  test('keeps long decision labels and descriptions readable when the recommendation is second', async () => {
+    const longCopyQueue = {
+      ...decisionQueue,
+      items: [{
+        ...decisionQueue.items[1],
+        title: 'Scope of the five-post daily X cap',
+        detail: 'Choose how the daily publication cap should apply across the GTM workspace.',
+        options: [
+          {
+            label: 'Keep the five-post cap for every workspace day',
+            description: 'Preserve the current limit so the publishing rhythm stays predictable for the team.',
+            recommended: false,
+          },
+          {
+            label: 'Raise the cap for approved launch windows',
+            description: 'Allow a bounded exception when a launch needs additional posts, with the existing audit trail.',
+            recommended: true,
+          },
+        ],
+      }],
+      count: 1,
+    };
+    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue' ? longCopyQueue : recap }));
+    renderPage();
+
+    const first = await screen.findByRole('button', { name: 'Rule: Keep the five-post cap for every workspace day' });
+    const second = screen.getByRole('button', { name: 'Rule: Raise the cap for approved launch windows (Recommended)' });
+    expect(first).toHaveClass('v2-activity__option--primary');
+    expect(second).not.toHaveClass('v2-activity__option--primary');
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText('Preserve the current limit so the publishing rhythm stays predictable for the team.')).toBeInTheDocument();
+    expect(screen.getByText('Allow a bounded exception when a launch needs additional posts, with the existing audit trail.')).toBeInTheDocument();
+  });
+
   test('changes the read window and opens the source pod from a factual queue row', async () => {
     renderPage();
     await screen.findByText('Review requested');

--- a/frontend/src/v2/__tests__/V2DecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2DecisionCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import V2DecisionCard from '../components/V2DecisionCard';
 
 const mockPost = jest.fn();
@@ -33,7 +33,9 @@ describe('V2DecisionCard', () => {
     expect(screen.getByText('Sprint impl')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Ship the rebuilt workspace' })).toHaveClass('v2-decision-card__choice--primary');
     expect(screen.getByRole('button', { name: 'Rule: Keep the legacy chat (Recommended)' })).not.toHaveClass('v2-decision-card__choice--primary');
-    expect(screen.getByRole('button', { name: 'Rule: Keep the legacy chat (Recommended)' })).toHaveTextContent('Recommended');
+    const recommendedChoice = screen.getByRole('button', { name: 'Rule: Keep the legacy chat (Recommended)' });
+    expect(recommendedChoice).not.toHaveTextContent('Recommended');
+    expect(within(recommendedChoice.parentElement as HTMLElement).getByText('Recommended')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Ship the rebuilt workspace' }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(

--- a/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
+++ b/frontend/src/v2/__tests__/V2ThreadDecisionCard.test.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import V2Thread from '../components/V2Thread';
 import { AuthContext } from '../../context/AuthContext';
@@ -460,7 +460,8 @@ describe('V2Thread decision cards', () => {
     const second = screen.getByRole('button', { name: 'Rule: Ship the rebuilt workspace (Recommended)' });
     expect(first).toHaveClass('v2-decision-card__choice--primary');
     expect(second).not.toHaveClass('v2-decision-card__choice--primary');
-    expect(second).toHaveTextContent('Recommended');
+    expect(second).not.toHaveTextContent('Recommended');
+    expect(within(second.parentElement as HTMLElement).getByText('Recommended')).toBeInTheDocument();
     expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -407,6 +407,8 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(decisionCard).toContain('aria-describedby={describedBy}');
     expect(decisionCard).toContain('v2-decision-card__option-recommended');
     expect(decisionCard).toContain('v2-decision-card__option-description');
+    expect(v2).toMatch(/\.v2-decision-card__options \{[\s\S]*?display: grid;[\s\S]*?gap: 12px;/);
+    expect(v2).toMatch(/\.v2-decision-card__option \{[\s\S]*?display: grid;[\s\S]*?gap: 4px;/);
 
     const neutralOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option');
     expect(neutralOption).toContain('border: 1px solid var(--v2-border)');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -404,6 +404,8 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       .toContain('width: 100%');
     expect(lastRuleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button'))
       .toContain('padding-inline: 12px');
+    expect(ruleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button:hover:not(:disabled)'))
+      .toContain('color: var(--v2-on-ink)');
     expect(activityPage).toContain('aria-describedby={describedBy}');
     expect(activityPage).toContain('v2-activity__decision-footer');
     expect(decisionCard).toContain('aria-describedby={describedBy}');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -402,6 +402,8 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       .toContain('max-width: none');
     expect(lastRuleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice'))
       .toContain('width: 100%');
+    expect(lastRuleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button'))
+      .toContain('padding-inline: 12px');
     expect(activityPage).toContain('aria-describedby={describedBy}');
     expect(activityPage).toContain('v2-activity__decision-footer');
     expect(decisionCard).toContain('aria-describedby={describedBy}');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -394,8 +394,19 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     const decisionActionsOverride = lastRuleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__queue-actions');
     expect(decisionActionsOverride).toContain('grid-column: 1 / -1');
     expect(decisionActionsOverride).toContain('max-width: none');
+    expect(decisionActionsOverride).toContain('width: 100%');
+    expect(decisionActionsOverride).toContain('flex-direction: column');
+    expect(decisionActionsOverride).toContain('gap: 12px');
+    expect(ruleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision')).toContain('align-items: start');
     expect(lastRuleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice'))
       .toContain('max-width: none');
+    expect(lastRuleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice'))
+      .toContain('width: 100%');
+    expect(activityPage).toContain('aria-describedby={describedBy}');
+    expect(activityPage).toContain('v2-activity__decision-footer');
+    expect(decisionCard).toContain('aria-describedby={describedBy}');
+    expect(decisionCard).toContain('v2-decision-card__option-recommended');
+    expect(decisionCard).toContain('v2-decision-card__option-description');
 
     const neutralOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option');
     expect(neutralOption).toContain('border: 1px solid var(--v2-border)');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -409,8 +409,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(decisionCard).toContain('aria-describedby={describedBy}');
     expect(decisionCard).toContain('v2-decision-card__option-recommended');
     expect(decisionCard).toContain('v2-decision-card__option-description');
-    expect(v2).toMatch(/\.v2-decision-card__options \{[\s\S]*?display: grid;[\s\S]*?gap: 12px;/);
-    expect(v2).toMatch(/\.v2-decision-card__option \{[\s\S]*?display: grid;[\s\S]*?gap: 4px;/);
+    expect(ruleBody(v2, '.v2-decision-card__options')).toContain('display: grid');
+    expect(ruleBody(v2, '.v2-decision-card__options')).toContain('gap: 12px');
+    expect(ruleBody(v2, '.v2-decision-card__option')).toContain('display: grid');
+    expect(ruleBody(v2, '.v2-decision-card__option')).toContain('gap: 4px');
 
     const neutralOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option');
     expect(neutralOption).toContain('border: 1px solid var(--v2-border)');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -404,8 +404,12 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       .toContain('width: 100%');
     expect(lastRuleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button'))
       .toContain('padding-inline: 12px');
-    expect(ruleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button:hover:not(:disabled)'))
-      .toContain('color: var(--v2-on-ink)');
+    const neutralOptionHover = ruleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button.v2-activity__option:not(.v2-activity__option--primary):hover:not(:disabled)');
+    expect(neutralOptionHover).toContain('background: var(--v2-surface-hover)');
+    expect(neutralOptionHover).toContain('color: var(--v2-text-primary)');
+    const primaryOptionHover = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option--primary:hover:not(:disabled)');
+    expect(primaryOptionHover).toContain('background: var(--v2-accent-strong)');
+    expect(primaryOptionHover).toContain('color: var(--v2-on-ink)');
     expect(activityPage).toContain('aria-describedby={describedBy}');
     expect(activityPage).toContain('v2-activity__decision-footer');
     expect(decisionCard).toContain('aria-describedby={describedBy}');

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -391,6 +391,11 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     const decisionActions = ruleBody(v2, '.v2-activity__queue-row--decision .v2-activity__queue-actions');
     expect(decisionActions).toContain('grid-column: 1 / -1');
     expect(decisionActions).toContain('justify-content: flex-start');
+    const decisionActionsOverride = lastRuleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__queue-actions');
+    expect(decisionActionsOverride).toContain('grid-column: 1 / -1');
+    expect(decisionActionsOverride).toContain('max-width: none');
+    expect(lastRuleBody(v2, '.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice'))
+      .toContain('max-width: none');
 
     const neutralOption = ruleBody(v2, '.v2-root .v2-activity__queue-actions button.v2-activity__option');
     expect(neutralOption).toContain('border: 1px solid var(--v2-border)');

--- a/frontend/src/v2/__tests__/v2-type-floors.test.ts
+++ b/frontend/src/v2/__tests__/v2-type-floors.test.ts
@@ -148,7 +148,6 @@ const ALLOWLIST: string[] = [
   '.v2-board__card-id', // 10.5px — no-mono-family
   '.v2-board__detail-update-author', // 11.5px — no-mono-family
   '.v2-connect__number', // 11.0px — no-mono-family
-  '.v2-decision-card__option > span', // 11.0px — no-mono-family
   '.v2-feature__eyebrow', // 11.0px — no-mono-family
   '.v2-filter-count', // 11.0px — no-mono-family
   '.v2-invite-card__meta', // 11.0px — no-mono-family

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -1155,65 +1155,86 @@ const V2ActivityPage: React.FC = () => {
                       {item.kind === 'decision' && (item.options || []).length > 0 && (
                         <>
                           {ruledDecisions[item.id] ? (
-                            <span className="v2-activity__decision-ruled" role="status">
-                              {t('activity.decision.ruled', ruledDecisions[item.id])}
-                            </span>
+                            <>
+                              <span className="v2-activity__decision-ruled" role="status">
+                                {t('activity.decision.ruled', ruledDecisions[item.id])}
+                              </span>
+                              <div className="v2-activity__decision-footer">
+                                <button type="button" className="v2-activity__queue-action--thread v2-activity__queue-action--bordered" onClick={() => openPod(item.podId, item.messageId)} disabled={!item.podId}>
+                                  {item.messageId === undefined || item.messageId === null || item.messageId === '' ? t('activity.openPod') : t('activity.open')}
+                                </button>
+                              </div>
+                            </>
                           ) : (
                             <>
-                              {(item.options || []).map((option, index) => (
-                                <div className="v2-activity__option-choice" key={option.label}>
-                                  <button
-                                    type="button"
-                                    className={`v2-activity__option${index === 0 ? ' v2-activity__option--primary' : ''}`}
-                                    onClick={() => ruleDecision(item, option.label)}
-                                    disabled={rulingId === item.id}
-                                    aria-label={t(option.recommended
-                                      ? 'activity.decision.ruleOptionRecommended'
-                                      : 'activity.decision.ruleOption', { option: option.label })}
-                                  >
-                                    {rulingId === item.id ? t('activity.decision.working') : <>
-                                      {option.label}
-                                      {option.recommended && <span className="v2-activity__option-recommended"> · {t('activity.decision.recommended')}</span>}
-                                    </>}
-                                  </button>
-                                  {option.description && (
-                                    <span className="v2-activity__option-description">{option.description}</span>
-                                  )}
-                                </div>
-                              ))}
-                              <button
-                                type="button"
-                                className="v2-activity__queue-action--secondary v2-activity__option"
-                                onClick={() => setOtherDecisionId((current) => current === item.id ? null : item.id)}
-                                disabled={rulingId === item.id}
-                              >
-                                {t('activity.decision.other')}
-                              </button>
-                              {otherDecisionId === item.id && (
-                                <div className="v2-activity__decision-other" data-testid="decision-other">
-                                  <textarea
-                                    aria-label={t('activity.decision.otherPlaceholder')}
-                                    rows={2}
-                                    value={otherDecisionValue}
-                                    onChange={(event) => setOtherDecisionValue(event.target.value)}
-                                    disabled={rulingId === item.id}
-                                  />
-                                  <button
-                                    type="button"
-                                    onClick={() => ruleDecision(item, otherDecisionValue)}
-                                    disabled={rulingId === item.id || !otherDecisionValue.trim()}
-                                  >
-                                    {rulingId === item.id ? t('activity.decision.working') : t('activity.decision.sendOther')}
-                                  </button>
-                                </div>
-                              )}
+                              {(item.options || []).map((option, index) => {
+                                const optionId = `${item.id}-${index}`.replace(/[^a-zA-Z0-9_-]/g, '-');
+                                const recommendedId = `${optionId}-recommended`;
+                                const descriptionId = `${optionId}-description`;
+                                const describedBy = option.description ? descriptionId : undefined;
+                                return (
+                                  <div className="v2-activity__option-choice" key={option.label}>
+                                    <button
+                                      type="button"
+                                      className={`v2-activity__option${index === 0 ? ' v2-activity__option--primary' : ''}`}
+                                      onClick={() => ruleDecision(item, option.label)}
+                                      disabled={rulingId === item.id}
+                                      aria-label={t(option.recommended
+                                        ? 'activity.decision.ruleOptionRecommended'
+                                        : 'activity.decision.ruleOption', { option: option.label })}
+                                      aria-describedby={describedBy}
+                                    >
+                                      {rulingId === item.id ? t('activity.decision.working') : option.label}
+                                    </button>
+                                    {option.recommended && (
+                                      <span id={recommendedId} className="v2-activity__option-recommended">{t('activity.decision.recommended')}</span>
+                                    )}
+                                    {option.description && (
+                                      <span id={descriptionId} className="v2-activity__option-description">{option.description}</span>
+                                    )}
+                                  </div>
+                                );
+                              })}
+                              <div className="v2-activity__decision-footer">
+                                <button
+                                  type="button"
+                                  className="v2-activity__queue-action--secondary v2-activity__option"
+                                  onClick={() => setOtherDecisionId((current) => current === item.id ? null : item.id)}
+                                  disabled={rulingId === item.id}
+                                >
+                                  {t('activity.decision.other')}
+                                </button>
+                                {otherDecisionId === item.id && (
+                                  <div className="v2-activity__decision-other" data-testid="decision-other">
+                                    <textarea
+                                      aria-label={t('activity.decision.otherPlaceholder')}
+                                      rows={2}
+                                      value={otherDecisionValue}
+                                      onChange={(event) => setOtherDecisionValue(event.target.value)}
+                                      disabled={rulingId === item.id}
+                                    />
+                                    <button
+                                      type="button"
+                                      onClick={() => ruleDecision(item, otherDecisionValue)}
+                                      disabled={rulingId === item.id || !otherDecisionValue.trim()}
+                                    >
+                                      {rulingId === item.id ? t('activity.decision.working') : t('activity.decision.sendOther')}
+                                    </button>
+                                  </div>
+                                )}
+                                <button type="button" className="v2-activity__queue-action--thread v2-activity__queue-action--bordered" onClick={() => openPod(item.podId, item.messageId)} disabled={!item.podId}>
+                                  {item.messageId === undefined || item.messageId === null || item.messageId === '' ? t('activity.openPod') : t('activity.open')}
+                                </button>
+                              </div>
                             </>
                           )}
                         </>
                       )}
-                      <button type="button" className="v2-activity__queue-action--thread v2-activity__queue-action--bordered" onClick={() => openPod(item.podId, item.messageId)} disabled={!item.podId}>
-                        {item.messageId === undefined || item.messageId === null || item.messageId === '' ? t('activity.openPod') : t('activity.open')}
-                      </button>
+                      {(item.kind !== 'decision' || (item.options || []).length === 0) && (
+                        <button type="button" className="v2-activity__queue-action--thread v2-activity__queue-action--bordered" onClick={() => openPod(item.podId, item.messageId)} disabled={!item.podId}>
+                          {item.messageId === undefined || item.messageId === null || item.messageId === '' ? t('activity.openPod') : t('activity.open')}
+                        </button>
+                      )}
                     </div>
                     {actionErrorItemId === item.id && actionError && (
                       <div className="v2-activity__row-action-error v2-activity__action-error" role="alert">{actionError}</div>

--- a/frontend/src/v2/components/V2DecisionCard.tsx
+++ b/frontend/src/v2/components/V2DecisionCard.tsx
@@ -117,52 +117,59 @@ const V2DecisionCard: React.FC<V2DecisionCardProps> = ({ decision, onRuled }) =>
         </p>
       ) : (
         <div className="v2-decision-card__options">
-          {options.map((option, index) => (
-            <div className="v2-decision-card__option" key={option.label}>
-              <button
-                type="button"
-                className={index === 0 ? 'v2-decision-card__choice v2-decision-card__choice--primary' : 'v2-decision-card__choice'}
-                onClick={() => { void choose(option.label); }}
-                disabled={saving}
-                aria-label={option.recommended
-                  ? t('activity.decision.ruleOptionRecommended', { option: option.label })
-                  : undefined}
-              >
-                {saving ? t('activity.decision.working') : <>
-                  {option.label}
-                  {option.recommended && <span className="v2-decision-card__recommended"> · {t('activity.decision.recommended')}</span>}
-                </>}
-              </button>
-              {option.description && <span>{option.description}</span>}
-            </div>
-          ))}
-          <button
-            type="button"
-            className="v2-decision-card__other"
-            onClick={() => setOtherOpen((open) => !open)}
-            disabled={saving}
-          >
-            {t('activity.decision.other')}
-          </button>
-          {otherOpen && (
-            <div className="v2-decision-card__other-form">
-              <input
-                ref={otherInputRef}
-                aria-label={t('activity.decision.otherPlaceholder')}
-                value={otherValue}
-                onChange={(event) => setOtherValue(event.target.value)}
-                disabled={saving}
-              />
-              <button
-                ref={otherSubmitRef}
-                type="button"
-                onClick={() => { otherSubmissionRef.current = true; void choose(otherValue); }}
-                disabled={saving || !otherValue.trim()}
-              >
-                {saving ? t('activity.decision.working') : t('activity.decision.sendOther')}
-              </button>
-            </div>
-          )}
+          {options.map((option, index) => {
+            const optionId = `${decision.id}-${index}`.replace(/[^a-zA-Z0-9_-]/g, '-');
+            const recommendedId = `${optionId}-recommended`;
+            const descriptionId = `${optionId}-description`;
+            const describedBy = option.description ? descriptionId : undefined;
+            return (
+              <div className="v2-decision-card__option" key={option.label}>
+                <button
+                  type="button"
+                  className={index === 0 ? 'v2-decision-card__choice v2-decision-card__choice--primary' : 'v2-decision-card__choice'}
+                  onClick={() => { void choose(option.label); }}
+                  disabled={saving}
+                  aria-label={option.recommended
+                    ? t('activity.decision.ruleOptionRecommended', { option: option.label })
+                    : undefined}
+                  aria-describedby={describedBy}
+                >
+                  {saving ? t('activity.decision.working') : option.label}
+                </button>
+                {option.recommended && <span id={recommendedId} className="v2-decision-card__option-recommended">{t('activity.decision.recommended')}</span>}
+                {option.description && <span id={descriptionId} className="v2-decision-card__option-description">{option.description}</span>}
+              </div>
+            );
+          })}
+          <div className="v2-decision-card__footer">
+            <button
+              type="button"
+              className="v2-decision-card__other"
+              onClick={() => setOtherOpen((open) => !open)}
+              disabled={saving}
+            >
+              {t('activity.decision.other')}
+            </button>
+            {otherOpen && (
+              <div className="v2-decision-card__other-form">
+                <input
+                  ref={otherInputRef}
+                  aria-label={t('activity.decision.otherPlaceholder')}
+                  value={otherValue}
+                  onChange={(event) => setOtherValue(event.target.value)}
+                  disabled={saving}
+                />
+                <button
+                  ref={otherSubmitRef}
+                  type="button"
+                  onClick={() => { otherSubmissionRef.current = true; void choose(otherValue); }}
+                  disabled={saving || !otherValue.trim()}
+                >
+                  {saving ? t('activity.decision.working') : t('activity.decision.sendOther')}
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       )}
       {error && <p className="v2-decision-card__error" role="alert">{error}</p>}

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -11756,6 +11756,9 @@ body.modern-ui.v2-canvas {
   line-height: 20px;
   white-space: normal;
 }
+.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button:hover:not(:disabled) {
+  color: var(--v2-on-ink);
+}
 .v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-recommended {
   display: block;
   color: var(--v2-text-muted);

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -11751,6 +11751,7 @@ body.modern-ui.v2-canvas {
 .v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button {
   justify-content: flex-start;
   padding-block: 6px;
+  padding-inline: 12px;
   text-align: left;
   line-height: 20px;
   white-space: normal;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -11756,8 +11756,9 @@ body.modern-ui.v2-canvas {
   line-height: 20px;
   white-space: normal;
 }
-.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button:hover:not(:disabled) {
-  color: var(--v2-on-ink);
+.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button.v2-activity__option:not(.v2-activity__option--primary):hover:not(:disabled) {
+  background: var(--v2-surface-hover);
+  color: var(--v2-text-primary);
 }
 .v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-recommended {
   display: block;

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9341,7 +9341,7 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-activity__option-recommended,
-.v2-decision-card__recommended {
+.v2-decision-card__option-recommended {
   font: 500 11px/14px var(--v2-font-mono);
   opacity: 0.9;
 }
@@ -10238,24 +10238,33 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-decision-card__options {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 7px;
+  display: grid;
+  gap: 12px;
 }
 
-.v2-decision-card__option { display: inline-flex; align-items: center; gap: 5px; }
+.v2-decision-card__option {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
 
 .v2-root button.v2-decision-card__choice,
 .v2-root button.v2-decision-card__other,
 .v2-root button.v2-decision-card__other-form button {
-  min-height: 30px;
-  padding: 5px 10px;
+  min-height: 32px;
+  padding: 6px 10px;
   border: 1px solid var(--v2-border);
   border-radius: 4px;
   background: var(--v2-surface);
   color: var(--v2-text-primary);
-  font: 500 12px/18px var(--v2-font);
+  font: 600 13px/20px var(--v2-font);
+}
+
+.v2-root button.v2-decision-card__choice {
+  width: 100%;
+  justify-content: flex-start;
+  text-align: left;
+  white-space: normal;
 }
 
 .v2-root button.v2-decision-card__choice--primary {
@@ -10268,15 +10277,27 @@ body.modern-ui.v2-canvas {
 .v2-root button.v2-decision-card__other:hover:not(:disabled) { background: var(--v2-surface-hover); }
 .v2-root button.v2-decision-card__choice--primary:hover:not(:disabled) { background: var(--v2-accent-strong); }
 
-.v2-decision-card__option > span {
+.v2-decision-card__option-description {
+  color: var(--v2-text-secondary);
+  font: 400 14px/20px var(--v2-font);
+}
+
+.v2-decision-card__option-recommended {
   color: var(--v2-text-muted);
-  font: 400 11px/16px var(--v2-font);
+  font: 500 11px/14px var(--v2-font-mono);
 }
 
 .v2-root button.v2-decision-card__other {
   border: 0;
   background: transparent;
   color: var(--v2-accent-text);
+}
+
+.v2-decision-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
 }
 
 .v2-decision-card__other-form {
@@ -10442,7 +10463,7 @@ body.modern-ui.v2-canvas {
   .v2-decision-card__options { align-items: stretch; flex-direction: column; }
   .v2-decision-card__option { width: 100%; }
   .v2-root button.v2-decision-card__choice { width: 100%; min-height: 44px; font-size: 15px; }
-  .v2-root button.v2-decision-card__other { align-self: center; min-height: 30px; }
+  .v2-root button.v2-decision-card__other { align-self: flex-start; min-height: 44px; }
 
   /* The workspace is edge-to-edge on a phone. Rail and pod list are drawers,
      while the transcript, composer, and tab bar share the white canvas. */
@@ -11712,8 +11733,42 @@ body.modern-ui.v2-canvas {
   grid-column: 1 / -1;
   grid-row: auto;
   max-width: none;
+  width: 100%;
   justify-content: flex-start;
+  align-items: stretch;
+  flex-direction: column;
+  gap: 12px;
+}
+.v2-activity__queue-row.v2-activity__queue-row--decision {
+  align-items: start;
+  row-gap: 12px;
 }
 .v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice {
+  width: 100%;
+  flex: none;
   max-width: none;
+}
+.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button {
+  justify-content: flex-start;
+  padding-block: 6px;
+  text-align: left;
+  line-height: 20px;
+  white-space: normal;
+}
+.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-recommended {
+  display: block;
+  color: var(--v2-text-muted);
+  font: 500 11px/14px var(--v2-font-mono);
+}
+.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-description {
+  color: var(--v2-text-secondary);
+  font-size: 14px;
+  line-height: 20px;
+}
+.v2-activity__decision-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
 }

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -11703,3 +11703,17 @@ body.modern-ui.v2-canvas {
   .v2-activity__queue-row .v2-activity__queue-actions { grid-column: 2; grid-row: auto; max-width: none; justify-content: flex-start; }
   .v2-activity__queue-row .v2-activity__option-choice { max-width: 100%; }
 }
+
+/* Decision alternatives are a full-width content line below the question.
+   These rules intentionally come after the generic queue-row overrides above:
+   a decision's options must not be squeezed into the 320px action column or
+   capped at 150px each when the card contains long copy. */
+.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__queue-actions {
+  grid-column: 1 / -1;
+  grid-row: auto;
+  max-width: none;
+  justify-content: flex-start;
+}
+.v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice {
+  max-width: none;
+}


### PR DESCRIPTION
Long decision options were squeezed beside the question into 150px columns, with recommendation text competing with labels. Activity alternatives also inherited a dark hover fill that made their dark text unreadable.

Stack the options below the question at the available card width, put Recommended on a separate line, and render full descriptions at 14/20 with accessible associations. Add a 12px inline inset to Activity choices and retain light hover surfaces for alternatives. Apply the same option grouping to thread cards while preserving authored order, cobalt primary treatment, choice handling and durable resolution.

Validation covers the real GTM cap question plus long three-option copy with the recommendation second at desktop and 390px phone widths. Independent review clears final 9a32b5d1 geometry, padding and settled hover contrast; the UX lead independently passed 48 production-build state checks across Activity/thread and desktop/phone. Final CI passed, including E2E and service tests against real databases. Tests guard the actual CSS rule bodies and description associations. Live verification follows deployment before Sam’s authorized choice is submitted.
