### PR TITLE
fix: keep pod focus board rooms synchronized

### DIFF
--- a/frontend/src/context/SocketContext.integration.test.tsx
+++ b/frontend/src/context/SocketContext.integration.test.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React from 'react';
+import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { SocketProvider, useSocket } from './SocketContext';
@@ -12,13 +12,27 @@ jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn() }));
 
 let container;
 let root;
+let socketHandlers;
+
+const RoomConsumer = ({ podId = '42' }) => {
+  const { joinPod, leavePod } = useSocket();
+  useEffect(() => {
+    joinPod(podId);
+    return () => leavePod(podId);
+  }, [podId, joinPod, leavePod]);
+  return null;
+};
 
 beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = ReactDOM.createRoot(container);
   const emit = jest.fn();
-  const on = jest.fn((event, cb) => { if(event==='connect') cb(); });
+  socketHandlers = {};
+  const on = jest.fn((event, cb) => {
+    socketHandlers[event] = cb;
+    if (event === 'connect') cb();
+  });
   const disconnect = jest.fn();
   io.mockReturnValue({ emit, on, disconnect });
   useAuth.mockReturnValue({ token: 't', currentUser: { _id: 'u1' } });
@@ -38,10 +52,50 @@ test('joinPod and sendMessage emit events', () => {
   });
 
   act(() => { value.joinPod('42'); });
-  expect(io.mock.results[0].value.emit).toHaveBeenCalledWith('joinPod', '42');
+  expect(io.mock.results[io.mock.results.length - 1].value.emit).toHaveBeenCalledWith('joinPod', '42');
 
   act(() => { value.sendMessage('42', 'hi'); });
-  expect(io.mock.results[0].value.emit).toHaveBeenCalledWith('sendMessage', {
+  expect(io.mock.results[io.mock.results.length - 1].value.emit).toHaveBeenCalledWith('sendMessage', {
     podId: '42', content: 'hi', messageType: 'text', userId: 'u1'
   });
+});
+
+test('keeps a shared pod room until its last mounted consumer leaves', () => {
+  const Rooms = ({ first, second }) => (
+    <SocketProvider>
+      {first && <RoomConsumer />}
+      {second && <RoomConsumer />}
+    </SocketProvider>
+  );
+  act(() => {
+    root.render(<Rooms first second={false} />);
+  });
+  const socket = io.mock.results[io.mock.results.length - 1].value;
+  expect(socket.emit).toHaveBeenCalledWith('joinPod', '42');
+
+  expect(socket.emit).toHaveBeenCalledTimes(1);
+  act(() => { root.render(<Rooms first second />); });
+  expect(socket.emit).toHaveBeenCalledTimes(1);
+
+  act(() => { root.render(<Rooms first second={false} />); });
+  expect(socket.emit).not.toHaveBeenCalledWith('leavePod', '42');
+  act(() => { root.render(<Rooms first={false} second={false} />); });
+  expect(socket.emit).toHaveBeenCalledWith('leavePod', '42');
+});
+
+test('re-joins rooms after a socket reconnect', () => {
+  act(() => {
+    root.render(<SocketProvider><RoomConsumer /></SocketProvider>);
+  });
+  const socket = io.mock.results[io.mock.results.length - 1].value;
+  expect(socket.emit).toHaveBeenCalledWith('joinPod', '42');
+
+  // Keep both callbacks in one React batch: if reconnect happens before a
+  // connected=false render, the provider's connect handler itself must restore
+  // the room rather than relying on the consumer effect to re-run.
+  act(() => {
+    socketHandlers.disconnect('transport close');
+    socketHandlers.connect();
+  });
+  expect(socket.emit.mock.calls.filter(([event, podId]) => event === 'joinPod' && podId === '42')).toHaveLength(2);
 });

--- a/frontend/src/context/SocketContext.tsx
+++ b/frontend/src/context/SocketContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { useAuth } from './AuthContext';
 import axios from 'axios';
@@ -32,6 +32,12 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
   const [connected, setConnected] = useState(false);
   const [pgAvailable, setPgAvailable] = useState(false);
   const { token, currentUser } = useAuth();
+  // Socket rooms are owned by the shared connection, while consumers mount
+  // independently (board, chat, and detail can all observe one pod). Keep a
+  // small ownership count so one consumer cannot evict another consumer's
+  // room membership during cleanup.
+  const podConsumerCountsRef = useRef<Map<string, number>>(new Map());
+  const joinedPodsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     const checkPgAvailability = async () => {
@@ -82,10 +88,35 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
         randomizationFactor: 0.5,
       });
 
