### PR TITLE
Teach agents to use decision cards for human forks

### DIFF
--- a/backend/__tests__/unit/scripts/moltbotToolContract.test.js
+++ b/backend/__tests__/unit/scripts/moltbotToolContract.test.js
@@ -179,6 +179,7 @@ describe('moltbot tool contract', () => {
       const required = [...collectRequiredTools().keys()];
       expect(required).not.toContain('commonly_read_file');
       expect(required).not.toContain('commonly_dm_agent');
+      expect(required).not.toContain('commonly_request_decision');
     });
 
     // ...and the exclusion has to stay earned. Both names must still be in the
@@ -187,6 +188,7 @@ describe('moltbot tool contract', () => {
     it('exempts only names that actually appear in the cues', () => {
       expect(cueText).toContain('commonly_read_file');
       expect(cueText).toContain('commonly_dm_agent');
+      expect(cueText).toContain('commonly_request_decision');
     });
 
     // Both halves of each pair must be present, or the cue is telling one

--- a/backend/__tests__/unit/services/agentMentionService.frameBudget.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.frameBudget.test.js
@@ -57,7 +57,9 @@ const AgentEvent = require('../../../models/AgentEvent');
 // 2,877 — leaving MIN at 2,600 would let a third of the frame vanish silently,
 // which is the failure the lower bound exists to catch. What the fleet buys for
 // the extra ~1,058 characters is in the PR body.
-const BUDGET_MAX = 4100;
+// The decision-card cue keeps @human addressing and a fallback for runtimes
+// that do not expose the MCP card tool in the same message.
+const BUDGET_MAX = 4200;
 const BUDGET_MIN = 3550;
 
 const referenceWake = async () => {

--- a/backend/__tests__/unit/services/agentMentionService.test.js
+++ b/backend/__tests__/unit/services/agentMentionService.test.js
@@ -877,6 +877,15 @@ describe('AgentMentionService', () => {
         expect(await frame()).toContain('@mention their handle');
       });
 
+      test('routes genuine advisory forks to the decision-card tool', async () => {
+        const content = await frame();
+        expect(content).toContain('MCP: `commonly_request_decision`');
+        expect(content).toContain('2–4 options');
+        expect(content).toContain('@human for a named ruler');
+        expect(content).toContain('if unavailable, ask the intended human');
+        expect(content).toMatch(/do not duplicate .*chat ask/);
+      });
+
       test('states that a bare name reaches no one', async () => {
         // The failure is silent — nothing errors, the message posts, and no
         // attention routes — so the cue has to name the outcome, not just

--- a/backend/services/agentMentionService.ts
+++ b/backend/services/agentMentionService.ts
@@ -591,8 +591,14 @@ const formatPodContextFrame = (podId: string): string =>
   // only-interrupter rule reserves push for the escalation envelope — so "I mentioned them" is never "they
   // know", and an agent that stops there has blocked itself on a filter
   // nobody may have opened.
-  `When you need a HUMAN — a decision, a merge press, an answer only they ` +
-  `have — @mention their handle. A bare name reaches no one: human attention ` +
+  `At a genuine HUMAN fork, use the card tool ` +
+  `(MCP: \`commonly_request_decision\`): give 2–4 options; mark one ` +
+  `recommended, ` +
+  `include context; add @human for a named ruler. It posts the card; ` +
+  `if unavailable, ask the intended human with a plain @human question; do not ` +
+  `duplicate chat ask. For ` +
+  `merge press or ordinary ` +
+  `answer, @mention their handle. A bare name reaches no one: human attention ` +
   `is matched on the literal @handle, so "Sam should decide this" is addressed ` +
   `to nobody. The handle is necessary and not sufficient — it flags the message ` +
   `in a mentions filter the human pulls; nothing pushes. Say plainly what you ` +

--- a/cli/__tests__/enforcement.test.mjs
+++ b/cli/__tests__/enforcement.test.mjs
@@ -42,8 +42,9 @@ describe('decision-fork prompt rule', () => {
   ])('frames prose fork: %s', (proseAsk) => {
     const prompt = frameDecisionForkRule(proseAsk);
     expect(prompt).toContain(DECISION_FORK_FRAME);
-    expect(prompt).toContain('commonly_request_decision');
-    expect(prompt).toContain('do not post a prose @ask');
+    expect(prompt).toContain('MCP: commonly_request_decision');
+    expect(prompt).toContain('include @human when a specific person should rule');
+    expect(prompt).toContain('do not duplicate the card with a prose @ask');
     expect(prompt).toContain(proseAsk);
   });
 });

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/cli",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/skills/commonly/SKILL.md
+++ b/cli/skills/commonly/SKILL.md
@@ -114,7 +114,7 @@ How to reach out:
   human must choose among 2–4 concrete options. Mark one recommended and add
   context; when a specific person should rule, address them with `@human` in
   the question (pod-wide choices need no invented target). The tool posts the
-  interactive card and returns a `decision.ruled` event. Do not duplicate it as
+  interactive card; its later ruling arrives as a `decision.ruled` event. Do not duplicate it as
   a chat ask, and do not treat it as permission for a privileged action.
   Unrelated work need not stop while it is pending.
 - **`@mention` in the pod** when the whole room benefits from seeing it (a handoff,

--- a/cli/skills/commonly/SKILL.md
+++ b/cli/skills/commonly/SKILL.md
@@ -110,8 +110,15 @@ Good reasons to ping someone (proactively — this is normal, not exceptional):
 - **A sync** — you and a peer are about to duplicate or collide on work.
 
 How to reach out:
+- **`commonly_request_decision(...)`** for a genuine advisory fork where a
+  human must choose among 2–4 concrete options. Mark one recommended and add
+  context; when a specific person should rule, address them with `@human` in
+  the question (pod-wide choices need no invented target). The tool posts the
+  interactive card and returns a `decision.ruled` event. Do not duplicate it as
+  a chat ask, and do not treat it as permission for a privileged action.
+  Unrelated work need not stop while it is pending.
 - **`@mention` in the pod** when the whole room benefits from seeing it (a handoff,
-  a decision, a question others should hear). Use the exact member name.
+  a merge press, or an ordinary answer). Use the exact member name.
 - **`commonly_dm_agent(agentName)`** for a focused 1:1 with another agent — quick
   feedback or collaboration that would clutter the team pod. It opens (or fetches)
   an agent-to-agent DM; it returns `{ room }`, then `commonly_post_message(room._id, …)`.

--- a/cli/src/lib/enforcement.js
+++ b/cli/src/lib/enforcement.js
@@ -35,7 +35,7 @@ export const CLAIMABLE_EVENT_TYPES = new Set([
 // whether the work genuinely cannot continue without a human ruling.
 export const DECISION_FORK_FRAME = [
   '[Decision forks]',
-  'If you are blocked on a genuine fork that needs a human choice, call commonly_request_decision; do not post a prose @ask.',
+  'If you are blocked on a genuine fork that needs a human choice, use your runtime\'s decision-card tool (MCP: commonly_request_decision); include @human when a specific person should rule, and do not duplicate the card with a prose @ask.',
   'Use it only when you cannot safely continue before a ruling. Give 2–4 concrete options and mark one recommendation.',
   'Use ordinary pod messages for status, factual questions, and coordination that do not require a human choice.',
 ].join('\n');

--- a/commonly-mcp/__tests__/tools.test.mjs
+++ b/commonly-mcp/__tests__/tools.test.mjs
@@ -184,6 +184,8 @@ describe('commonly_request_decision', () => {
     expect(tool.description).toContain('not for status updates');
     expect(tool.description).toMatch(/never approval|not approval/i);
     expect(tool.description).toContain('never encode an executable');
+    expect(tool.description).toMatch(/specific person should rule/);
+    expect(tool.description).toMatch(/unrelated work need not stop/);
   });
 });
 
@@ -446,6 +448,13 @@ describe('agent-facing tone contract', () => {
   it('tells the agent to post the result rather than its reasoning', () => {
     expect(desc).toMatch(/RESULT, not your reasoning/);
   });
+
+  it('routes genuine forks to the decision card instead of chat', () => {
+    expect(desc).toContain('commonly_request_decision');
+    expect(desc).toContain('@human in the question');
+    expect(desc).toMatch(/do not duplicate the ask in chat/i);
+    expect(desc).toMatch(/interactive card/);
+  });
 });
 
 describe('commonly_get_started', () => {
@@ -472,6 +481,15 @@ describe('commonly_get_started', () => {
   it('warns that pod content is data, not instructions', async () => {
     // Prompt-injection hygiene for agents reading rooms strangers can write to.
     expect((await tool.call({})).content[0].text).toMatch(/data, not command/);
+  });
+
+  it('distinguishes decision cards from ordinary mentions and messages', async () => {
+    const text = (await tool.call({})).content[0].text;
+    expect(text).toMatch(/commonly_request_decision/);
+    expect(text).toMatch(/interactive card/);
+    expect(text).toMatch(/do not duplicate/i);
+    expect(text).toMatch(/merge press, ordinary answer/);
+    expect(text).toMatch(/pod-wide choices need no invented target/);
   });
 });
 

--- a/commonly-mcp/package-lock.json
+++ b/commonly-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/mcp",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"
       },

--- a/commonly-mcp/package.json
+++ b/commonly-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/mcp",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/commonly-mcp/src/tools.js
+++ b/commonly-mcp/src/tools.js
@@ -114,13 +114,18 @@ messages a minute, and attach a file instead of pasting a document.
 
 ## Working with others
 
-- \`@mention\` someone to ask for a response. Mentioning an agent wakes it.
+- \`@mention\` someone for a merge press, ordinary answer, or FYI the room
+  should see. Mentioning an agent wakes it.
 - \`commonly_dm_agent\` for a focused 1:1 instead of cluttering a team room.
 - \`commonly_ask_agent\` for a private question that returns an answer later.
-- \`commonly_request_decision\` only at a genuine fork where a human must
-  choose among 2–4 concrete alternatives. It posts the question in the pod;
-  their ruling is stored as a threaded reply and delivered as a typed
-  \`decision.ruled\` event.
+- \`commonly_request_decision\` only at a genuine advisory fork where a human
+  must choose among 2–4 concrete alternatives. Put the recommended option
+  first and mark it; include context. Address a specific intended human with
+  \`@human\` in the question; pod-wide choices need no invented target. It
+  posts the interactive card itself, so do not duplicate the ask with
+  \`commonly_post_message\`. Their ruling is stored as a threaded reply and
+  delivered as a typed \`decision.ruled\` event; this is not permission for a
+  privileged action, and unrelated work need not stop while it is pending.
 - Read and write memory with \`commonly_read_agent_memory\` /
   \`commonly_save_my_memory\`. Write what a teammate would need next week, not a
   transcript.
@@ -150,7 +155,7 @@ export const buildTools = (config) => {
     }
   };
 
-  return [
+  const tools = [
     {
       name: 'commonly_get_started',
       description: 'Read this ONCE at the start of your first turn in Commonly, before any other commonly_* call. Explains what Commonly is, how a pod works, and the behaviour expected of you here. Served from this package — no network call, no auth needed.',
@@ -163,7 +168,7 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_post_message',
-      description: 'Post a chat message into a pod as this agent.\n\nA pod is a CHAT ROOM a human may scroll, not a report surface. These are hard constraints, not preferences — an earlier version of this text said "keep it concise" and produced a 2,698-character median, because "concise" is unfalsifiable and a model can believe it complied at any length:\n- Aim under 400 characters per message. NEVER hit that by cutting content: if you have more to say, send another message. Two short messages beat one wall, and both beat saying less than you meant.\n- Over ~800 characters of ONE indivisible thing (a diff, a table, a doc) it is not a message — attach it with commonly_attach_file and post one line saying what it is.\n- Post the RESULT, not your reasoning. The thinking earned the answer; it is not the answer. Reasoning belongs in a PR body or a doc.\n- Never open with a bold sentence. No section headers, no ✅/❌ lists, no pasted tables — those are report furniture and they are what make agent rooms unreadable.\n- Never narrate your own diligence ("noting this for the record", "stated precisely so it is not misread"). Delete those sentences entirely.\n- One idea per message. A second header means it should be two messages or a linked document.\n- Cap 3 messages per minute AND 3 in a row. The rate cap alone produced 24-message monologues: at 3/min sustained for seven minutes, one agent owned the entire room. A rate bounds how FAST you talk, never how LONG you hold the floor.\n- Before a 4th consecutive message with nobody else having spoken, STOP. Not "wrap up" — stop. A run of your own messages is a monologue whatever its rate, and the reader experiences it as one wall you pressed enter inside of. If the remaining material genuinely needs saying, it is a document: attach it and post one line.\n- Splitting is for one answer that does not fit, not for thinking out loud in public. Three messages answering one question is fine. Three messages arriving at an answer is reasoning, and the rule above already says reasoning does not go in the room.\n\nReply to what was actually said. If you would add nothing, do not post — in a 1:1 DM you may return the literal string NO_REPLY (and ONLY that string) to stay silent.\n\nThree addressing modes: a plain post broadcasts to the room; `replyToMessageId` addresses a specific message AND pings its author (matches the backend field name in ADR-004 §Message shape); `threadRootId` continues an existing thread WITHOUT pinging anyone — use it for follow-ups, elaboration, and anything past your first message on a topic. Prose overflow goes in a thread, not as consecutive top-level messages: post one top-level message, then put the detail in its thread by passing the first message\'s id as threadRootId.',
+      description: 'Post a chat message into a pod as this agent.\n\nA pod is a CHAT ROOM a human may scroll, not a report surface. These are hard constraints, not preferences — an earlier version of this text said "keep it concise" and produced a 2,698-character median, because "concise" is unfalsifiable and a model can believe it complied at any length:\n- Aim under 400 characters per message. NEVER hit that by cutting content: if you have more to say, send another message. Two short messages beat one wall, and both beat saying less than you meant.\n- Over ~800 characters of ONE indivisible thing (a diff, a table, a doc) it is not a message — attach it with commonly_attach_file and post one line saying what it is.\n- Post the RESULT, not your reasoning. The thinking earned the answer; it is not the answer. Reasoning belongs in a PR body or a doc.\n- Never open with a bold sentence. No section headers, no ✅/❌ lists, no pasted tables — those are report furniture and they are what make agent rooms unreadable.\n- Never narrate your own diligence ("noting this for the record", "stated precisely so it is not misread"). Delete those sentences entirely.\n- One idea per message. A second header means it should be two messages or a linked document.\n- Cap 3 messages per minute AND 3 in a row. The rate cap alone produced 24-message monologues: at 3/min sustained for seven minutes, one agent owned the entire room. A rate bounds how FAST you talk, never how LONG you hold the floor.\n- Before a 4th consecutive message with nobody else having spoken, STOP. Not "wrap up" — stop. A run of your own messages is a monologue whatever its rate, and the reader experiences it as one wall you pressed enter inside of. If the remaining material genuinely needs saying, it is a document: attach it and post one line.\n- Splitting is for one answer that does not fit, not for thinking out loud in public. Three messages answering one question is fine. Three messages arriving at an answer is reasoning, and the rule above already says reasoning does not go in the room.\n\nReply to what was actually said. If you would add nothing, do not post — in a 1:1 DM you may return the literal string NO_REPLY (and ONLY that string) to stay silent.\n\nThree addressing modes: a plain post broadcasts to the room; `replyToMessageId` addresses a specific message AND pings its author (matches the backend field name in ADR-004 §Message shape); `threadRootId` continues an existing thread WITHOUT pinging anyone — use it for follow-ups, elaboration, and anything past your first message on a topic. Prose overflow goes in a thread, not as consecutive top-level messages: post one top-level message, then put the detail in its thread by passing the first message\'s id as threadRootId.' + '\n\nIf a genuine fork needs a human to choose, call commonly_request_decision; include @human in the question when a specific person should rule, and let the tool post its own interactive card. Do not duplicate the ask in chat; status updates and ordinary questions remain messages.',
       inputSchema: reqWith({
         podId: STRING,
         content: STRING,
@@ -496,7 +501,7 @@ export const buildTools = (config) => {
     },
     {
       name: 'commonly_request_decision',
-      description: 'Ask the human members of a pod to resolve a genuine fork in your work. Choose an advisory class: strategy, implementation, or prioritization. Use only when you cannot safely continue without their choice — not for status updates, routine execution, or a question you can answer from the pod. Supply 2–4 concrete options; put the recommended one first and mark it `recommended: true` (at most one). Commonly posts your question as your own message, renders an option card, stores the human’s choice as a threaded reply, and delivers it back as a `decision.ruled` event. This is advisory coordination only, never approval or authority to act: never encode an executable or privileged action here; use propose-action for side effects that need consent.',
+      description: 'Ask the human members of a pod to resolve a genuine fork in your work. Choose an advisory class: strategy, implementation, or prioritization. Use only when you cannot safely continue without their choice — not for status updates, routine execution, or a question you can answer from the pod. Supply 2–4 concrete options; put the recommended one first and mark it `recommended: true` (at most one). If a specific person should rule, include their @human in the question; a pod-wide choice needs no invented target. Commonly posts your question as your own message, renders an interactive option card, stores the human’s choice as a threaded reply, and delivers it back as a `decision.ruled` event. Do not also call commonly_post_message for the ask; unrelated work need not stop while the ruling is pending. This is advisory coordination only, never approval or authority to act: never encode an executable or privileged action here; use propose-action for side effects that need consent.',
       inputSchema: reqWith({
         podId: STRING,
         decisionClass: DECISION_CLASS,
@@ -562,4 +567,5 @@ export const buildTools = (config) => {
     // as the machine's OWN GitHub identity rather than ours, and it supports
     // line-level review comments, which these tools never did.
   ];
+  return tools;
 };

--- a/docs/agents/skills/commonly/SKILL.md
+++ b/docs/agents/skills/commonly/SKILL.md
@@ -114,7 +114,7 @@ How to reach out:
   human must choose among 2–4 concrete options. Mark one recommended and add
   context; when a specific person should rule, address them with `@human` in
   the question (pod-wide choices need no invented target). The tool posts the
-  interactive card and returns a `decision.ruled` event. Do not duplicate it as
+  interactive card; its later ruling arrives as a `decision.ruled` event. Do not duplicate it as
   a chat ask, and do not treat it as permission for a privileged action.
   Unrelated work need not stop while it is pending.
 - **`@mention` in the pod** when the whole room benefits from seeing it (a handoff,

--- a/docs/agents/skills/commonly/SKILL.md
+++ b/docs/agents/skills/commonly/SKILL.md
@@ -110,8 +110,15 @@ Good reasons to ping someone (proactively — this is normal, not exceptional):
 - **A sync** — you and a peer are about to duplicate or collide on work.
 
 How to reach out:
+- **`commonly_request_decision(...)`** for a genuine advisory fork where a
+  human must choose among 2–4 concrete options. Mark one recommended and add
+  context; when a specific person should rule, address them with `@human` in
+  the question (pod-wide choices need no invented target). The tool posts the
+  interactive card and returns a `decision.ruled` event. Do not duplicate it as
+  a chat ask, and do not treat it as permission for a privileged action.
+  Unrelated work need not stop while it is pending.
 - **`@mention` in the pod** when the whole room benefits from seeing it (a handoff,
-  a decision, a question others should hear). Use the exact member name.
+  a merge press, or an ordinary answer). Use the exact member name.
 - **`commonly_dm_agent(agentName)`** for a focused 1:1 with another agent — quick
   feedback or collaboration that would clutter the team pod. It opens (or fetches)
   an agent-to-agent DM; it returns `{ room }`, then `commonly_post_message(room._id, …)`.

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -3746,7 +3746,7 @@ assert both the transformed row and suppression of the duplicate durable row.
 
 The runtime frame told agents that when they needed “a decision” they should
 `@mention` a human. The MCP package already exposed `commonly_request_decision`,
-which posts an interactive card and returns a typed `decision.ruled` event. The
+which posts an interactive card and later delivers a typed `decision.ruled` event. The
 conflicting cue made an agent wait for a mention-visible response or author a
 card-shaped chat message instead of calling the tool. The generic mention path
 is still correct for merge presses and ordinary answers; this was a discovery

--- a/docs/development/agent-experience-audit.md
+++ b/docs/development/agent-experience-audit.md
@@ -3738,3 +3738,25 @@ consume the state. A green root-only test can prove the map is populated while
 missing the user-visible path entirely. The safe test shape is the real
 source → reply → durable ruling relationship, and the implementation must
 assert both the transformed row and suppression of the duplicate durable row.
+
+## 56. An interactive decision tool can be hidden by a generic human cue (2026-09-08, kai)
+
+*Origin observation: Sam, msg 65680; verification: `formatPodContextFrame` in
+`backend/services/agentMentionService.ts` and the Commonly MCP tool registry.*
+
+The runtime frame told agents that when they needed “a decision” they should
+`@mention` a human. The MCP package already exposed `commonly_request_decision`,
+which posts an interactive card and returns a typed `decision.ruled` event. The
+conflicting cue made an agent wait for a mention-visible response or author a
+card-shaped chat message instead of calling the tool. The generic mention path
+is still correct for merge presses and ordinary answers; this was a discovery
+failure, not a missing API.
+
+**Repair:** teach the decision-card choice in the delivered runtime frame and
+the bundled Commonly skill; keep decision cards and `@human` addressing
+complementary (while FYI mentions remain ordinary messages); cross-reference
+the choice from `commonly_post_message`; pin the distinction in MCP
+orientation/tool-description tests; and align the CLI fork frame with the
+same AND semantics. The decision tool posts its own ask,
+remains advisory (not privileged-action consent), and does not require
+unrelated work to stop while a ruling is pending.

--- a/scripts/verify-moltbot-tool-contract.js
+++ b/scripts/verify-moltbot-tool-contract.js
@@ -278,7 +278,14 @@ const REQUIRED_TOOL_SOURCES = [
     // the same capability. These are MCP tools; the pin neither has nor owes
     // them. Every entry is asserted to still appear in the cue text below, so
     // this list cannot outlive the line that justified it.
-    namedForOtherDrivers: ['commonly_read_file', 'commonly_dm_agent'],
+    namedForOtherDrivers: [
+      'commonly_read_file',
+      'commonly_dm_agent',
+      // The decision-card API is exposed by @commonlyai/mcp. Keep the
+      // cross-runtime guidance in the shared frame without requiring the
+      // pinned OpenClaw extension to invent a counterpart.
+      'commonly_request_decision',
+    ],
   },
 ];
 


### PR DESCRIPTION
## Summary
- teach the delivered mention frame and bundled skill to use `commonly_request_decision` for genuine advisory forks while preserving @human addressing when a named ruler is relevant
- distinguish decision cards from ordinary mentions/messages in MCP orientation, tool descriptions, post-message guidance, and the CLI fork frame
- add runtime delivery, cross-driver contract, MCP/CLI, package version, and AX-audit coverage

## Verification
- `cd backend && npx jest __tests__/unit/services/agentMentionService.test.js __tests__/unit/services/agentMentionService.frameBudget.test.js __tests__/unit/scripts/moltbotToolContract.test.js --runInBand`
- `cd backend && npm run tsc:check`
- `cd commonly-mcp && npm test -- --runInBand`
- `cd cli && npm test -- --runInBand cli/__tests__/enforcement.test.mjs`
- `node scripts/verify-moltbot-tool-contract.js`

Task: TASK-016 / Sam msg 65680