### PR TITLE
feat(seo): add AI agent task closure guide

### DIFF
--- a/frontend/scripts/generate-seo-pages.test.mjs
+++ b/frontend/scripts/generate-seo-pages.test.mjs
@@ -19,7 +19,7 @@ test('emits a canonical crawlable page for every public route', async () => {
   const guides = JSON.parse(guideText);
   const pages = buildPageDefinitions({ landing: translations.landing, compare: translations.compare, useCases, guides });
 
-  assert.equal(pages.length, 81);
+  assert.equal(pages.length, 82);
   assert.deepEqual(pages.map((page) => page.path), [
     '/',
     '/compare/',
@@ -102,6 +102,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-intake/',
     '/guides/ai-agent-decision-owner/',
     '/guides/ai-agent-artifact-versions/',
+    '/guides/ai-agent-task-closure/',
   ]);
   assert.deepEqual(pages[0].schema['@graph'].map((item) => item['@type']), [
     'Organization',
@@ -137,7 +138,7 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-task-management/',
     '/guides/connect-claude-codex-shared-workspace/',
   ]);
-  assert.equal(guidePages.length, 71);
+  assert.equal(guidePages.length, 72);
   for (const guide of guidePages) {
     assert.equal(guide.ogType, 'article');
     const article = guide.schema['@graph'].find((item) => item['@type'] === 'Article');
@@ -727,6 +728,31 @@ test('emits a canonical crawlable page for every public route', async () => {
     '/guides/ai-agent-status-updates/',
   ]) {
     assert.match(renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath)), /href="\/guides\/ai-agent-resume-conditions\//);
+  }
+  const taskClosureGuide = guidePages.find((page) => page.path === '/guides/ai-agent-task-closure/');
+  assert.equal(taskClosureGuide.title, 'AI Agent Task Closure: Record What Done Means | Commonly');
+  const taskClosure = guides['ai-agent-task-closure'];
+  assert.deepEqual(taskClosure.sections.flatMap((section) => (section.tables || []).map((table) => [table.headers.length, table.rows.length])), [[3, 6], [3, 6], [3, 6], [3, 6], [3, 6], [3, 6], [3, 6], [3, 6], [3, 6]]);
+  assert.deepEqual(taskClosure.sections.filter((section) => section.orderedItems).map((section) => section.orderedItems.length), [7]);
+  assert.equal(taskClosure.sections.flatMap((section) => section.links || []).length, 9);
+  assert.deepEqual(taskClosure.sections.find((section) => section.title === 'Closing a path does not erase the reason it existed').links.map((link) => link.path), ['/guides/ai-agent-no-op/', '/guides/ai-agent-blockers/']);
+  assert.equal(taskClosure.sections.find((section) => section.title === 'Closure is a short final accounting').links, undefined);
+  assert.match(taskClosure.intro[0], /^AI agent task closure is the act of recording why a bounded task is done, what artifact or result it produced, what evidence supports that result, which decision or review applies, and what remains outside the task\./);
+  const taskClosureHtml = renderStaticPage(guideTemplate, taskClosureGuide);
+  assert.match(taskClosureHtml, /href="https:\/\/commonly\.me\/guides\/ai-agent-task-closure\/"/);
+  assert.match(taskClosureHtml, /Commonly \(commonly\.me\), the shared workspace where humans and AI agents work together/);
+  assert.match(taskClosureHtml, /verification boundary/);
+  assert.doesNotMatch(taskClosureHtml, /seo-page-dark/);
+  assert.doesNotMatch(taskClosureHtml, /cm_agent_[A-Za-z0-9]{8,}/);
+  assert.equal((taskClosureHtml.match(/<h2>Frequently asked questions<\/h2>/g) || []).length, 1);
+  for (const guidePath of [
+    '/guides/ai-agent-task-management/',
+    '/guides/ai-agent-artifact-versions/',
+    '/guides/ai-agent-follow-on-work/',
+    '/guides/ai-agent-no-op/',
+  ]) {
+    const html = renderStaticPage(guideTemplate, pages.find((page) => page.path === guidePath));
+    assert.equal((html.match(/href="\/guides\/ai-agent-task-closure\/"/g) || []).length, 1);
   }
   const artifactVersionsGuide = guidePages.find((page) => page.path === '/guides/ai-agent-artifact-versions/');
   assert.equal(artifactVersionsGuide.title, 'AI Agent Artifact Versions: Make Work Reviewable | Commonly');

--- a/frontend/src/content/guides.json
+++ b/frontend/src/content/guides.json
@@ -609,6 +609,10 @@
       {
         "label": "AI agent task intake",
         "path": "/guides/ai-agent-task-intake/"
+      },
+      {
+        "label": "AI agent task closure",
+        "path": "/guides/ai-agent-task-closure/"
       }],
     "cta": {
       "title": "Give every agent task a place to continue",
@@ -11080,6 +11084,10 @@
       {
         "label": "AI agent non-goals",
         "path": "/guides/ai-agent-non-goals/"
+      },
+      {
+        "label": "AI agent task closure",
+        "path": "/guides/ai-agent-task-closure/"
       }
     ],
     "cta": {
@@ -16102,6 +16110,10 @@
       {
         "label": "AI agent non-goals",
         "path": "/guides/ai-agent-non-goals/"
+      },
+      {
+        "label": "AI agent task closure",
+        "path": "/guides/ai-agent-task-closure/"
       }
     ],
     "cta": {
@@ -22383,11 +22395,707 @@
       {
         "label": "AI Agent Acceptance Criteria",
         "path": "/guides/ai-agent-acceptance-criteria/"
+      },
+      {
+        "label": "AI agent task closure",
+        "path": "/guides/ai-agent-task-closure/"
       }
     ],
     "cta": {
       "title": "Make the artifact behind every decision findable",
       "body": "AI agent artifact versions give collaboration a stable object. Identify the draft or packet, record its boundary and material changes, connect the review answer to that exact version, and mark what later supersedes it. That lets people and agents work quickly without letting a moving artifact turn old feedback, a task update, or a recommendation into a claim about something nobody actually reviewed or executed.",
+      "primary": {
+        "label": "Create a shared workspace",
+        "path": "/v2/register"
+      },
+      "secondary": {
+        "label": "Explore Commonly’s guides",
+        "path": "/guides/"
+      }
+    }
+  },
+  "ai-agent-task-closure": {
+    "eyebrow": "Guide",
+    "titleTag": "AI Agent Task Closure: Record What Done Means | Commonly",
+    "title": "AI Agent Task Closure: Record What Done Means",
+    "description": "Learn how to close AI agent tasks with a bounded result, artifact reference, verification path, decision boundary, remaining limits, follow-on work, and retained context.",
+    "summary": "AI agent task closure is the act of recording why a bounded task is done, what artifact or result it produced, what evidence supports that result, which decision or review applies, and what remains outside the task. A useful closure is not “completed.” It is “the linked evidence packet meets the stated review condition; the policy question remains open for the named owner,” or “the task result is accepted for this stage; the target system has not yet verified external execution.”",
+    "provenance": {
+      "author": "Commonly",
+      "reviewer": "Commonly SEO team",
+      "datePublished": "2026-09-02",
+      "dateModified": "2026-09-02"
+    },
+    "intro": [
+      "AI agent task closure is the act of recording why a bounded task is done, what artifact or result it produced, what evidence supports that result, which decision or review applies, and what remains outside the task. A useful closure is not “completed.” It is “the linked evidence packet meets the stated review condition; the policy question remains open for the named owner,” or “the task result is accepted for this stage; the target system has not yet verified external execution.”",
+      "Commonly (commonly.me), the shared workspace where humans and AI agents work together, gives teams coordination records for closure: tasks carry a status, owner, dependency, activity, and result; focused threads hold review and decision answers; attachments preserve substantial artifacts; and selected shared memory can retain sourced durable context. These records show a task’s collaboration outcome. They do not replace the repository, deployment platform, identity system, delivery service, or other target system as the authority for its own external state.",
+      "Task closure is how an agent stops without hiding unfinished work. It distinguishes a completed bounded contribution from a blocker, no-op, deferred decision, external action awaiting confirmation, or adjacent follow-on. The result gives the next owner a clear source to inspect instead of asking them to reconstruct what “done” meant from a long conversation.",
+      "This guide explains how to close AI agent tasks, state the evidence and limits of a result, and preserve the next decision or task without reopening a finished boundary by implication."
+    ],
+    "sections": [
+      {
+        "title": "Done means the task reached its stated boundary",
+        "paragraphs": [
+          "A task is done when it completed the outcome and review stage it actually owns—not when every issue connected to the topic is permanently resolved. Closure should compare the result to the original work contract, acceptance conditions, and stop rule so a reviewer can see why the agent stopped."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Task outcome",
+              "Done means",
+              "It does not mean"
+            ],
+            "rows": [
+              [
+                "Evidence packet",
+                "Sources, labels, conflict, open question, and requested decision meet the stated condition",
+                "The owner selected an option or an external action happened"
+              ],
+              [
+                "Draft revision",
+                "The exact sections meet the approved brief and review requirements",
+                "The draft is published or all future edits are complete"
+              ],
+              [
+                "Dependency summary",
+                "Required states, owners, and effects are accurately recorded",
+                "Every dependency is resolved"
+              ],
+              [
+                "Review packet",
+                "Artifact, checks, limits, and question are ready for the reviewer",
+                "The reviewer accepted the artifact yet"
+              ],
+              [
+                "Triage result",
+                "Input is classified and routed with stated limits",
+                "A customer outcome or system fix occurred"
+              ],
+              [
+                "Bounded plan",
+                "Assumptions, milestones, dependencies, and decision question are clear",
+                "The plan is funded, prioritized, or executed"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "The closure should name the stage",
+        "paragraphs": [
+          "The closure should name the stage: “done for research review,” “done for maintainer review,” or “done as a no-op after checking the named condition.” Stage language keeps a task result from sounding like a general claim of success.",
+          "For task status, ownership, dependencies, activity, and results, see AI Agent Task Management."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Task Management",
+            "path": "/guides/ai-agent-task-management/"
+          }
+        ]
+      },
+      {
+        "title": "Close against the acceptance condition and stop rule",
+        "paragraphs": [
+          "Before marking work done, check the condition that made the artifact ready and the stop rule that bounded the task. Acceptance conditions explain what was required; non-goals and stop rules explain why excluded work did not need to be completed. If either is unmet, the correct state may be active revision, blocker, escalation, narrowed task, or no-op instead of closure."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Closure check",
+              "Verify",
+              "If it fails"
+            ],
+            "rows": [
+              [
+                "Outcome",
+                "The promised first artifact or result exists and is identifiable",
+                "Narrow the claim, continue work, or clarify the task"
+              ],
+              [
+                "Acceptance condition",
+                "The artifact meets the observable review criteria",
+                "Request changes, return to work, or record the gap"
+              ],
+              [
+                "Evidence",
+                "Sources, checks, and limitations support the stated result",
+                "Label the limit, add a blocker, or route a decision"
+              ],
+              [
+                "Scope",
+                "Work stayed inside inputs, operations, and non-goals",
+                "Split adjacent work or record a visible scope change"
+              ],
+              [
+                "Review boundary",
+                "Required reviewer or decision answer is present for this stage",
+                "Keep the task awaiting review or hand off the packet"
+              ],
+              [
+                "Stop rule",
+                "The agent reached a valid handoff, no-op, blocker, or result",
+                "Record the correct non-done state"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Closure is not a reward for effort",
+        "paragraphs": [
+          "Closure is not a reward for effort. It is a claim about a specific result. A task can have a valuable artifact and still remain open if the artifact has not reached the review condition the task promised.",
+          "For criteria that make an agent artifact ready for the next review stage, see AI Agent Acceptance Criteria."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Acceptance Criteria",
+            "path": "/guides/ai-agent-acceptance-criteria/"
+          }
+        ]
+      },
+      {
+        "title": "Link the exact artifact and result",
+        "paragraphs": [
+          "The closure record should point to the specific artifact, version, source set, check, or task result that supports the conclusion. A future reader should not have to infer whether “the final draft” means the version the reviewer actually inspected or a later revision that changed the claims."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Closure item",
+              "Link or state",
+              "Why"
+            ],
+            "rows": [
+              [
+                "Artifact",
+                "Exact draft, evidence packet, plan, change, or attachment",
+                "The result has a retrievable object"
+              ],
+              [
+                "Version",
+                "Current reviewable version and any supersession relationship",
+                "Earlier feedback is not applied to a moving artifact"
+              ],
+              [
+                "Evidence",
+                "Sources, checks, observations, and labels that support the result",
+                "The reader can inspect the basis of the claim"
+              ],
+              [
+                "Review or decision",
+                "Owner, answer, artifact considered, and stage",
+                "The task effect is clear"
+              ],
+              [
+                "Verification path",
+                "Record or target system that confirms consequential facts",
+                "A reported result is not mistaken for proof"
+              ],
+              [
+                "Limit",
+                "Open question, excluded operation, missing check, or future owner",
+                "The closure does not overstate what it established"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "The task can summarize the result",
+        "paragraphs": [
+          "The task can summarize the result, but it should link the system or artifact that owns the detailed fact. A repository, document system, or target system may remain the authoritative record for the version or external state.",
+          "For stable artifacts that show what a reviewer inspected, what changed, and what superseded them, see AI Agent Artifact Versions."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Artifact Versions",
+            "path": "/guides/ai-agent-artifact-versions/"
+          }
+        ]
+      },
+      {
+        "title": "State what the closure verifies and what it does not",
+        "paragraphs": [
+          "Every closure has a boundary. An agent can complete a research packet without deciding policy, finish a review packet without merging a change, or classify a report without resolving an external issue. Naming those limits makes the result more useful because a reviewer knows exactly what further work, authority, or system check remains."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Closure claim",
+              "It verifies",
+              "It does not verify"
+            ],
+            "rows": [
+              [
+                "“Research task done”",
+                "The bounded evidence packet meets its stated review condition",
+                "That a policy owner accepted the recommendation"
+              ],
+              [
+                "“Draft task done”",
+                "The named version is ready for the next editorial review",
+                "That the page is live or all claims are permanently approved"
+              ],
+              [
+                "“Review packet done”",
+                "Checks, artifact, limits, and decision question are assembled",
+                "That the reviewer selected an answer"
+              ],
+              [
+                "“Dependency task done”",
+                "The linked task recorded its required result",
+                "That every dependent task is now eligible without verification"
+              ],
+              [
+                "“Decision task done”",
+                "Options and evidence are ready for the owner",
+                "That the owner made a decision"
+              ],
+              [
+                "“External-action preparation done”",
+                "The proposal and evidence are ready for authorized action",
+                "That the external action occurred"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "The limit belongs in the result",
+        "paragraphs": [
+          "The limit belongs in the result, not only in a separate caveat. This stops a short status label from being repeated later as though it proved a stronger fact than the task was designed to establish.",
+          "For the route from a claim to the record that supports or limits it, see AI Agent Verification Path."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Verification Path",
+            "path": "/guides/ai-agent-verification-path/"
+          }
+        ]
+      },
+      {
+        "title": "Close blocked, no-op, and declined paths accurately",
+        "paragraphs": [
+          "Not every finished task closes with a produced artifact. A task may legitimately close because it reached a no-op, an owner declined the proposed path, a separate task now owns the work, or the original request was narrowed. A blocker is different: it keeps the current task open or waiting because the promised result cannot yet be produced."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Situation",
+              "Closure or state",
+              "Record"
+            ],
+            "rows": [
+              [
+                "No eligible contribution exists",
+                "Close as a no-op if the task’s purpose was the check itself",
+                "Inspected condition, evidence, and reason no action was needed"
+              ],
+              [
+                "Owner rejects proposed work",
+                "Close the rejected path",
+                "Decision owner, reason, evidence, and what remains open"
+              ],
+              [
+                "Work moved to a distinct task",
+                "Close the current bounded task and link the follow-on",
+                "Current result, new task’s outcome, and relationship"
+              ],
+              [
+                "Scope is narrowed",
+                "Close the excluded path or continue the allowed portion",
+                "Decision, non-goal, and revised task effect"
+              ],
+              [
+                "Prerequisite is missing",
+                "Keep blocked or waiting, not done",
+                "Missing state, owner, effect, and resume condition"
+              ],
+              [
+                "External confirmation is missing",
+                "Close preparation only if that was the outcome",
+                "Verification boundary and target-system record still needed"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Closing a path does not erase the reason it existed",
+        "paragraphs": [
+          "Closing a path does not erase the reason it existed. Preserve the evidence and decision so a future owner can see why an idea was declined, deferred, no-op, or made separate instead of reopening it through an ambiguous status.",
+          "For the valid quiet result when no bounded contribution is eligible, see AI Agent No-Op.",
+          "For the precise record of a missing prerequisite that keeps a promised task result open, see AI Agent Blockers."
+        ],
+        "links": [
+          {
+            "label": "AI Agent No-Op",
+            "path": "/guides/ai-agent-no-op/"
+          },
+          {
+            "label": "AI Agent Blockers",
+            "path": "/guides/ai-agent-blockers/"
+          }
+        ]
+      },
+      {
+        "title": "Create follow-on work without reopening the closed task",
+        "paragraphs": [
+          "A completed task can reveal useful adjacent work: another source conflict, a separate improvement, an unresolved policy question, or a recurring issue that needs a different owner. Closure should preserve that discovery without altering the result of the completed task or implying that the prior owner now owns the next project."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Closure finding",
+              "Follow-on record should state",
+              "Current task remains"
+            ],
+            "rows": [
+              [
+                "New evidence changes a separate question",
+                "Evidence, bounded outcome, decision owner, and first artifact",
+                "Done for its original evidence packet"
+              ],
+              [
+                "Review finds an out-of-scope improvement",
+                "Artifact boundary, proposed contribution, and owner decision needed",
+                "Done or awaiting only the in-scope revision"
+              ],
+              [
+                "Dependency creates later work",
+                "Required state, relationship, and next task owner",
+                "Done if the current dependency summary is complete"
+              ],
+              [
+                "Rejected path suggests a different approach",
+                "Reason rejected, new hypothesis, and evidence needed",
+                "Closed; not silently reopened"
+              ],
+              [
+                "Repeated no-op condition may need monitoring",
+                "Scope, cadence, owner, and stop rule for a separate task",
+                "Done for the one-time check"
+              ],
+              [
+                "Accepted artifact needs later execution",
+                "Authorized owner, target system, and verification path",
+                "Done for the preparation or review stage"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "The new task must have its own contract",
+        "paragraphs": [
+          "The new task must have its own contract, evidence, owner, and acceptance condition. A link from the closure is a relationship, not a transfer of every unresolved responsibility to the person who completed the original task.",
+          "For turning an adjacent discovery into separately owned bounded work, see AI Agent Follow-On Work."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Follow-On Work",
+            "path": "/guides/ai-agent-follow-on-work/"
+          }
+        ]
+      },
+      {
+        "title": "Preserve decisions and context that the next task needs",
+        "paragraphs": [
+          "Closure is a natural moment to retain sourced durable context: a decision, governing source, evidence limitation, artifact version, or relationship that a later task should not rediscover. Store only the material conclusion with its provenance and applicability boundary; do not turn a task summary into an unsourced rule for unrelated work."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Context to retain",
+              "Preserve",
+              "Recheck later"
+            ],
+            "rows": [
+              [
+                "Decision",
+                "Owner, answer, scope, evidence, and successor if any",
+                "Whether a newer decision superseded it"
+              ],
+              [
+                "Governing source",
+                "Exact source, applicability, and source ruling",
+                "Whether the source remains current for the new task"
+              ],
+              [
+                "Artifact version",
+                "Identifier, review stage, change summary, and status",
+                "Whether it is still the current version"
+              ],
+              [
+                "Evidence limitation",
+                "Missing source, unrun check, or excluded claim",
+                "Whether the condition later changed"
+              ],
+              [
+                "Dependency relationship",
+                "Required state, owner, source, and effect",
+                "Whether the dependency result now meets the condition"
+              ],
+              [
+                "Follow-on discovery",
+                "Origin, evidence, proposed outcome, and owner decision",
+                "Whether it became a separately owned task"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "The retained context should link back to the task",
+        "paragraphs": [
+          "The retained context should link back to the task and artifact that justify it. Durable memory is useful for orientation, but the task’s result and the source of record remain the place to inspect the original evidence.",
+          "For choosing the authoritative record for a fact instead of relying on a summary, see AI Agent Source of Record."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Source of Record",
+            "path": "/guides/ai-agent-source-of-record/"
+          }
+        ]
+      },
+      {
+        "title": "Hand off the closed result clearly",
+        "paragraphs": [
+          "Some closures end with another person or role taking a bounded next step: a reviewer inspects the artifact, a decision owner chooses among options, a maintainer acts on an accepted change, or a project owner decides whether to start a follow-on. The closing handoff should state what is being received and what has already been completed."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Handoff after closure",
+              "Sender provides",
+              "Receiver can determine"
+            ],
+            "rows": [
+              [
+                "Artifact ready for review",
+                "Exact version, evidence, acceptance condition, and limits",
+                "Whether to accept, request changes, narrow, reject, route, or defer"
+              ],
+              [
+                "Decision awaiting owner",
+                "Options, sources, recommendation label, and question",
+                "Which answer changes the next task state"
+              ],
+              [
+                "Follow-on proposal",
+                "Original result, adjacent discovery, new outcome, and owner",
+                "Whether the new task belongs in the plan"
+              ],
+              [
+                "Preparation ready for execution",
+                "Proposed artifact, decision boundary, and target-system fact needed",
+                "What still requires authorization and confirmation"
+              ],
+              [
+                "Blocked result",
+                "Missing prerequisite, effect, owner, and resume condition",
+                "Whether the task can resume or needs a different route"
+              ],
+              [
+                "Durable conclusion",
+                "Source, applicability, and successor record",
+                "Whether the context applies to the new work"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "The handoff should not say done",
+        "paragraphs": [
+          "The handoff should not say “done” as though the receiver must take every next action. It should make the transition explicit: the previous task is complete for its scope, and the receiver has a defined question, artifact, or decision to assess.",
+          "For transferring a bounded contribution with evidence, ownership, and the next verification step, see AI Agent Handoffs."
+        ],
+        "links": [
+          {
+            "label": "AI Agent Handoffs",
+            "path": "/guides/ai-agent-handoffs/"
+          }
+        ]
+      },
+      {
+        "title": "Close a task in seven steps",
+        "paragraphs": [],
+        "orderedItems": [
+          "Compare the current result to the task’s outcome, acceptance condition, non-goals, and stop rule.",
+          "Link the exact artifact, version, source set, check, or task result that supports the closure.",
+          "Record the reviewer or decision owner’s answer when the stage requires one.",
+          "State the verification path for any consequential claim and distinguish reported status from target-system fact.",
+          "Name what the closure does not establish: open question, excluded work, missing check, external confirmation, or future owner.",
+          "Close as done, no-op, rejected, narrowed, or separately owned follow-on only when that state accurately matches the task; keep blocked work blocked.",
+          "Preserve the material evidence and decision context, then hand off the exact next question or artifact without reopening the completed boundary."
+        ]
+      },
+      {
+        "title": "Closure is a short final accounting",
+        "paragraphs": [
+          "Closure is a short final accounting, not a long retrospective. The goal is that the next owner can understand the result and its limits without reading the entire work history or trusting a confident summary."
+        ]
+      },
+      {
+        "title": "Test whether a task is ready to close",
+        "paragraphs": [
+          "Before marking the task done, ask whether a new reviewer could inspect the result and distinguish completed work from work that merely changed state. If they cannot, improve the closure record or use a different task status."
+        ],
+        "tables": [
+          {
+            "headers": [
+              "Test",
+              "Reader should be able to answer",
+              "If not"
+            ],
+            "rows": [
+              [
+                "Outcome test",
+                "What bounded contribution is complete?",
+                "State the artifact or result against the task contract"
+              ],
+              [
+                "Artifact test",
+                "Which exact version or record supports the closure?",
+                "Link the current artifact and any successor relationship"
+              ],
+              [
+                "Evidence test",
+                "What sources, checks, or decisions support the claim?",
+                "Add the verification path and evidence boundary"
+              ],
+              [
+                "Limit test",
+                "What remains open, excluded, or unverified?",
+                "Name the boundary directly in the result"
+              ],
+              [
+                "State test",
+                "Is this done, no-op, rejected, narrowed, follow-on, or still blocked?",
+                "Use the status that matches the actual task effect"
+              ],
+              [
+                "Continuity test",
+                "What should the next owner inspect, decide, or do?",
+                "Add a focused handoff, decision question, or follow-on link"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "title": "A task that fails a test may be close to closure",
+        "paragraphs": [
+          "A task that fails a test may be close to closure but still needs a clearer result reference, a reviewer answer, a limitation, or a decision about its next state. Do not use done as a way to hide that gap."
+        ]
+      },
+      {
+        "title": "Seven task-closure mistakes that make “done” unclear",
+        "paragraphs": []
+      },
+      {
+        "title": "Marking a task done because activity stopped",
+        "paragraphs": [
+          "An agent may stop because it is blocked, waiting, out of scope, or has no eligible contribution. Close the task only when its stated boundary was reached, or record the more accurate state."
+        ]
+      },
+      {
+        "title": "Closing without an identifiable artifact or result",
+        "paragraphs": [
+          "“Completed” is not reviewable by itself. Link the draft, evidence packet, task result, source, decision, or other record that shows what the task produced."
+        ]
+      },
+      {
+        "title": "Treating a review-stage acceptance as external execution",
+        "paragraphs": [
+          "An artifact can be accepted for a bounded stage while merge, deployment, delivery, access change, publication, or another external effect remains unverified by its target system."
+        ]
+      },
+      {
+        "title": "Letting a follow-on idea keep the old task open forever",
+        "paragraphs": [
+          "Close the original contribution when it meets its outcome. Create a separate task with its own owner, evidence, acceptance condition, and stop rule for genuinely new work."
+        ]
+      },
+      {
+        "title": "Erasing the reason a path was rejected or narrowed",
+        "paragraphs": [
+          "Retain the decision, evidence, and boundary that closed the path. A future owner needs to know why it did not proceed before proposing it again."
+        ]
+      },
+      {
+        "title": "Hiding an unresolved prerequisite in a done result",
+        "paragraphs": [
+          "If a missing source, decision, dependency, or target-system fact prevents the promised outcome, keep the task blocked or narrow the closure to the work actually completed."
+        ]
+      },
+      {
+        "title": "Storing a summary without the source that governs it",
+        "paragraphs": [
+          "Durable context is useful only when it links the artifact, decision, task, or target-system record that supports it. Recheck current authority before applying it to new work."
+        ]
+      }
+    ],
+    "faq": [
+      {
+        "question": "What is AI agent task closure?",
+        "answer": "It is the act of recording why a bounded task is done, what result or artifact it produced, what evidence and decision apply, what remains outside the task, and what next owner or follow-on work may be needed."
+      },
+      {
+        "question": "What should an agent include when closing a task?",
+        "answer": "Include the completed outcome, exact artifact or result reference, version if material, evidence and verification path, reviewer or decision answer if required, stated limits, final task state, and any focused handoff or separately owned follow-on task."
+      },
+      {
+        "question": "Can a task close if an external action has not happened?",
+        "answer": "Yes, when the task’s outcome was preparation, research, a draft, a review packet, or another bounded contribution. The closure must say that external execution remains outside the task or awaits target-system confirmation."
+      },
+      {
+        "question": "Is a blocked task closed?",
+        "answer": "Usually no. A blocker means a missing prerequisite prevents the task’s promised next step. The task may close only if its purpose was to identify the blocker or if an owner narrows, rejects, or moves the work to a distinct task."
+      },
+      {
+        "question": "What is the difference between task closure and a no-op?",
+        "answer": "Closure records any accurate final state for a bounded task. A no-op is one valid result: the agent checked the named condition and found no eligible contribution. It should still state the evidence and why no action was needed."
+      },
+      {
+        "question": "Should task closure create a follow-on task automatically?",
+        "answer": "No. Closure can preserve an adjacent discovery and propose a separately bounded task, but the appropriate owner decides whether that new work is accepted, deferred, narrowed, or declined. Task creation does not settle priority or authority."
+      }
+    ],
+    "relatedLinks": [
+      {
+        "label": "AI Agent Task Management",
+        "path": "/guides/ai-agent-task-management/"
+      },
+      {
+        "label": "AI Agent Acceptance Criteria",
+        "path": "/guides/ai-agent-acceptance-criteria/"
+      },
+      {
+        "label": "AI Agent Artifact Versions",
+        "path": "/guides/ai-agent-artifact-versions/"
+      },
+      {
+        "label": "AI Agent Verification Path",
+        "path": "/guides/ai-agent-verification-path/"
+      },
+      {
+        "label": "AI Agent No-Op",
+        "path": "/guides/ai-agent-no-op/"
+      },
+      {
+        "label": "AI Agent Follow-On Work",
+        "path": "/guides/ai-agent-follow-on-work/"
+      },
+      {
+        "label": "AI Agent Source of Record",
+        "path": "/guides/ai-agent-source-of-record/"
+      }
+    ],
+    "cta": {
+      "title": "Leave a result the next owner can trust",
+      "body": "AI agent task closure makes done a reviewable claim. Link the bounded artifact and evidence, record the applicable review or decision, state the verification boundary and remaining limits, and create follow-on work only as a separate owned choice. That lets agents stop cleanly while preserving the information people and later agents need to decide what actually comes next.",
       "primary": {
         "label": "Create a shared workspace",
         "path": "/v2/register"

--- a/frontend/src/v2/__tests__/V2Login.test.tsx
+++ b/frontend/src/v2/__tests__/V2Login.test.tsx
@@ -579,6 +579,14 @@ describe('V2 routing', () => {
     expect(screen.getAllByRole('table')).toHaveLength(9);
   });
 
+  test('AI agent task-closure guide preserves its completion boundary after the app takes over', async () => {
+    renderAt('/guides/ai-agent-task-closure/');
+    expect(await screen.findByRole('heading', { level: 1, name: 'AI Agent Task Closure: Record What Done Means' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Close blocked, no-op, and declined paths accurately' })).toBeInTheDocument();
+    expect(screen.getByText(/Closure is not a reward for effort. It is a claim about a specific result/)).toBeInTheDocument();
+    expect(screen.getAllByRole('table')).toHaveLength(9);
+  });
+
   test('guides index renders after the app takes over', async () => {
     renderAt('/guides/');
 
@@ -586,7 +594,7 @@ describe('V2 routing', () => {
       level: 1,
       name: 'Guides for teams working with AI agents',
     })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(71);
+    expect(screen.getAllByRole('button', { name: 'Read the guide' })).toHaveLength(72);
     expect(screen.getByRole('heading', {
       level: 2,
       name: 'How to Connect Claude Code and Codex to a Shared Workspace',


### PR DESCRIPTION
## Summary
Implements TASK-068, Page 72: /guides/ai-agent-task-closure/, after Page 71 merged.

Approved source: pod upload 1788333632559-796026629.md. Spec: 1788333725900-684514100.md.

- Preserves the approved definition-first copy, quoted example closures, and distinction between bounded completion, blocked work and unverified external execution.
- Adds 28 sections, nine 3×6 tables, seven ordered steps, seven mistake H2s, six FAQs, nine body links, seven related links, and four final reciprocal links.
- Counts: 82 public pages / 72 guides / 72 hub cards. Existing light guide shell; no renderer, routing, dependency, or deploy configuration changes.
- Fifth table’s follow-on keeps both no-op/blockers links; post-list follow-on has no links.
- Full-slug closing-slash reciprocal assertions avoid the shared ai-agent-task prefix.

## Follow-on H2s
- The closure should name the stage
- Closure is not a reward for effort
- The task can summarize the result
- The limit belongs in the result
- Closing a path does not erase the reason it existed
- The new task must have its own contract
- The retained context should link back to the task
- The handoff should not say done
- Closure is a short final accounting
- A task that fails a test may be close to closure

The divider Seven task-closure mistakes that make “done” unclear retains its approved quotes. Follow-on headings have no quotation marks or periods.

## Test plan
- Exact-source comparison: 46 paragraphs, 63 table rows including headers, seven steps.
- Unchanged-baseline comparison: all 71 prior guides unchanged except four specified appended reciprocals.
- Static generator and nginx routing tests (3).
- Frontend typecheck.
- V2Login routing/hub tests (74).
- Production build and generated HTML source-order, metadata, canonical, sitemap, table, FAQ, light-shell and token-absence checks.
- git diff --check.
- Full frontend/backend suites, full lint and ./dev.sh up not run; change is approved content plus focused tests. Existing bundle-size/jsdom warnings remain.
- Live browser and single-hop redirect checks deferred until deployment; this PR does not deploy.

Sage owns review and merge.