-      newSocket.on('connect', () => { setConnected(true); });
-      newSocket.on('connect_error', (error: Error) => { console.error('Socket connection error:', error.message); setConnected(false); });
-      newSocket.on('disconnect', (reason: string) => { console.log('Socket disconnected, reason:', reason); setConnected(false); });
-      newSocket.on('error', (error: unknown) => { console.error('Socket error:', error); setConnected(false); });
+      newSocket.on('connect', () => {
+        // A reconnect drops server-side rooms even when React never observed
+        // a render between disconnect and connect. Restore every live owner.
+        joinedPodsRef.current.clear();
+        podConsumerCountsRef.current.forEach((owners, podId) => {
+          if (owners > 0) {
+            newSocket.emit('joinPod', podId);
+            joinedPodsRef.current.add(podId);
+          }
+        });
+        setConnected(true);
+      });
+      newSocket.on('connect_error', (error: Error) => {
+        console.error('Socket connection error:', error.message);
+        joinedPodsRef.current.clear();
+        setConnected(false);
+      });
+      newSocket.on('disconnect', (reason: string) => {
+        console.log('Socket disconnected, reason:', reason);
+        // Socket.IO drops all server-side rooms on disconnect. Forget local
+        // ownership too so the next connected effect emits a fresh join.
+        joinedPodsRef.current.clear();
+        setConnected(false);
+      });
+      newSocket.on('error', (error: unknown) => {
+        console.error('Socket error:', error);
+        joinedPodsRef.current.clear();
+        setConnected(false);
+      });
 
       // Backoff 30sn'ye kadar çıkabildiği için, kullanıcı sekmeye döndüğünde ya
       // da ağ geri geldiğinde bir sonraki denemeyi beklemek yerine hemen bağlan.
@@ -104,18 +135,38 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
         document.removeEventListener('visibilitychange', onVisible);
         window.removeEventListener('online', reconnectNow);
         window.removeEventListener('focus', reconnectNow);
+        joinedPodsRef.current.clear();
+        podConsumerCountsRef.current.clear();
+        setSocket((current) => (current === newSocket ? null : current));
+        setConnected(false);
         newSocket.disconnect();
       };
     }
   }, [token, currentUser?._id]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const joinPod = (podId: string): void => {
-    if (socket && connected && podId) socket.emit('joinPod', podId);
-  };
+  const joinPod = useCallback((podId: string): void => {
+    if (!podId) return;
+    const owners = podConsumerCountsRef.current.get(podId) || 0;
+    podConsumerCountsRef.current.set(podId, owners + 1);
+    if (socket && connected && !joinedPodsRef.current.has(podId)) {
+      socket.emit('joinPod', podId);
+      joinedPodsRef.current.add(podId);
+    }
+  }, [socket, connected]);
 
-  const leavePod = (podId: string): void => {
-    if (socket && connected && podId) socket.emit('leavePod', podId);
-  };
+  const leavePod = useCallback((podId: string): void => {
+    if (!podId) return;
+    const owners = podConsumerCountsRef.current.get(podId) || 0;
+    if (owners <= 1) {
+      podConsumerCountsRef.current.delete(podId);
+      if (socket && connected && joinedPodsRef.current.has(podId)) {
+        socket.emit('leavePod', podId);
+        joinedPodsRef.current.delete(podId);
+      }
+      return;
+    }
+    podConsumerCountsRef.current.set(podId, owners - 1);
+  }, [socket, connected]);
 
   const sendMessage = (
     podId: string,

--- a/frontend/src/v2/__tests__/V2PodBoard.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodBoard.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import V2PodBoard from '../components/V2PodBoard';
 import { AuthContext } from '../../context/AuthContext';
 
-let mockSocketValue = { socket: null, connected: false };
+let mockSocketValue = { socket: null, connected: false, joinPod: jest.fn(), leavePod: jest.fn() };
 jest.mock('../../context/SocketContext', () => ({
   useSocket: () => mockSocketValue,
 }));
@@ -72,7 +72,7 @@ const wireAxios = (tasks = TASKS) => {
   });
 };
 
-const renderBoard = (entry = '/v2/pods/pod-1/board') => render(
+const boardTree = (entry = '/v2/pods/pod-1/board') => (
   <AuthContext.Provider value={authValue}>
     <MemoryRouter initialEntries={[entry]}>
       <Routes>
@@ -80,8 +80,10 @@ const renderBoard = (entry = '/v2/pods/pod-1/board') => render(
         <Route path="/v2/pods/:podId" element={<div>chat page</div>} />
       </Routes>
     </MemoryRouter>
-  </AuthContext.Provider>,
+  </AuthContext.Provider>
 );
+
+const renderBoard = (entry = '/v2/pods/pod-1/board') => render(boardTree(entry));
 
 const SwitchPod = () => {
   const navigate = useNavigate();
@@ -102,7 +104,7 @@ const renderNavigableBoard = () => render(
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockSocketValue = { socket: null, connected: false };
+  mockSocketValue = { socket: null, connected: false, joinPod: jest.fn(), leavePod: jest.fn() };
   wireAxios();
 });
 
@@ -174,6 +176,8 @@ describe('V2PodBoard', () => {
 
   test('refetches when a task_updated socket event lands for this pod', async () => {
     const handlers = {};
+    const joinPod = jest.fn();
+    const leavePod = jest.fn();
     mockSocketValue = {
       socket: {
         on: (event, fn) => { handlers[event] = fn; },
@@ -181,6 +185,8 @@ describe('V2PodBoard', () => {
         emit: jest.fn(),
       },
       connected: true,
+      joinPod,
+      leavePod,
     };
     renderBoard();
     await screen.findByRole('region', { name: 'Pending' });
@@ -197,6 +203,58 @@ describe('V2PodBoard', () => {
       const focusCallsAfter = axios.get.mock.calls.filter(([url]) => url.endsWith('/focus')).length;
       expect(focusCallsAfter).toBeGreaterThan(focusCallsBefore);
     });
+  });
+
+  test('joins the current pod room and hands ownership across navigation', async () => {
+    const handlers = {};
+    const joinPod = jest.fn();
+    const leavePod = jest.fn();
+    mockSocketValue = {
+      socket: {
+        on: (event, fn) => { handlers[event] = fn; },
+        off: jest.fn(),
+        emit: jest.fn(),
+      },
+      connected: true,
+      joinPod,
+      leavePod,
+    };
+    renderNavigableBoard();
+
+    await screen.findByRole('region', { name: 'Pending' });
+    expect(joinPod).toHaveBeenCalledWith('pod-a');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch pod' }));
+    await screen.findByRole('region', { name: 'Pending' });
+    expect(leavePod).toHaveBeenCalledWith('pod-a');
+    expect(joinPod).toHaveBeenCalledWith('pod-b');
+  });
+
+  test('refreshes focus after reconnecting without a visibility change', async () => {
+    const refreshed = { ...FOCUS, revision: 3, focus: { ...FOCUS.focus, goal: 'Reconnected focus' } };
+    let focusCalls = 0;
+    axios.get.mockImplementation((url) => {
+      if (url.endsWith('/focus')) {
+        focusCalls += 1;
+        return Promise.resolve({ data: focusCalls === 1 ? FOCUS : refreshed });
+      }
+      if (url.startsWith('/api/v1/tasks/')) return Promise.resolve({ data: { tasks: TASKS } });
+      if (url.startsWith('/api/pods/')) return Promise.resolve({ data: { name: 'My Workspace' } });
+      return Promise.resolve({ data: {} });
+    });
+    const view = renderBoard();
+    expect(await screen.findByText('Ship the pilot')).toBeInTheDocument();
+    expect(focusCalls).toBe(1);
+
+    mockSocketValue = {
+      socket: { on: jest.fn(), off: jest.fn() },
+      connected: true,
+      joinPod: jest.fn(),
+      leavePod: jest.fn(),
+    };
+    act(() => { view.rerender(boardTree()); });
+    await waitFor(() => expect(screen.getByText('Reconnected focus')).toBeInTheDocument());
+    expect(focusCalls).toBe(2);
   });
 
   test('renders a populated focus and saves an explicit ordered edit', async () => {
@@ -290,12 +348,16 @@ describe('V2PodBoard', () => {
     const refreshed = { ...FOCUS, revision: 3, focus: { ...FOCUS.focus, goal: 'Background update' } };
     let focusCalls = 0;
     const handlers = {};
+    const joinPod = jest.fn();
+    const leavePod = jest.fn();
     mockSocketValue = {
       socket: {
         on: (event, fn) => { handlers[event] = fn; },
         off: jest.fn(),
       },
       connected: true,
+      joinPod,
+      leavePod,
     };
     axios.get.mockImplementation((url) => {
       if (url.endsWith('/focus')) {

--- a/frontend/src/v2/__tests__/V2PodBoard.test.tsx
+++ b/frontend/src/v2/__tests__/V2PodBoard.test.tsx
@@ -242,17 +242,21 @@ describe('V2PodBoard', () => {
       if (url.startsWith('/api/pods/')) return Promise.resolve({ data: { name: 'My Workspace' } });
       return Promise.resolve({ data: {} });
     });
-    const view = renderBoard();
-    expect(await screen.findByText('Ship the pilot')).toBeInTheDocument();
-    expect(focusCalls).toBe(1);
-
+    const handlers = {};
     mockSocketValue = {
-      socket: { on: jest.fn(), off: jest.fn() },
+      socket: {
+        on: (event, fn) => { handlers[event] = fn; },
+        off: jest.fn(),
+      },
       connected: true,
       joinPod: jest.fn(),
       leavePod: jest.fn(),
     };
-    act(() => { view.rerender(boardTree()); });
+    renderBoard();
+    expect(await screen.findByText('Ship the pilot')).toBeInTheDocument();
+    expect(focusCalls).toBe(1);
+
+    act(() => { handlers.connect(); });
     await waitFor(() => expect(screen.getByText('Reconnected focus')).toBeInTheDocument());
     expect(focusCalls).toBe(2);
   });

--- a/frontend/src/v2/components/V2PodBoard.tsx
+++ b/frontend/src/v2/components/V2PodBoard.tsx
@@ -164,7 +164,6 @@ const V2PodBoard: React.FC = () => {
   const closeFocusEditorRef = useRef<() => void>(() => undefined);
   const focusRequestRef = useRef(0);
   const focusMutationRef = useRef(0);
-  const focusWasConnectedRef = useRef(connected);
 
   const openCreateTask = useCallback(() => {
     setCreateError(null);
@@ -238,12 +237,6 @@ const V2PodBoard: React.FC = () => {
   }, [loadFocus]);
 
   useEffect(() => {
-    const wasConnected = focusWasConnectedRef.current;
-    focusWasConnectedRef.current = connected;
-    if (connected && !wasConnected) loadFocus();
-  }, [connected, loadFocus]);
-
-  useEffect(() => {
     if (!focusConflictLatest || !focusRead || focusRead.revision <= focusConflictLatest.revision) return;
     setFocusConflictLatest(focusRead);
     setFocusConflictReviewed(false);
@@ -281,6 +274,13 @@ const V2PodBoard: React.FC = () => {
     socket.on('pod_focus_updated', onFocusUpdated);
     return () => { socket.off('pod_focus_updated', onFocusUpdated); };
   }, [podId, socket, connected, loadFocus]);
+
+  useEffect(() => {
+    if (!socket) return undefined;
+    const onConnect = () => { loadFocus(); };
+    socket.on('connect', onConnect);
+    return () => { socket.off('connect', onConnect); };
+  }, [socket, loadFocus]);
 
   useEffect(() => {
     const onVisibility = () => { if (document.visibilityState === 'visible') loadFocus(); };

--- a/frontend/src/v2/components/V2PodBoard.tsx
+++ b/frontend/src/v2/components/V2PodBoard.tsx
@@ -130,7 +130,7 @@ const V2PodBoard: React.FC = () => {
   const api = useV2Api();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { socket, connected } = useSocket();
+  const { socket, connected, joinPod, leavePod } = useSocket();
 
   const [tasks, setTasks] = useState<BoardTask[]>([]);
   const [podName, setPodName] = useState<string>('');
@@ -164,6 +164,7 @@ const V2PodBoard: React.FC = () => {
   const closeFocusEditorRef = useRef<() => void>(() => undefined);
   const focusRequestRef = useRef(0);
   const focusMutationRef = useRef(0);
+  const focusWasConnectedRef = useRef(connected);
 
   const openCreateTask = useCallback(() => {
     setCreateError(null);
@@ -237,6 +238,12 @@ const V2PodBoard: React.FC = () => {
   }, [loadFocus]);
 
   useEffect(() => {
+    const wasConnected = focusWasConnectedRef.current;
+    focusWasConnectedRef.current = connected;
+    if (connected && !wasConnected) loadFocus();
+  }, [connected, loadFocus]);
+
+  useEffect(() => {
     if (!focusConflictLatest || !focusRead || focusRead.revision <= focusConflictLatest.revision) return;
     setFocusConflictLatest(focusRead);
     setFocusConflictReviewed(false);
@@ -258,6 +265,12 @@ const V2PodBoard: React.FC = () => {
     })();
     return () => { cancelled = true; };
   }, [api, podId]);
+
+  useEffect(() => {
+    if (!podId || !socket || !connected) return undefined;
+    joinPod(podId);
+    return () => { leavePod(podId); };
+  }, [podId, socket, connected, joinPod, leavePod]);
 
   useEffect(() => {
     if (!podId || !socket || !connected) return undefined;


### PR DESCRIPTION
## Summary
- join the Socket.IO pod room from V2PodBoard on mount, navigation, and reconnect
- refcount shared room consumers so board/chat/detail cleanup cannot evict one another
- cover navigation, two-consumer ownership, and reconnect with discriminating tests

## Verification
- frontend focused board + SocketContext tests: 14 passed
- frontend full Jest + static route tests: 102 suites / 795 tests passed
- frontend typecheck and changed-file ESLint passed

Fixes the deployed TASK-129 follow-up where second board tabs stayed at revision 1 despite REST/context revision 2.