### PR TITLE
feat(daemon): support detected adapter configuration edits

### DIFF
--- a/cli/__tests__/adapters.claude.test.mjs
+++ b/cli/__tests__/adapters.claude.test.mjs
@@ -10,6 +10,8 @@
 
 import { jest } from '@jest/globals';
 import { EventEmitter } from 'events';
+import os from 'os';
+import path from 'path';
 
 // Mock child_process.spawnSync used by detect(). We leave `spawn` real so
 // nothing else in the module breaks — the adapter uses `_spawnImpl` instead.
@@ -55,6 +57,10 @@ describe('claude adapter — detect()', () => {
     const res = await claude.detect();
     expect(res).toEqual({ path: '/usr/local/bin/claude', version: '2.5.1' });
     expect(spawnSyncMock).toHaveBeenCalledWith('claude', ['--version'], expect.any(Object));
+    const detectOptions = spawnSyncMock.mock.calls.find(([cmd]) => cmd === 'claude')[2];
+    expect(detectOptions.env.PATH.split(path.delimiter)).toContain(
+      path.join(os.homedir(), '.local', 'bin'),
+    );
   });
 
   test('falls back to `claude` as path when `which` is unavailable (e.g. Windows)', async () => {
@@ -118,6 +124,19 @@ describe('claude adapter — spawn()', () => {
     );
     // Explicit: must NOT use --session-id on resume path — the whole point.
     expect(calls[0].args).not.toContain('--session-id');
+  });
+
+  test('adds ~/.local/bin to the child PATH for launchd environments', async () => {
+    const { impl, calls } = makeSpawnImpl({ stdout: 'ok' });
+    await claude.spawn('hello', {
+      sessionId: 'sid-123',
+      env: { PATH: '/opt/homebrew/bin:/usr/bin' },
+      _spawnImpl: impl,
+    });
+
+    expect(calls[0].opts.env.PATH.split(path.delimiter)).toContain(
+      path.join(os.homedir(), '.local', 'bin'),
+    );
   });
 
   test('self-heals when --resume hits "already in use": retries with fresh UUID + --session-id', async () => {

--- a/cli/__tests__/attach.test.mjs
+++ b/cli/__tests__/attach.test.mjs
@@ -140,6 +140,43 @@ describe('updateAgentConfiguration', () => {
       environment: { model: 'new-model', effort: 'high' },
     });
   });
+
+  test('validates and persists a detected adapter without leaking it into ADR-008 environment', async () => {
+    const client = { patch: jest.fn(async () => ({ success: true })) };
+    const adapter = { detect: jest.fn(async () => ({ path: '/usr/local/bin/claude' })) };
+    const result = await updateAgentConfiguration({
+      client,
+      record,
+      adapter: 'claude',
+      adapterRegistry: {
+        getAdapter: jest.fn((name) => (name === 'claude' ? adapter : null)),
+        listAdapterNames: jest.fn(() => ['claude', 'codex']),
+      },
+    });
+
+    expect(result).toEqual({
+      agentName: 'juno', podId: 'pod-9', instanceId: 'writer', changed: ['runtime'], adapter: 'claude',
+    });
+    expect(adapter.detect).toHaveBeenCalledTimes(1);
+    expect(client.patch).toHaveBeenCalledWith(
+      '/api/registry/pods/pod-9/agents/juno',
+      { instanceId: 'writer', config: { runtime: { adapter: 'claude' } } },
+    );
+  });
+
+  test('rejects an unknown or unavailable adapter before PATCH', async () => {
+    const client = { patch: jest.fn() };
+    const adapter = { detect: jest.fn(async () => null) };
+    const adapterRegistry = {
+      getAdapter: jest.fn((name) => (name === 'claude' ? adapter : null)),
+      listAdapterNames: jest.fn(() => ['claude', 'codex']),
+    };
+    await expect(updateAgentConfiguration({ client, record, adapter: 'unknown', adapterRegistry }))
+      .rejects.toThrow(/Unknown adapter/);
+    await expect(updateAgentConfiguration({ client, record, adapter: 'claude', adapterRegistry }))
+      .rejects.toThrow(/not found on PATH/);
+    expect(client.patch).not.toHaveBeenCalled();
+  });
 });
 
 const makeClient = ({ publishOk = true, runtimeToken = null } = {}) => {

--- a/cli/__tests__/command-registration.test.mjs
+++ b/cli/__tests__/command-registration.test.mjs
@@ -56,7 +56,7 @@ describe('command registration', () => {
     const config = findCommand(registerAll(), ['agent', 'config']);
     expect(config).toBeDefined();
     expect(config.options.map((option) => option.long)).toEqual(expect.arrayContaining([
-      '--model', '--effort', '--env', '--instance',
+      '--adapter', '--model', '--effort', '--env', '--instance',
     ]));
   });
 

--- a/cli/__tests__/daemon-supervisor.test.mjs
+++ b/cli/__tests__/daemon-supervisor.test.mjs
@@ -33,7 +33,7 @@ const boundRow = (over = {}) => ({
   ...over,
 });
 
-const makeHarness = ({ rows, tokens = {}, mintResponses = [] } = {}) => {
+const makeHarness = ({ rows, tokens = {}, mintResponses = [], resolveAdapter = async () => 'claude' } = {}) => {
   const children = [];
   const timers = [];
   const client = {
@@ -58,7 +58,7 @@ const makeHarness = ({ rows, tokens = {}, mintResponses = [] } = {}) => {
     }),
     loadToken: (name) => tokens[name] || null,
     saveToken,
-    resolveAdapter: jest.fn(async () => 'claude'),
+    resolveAdapter: jest.fn(resolveAdapter),
     setTimeoutFn: (fn, ms) => { timers.push({ fn, ms }); return timers.length; },
     clearTimeoutFn: jest.fn(),
   });
@@ -173,6 +173,37 @@ describe('tick', () => {
     expect(children).toHaveLength(1);
     children[0].child.emit('exit', 0);
     // desired stays true → exit handler schedules the respawn.
+  });
+
+  test('a declared adapter change updates the token record and restarts the seat', async () => {
+    let adapter = 'claude';
+    const tokens = { 'wren-test': { agentName: 'wren-test', adapter } };
+    const { supervisor, client, children, saveToken } = makeHarness({
+      rows: () => [boundRow({ runtime: { runtimeType: 'wrapper', adapter } })],
+      tokens,
+      resolveAdapter: async (runtime) => runtime?.adapter || 'claude',
+    });
+    await supervisor.tick();
+    expect(children).toHaveLength(1);
+    expect(saveToken).not.toHaveBeenCalled();
+
+    adapter = 'codex';
+    await supervisor.tick();
+    expect(saveToken).toHaveBeenCalledWith('wren-test', expect.objectContaining({ adapter: 'codex' }));
+    expect(children[0].child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(client.post).not.toHaveBeenCalledWith('/api/agent-binding/runtime-token', expect.anything());
+  });
+
+  test('a declared adapter that resolves to a fallback is rejected without spawning', async () => {
+    const tokens = { 'wren-test': { agentName: 'wren-test', adapter: 'codex' } };
+    const { supervisor, children, saveToken } = makeHarness({
+      rows: () => [boundRow({ runtime: { runtimeType: 'wrapper', adapter: 'claude' } })],
+      tokens,
+      resolveAdapter: async () => 'codex',
+    });
+    await supervisor.tick();
+    expect(children).toHaveLength(0);
+    expect(saveToken).not.toHaveBeenCalled();
   });
 
   test('a row without a model never strips a hand-set environment', async () => {

--- a/cli/__tests__/daemon-supervisor.test.mjs
+++ b/cli/__tests__/daemon-supervisor.test.mjs
@@ -194,6 +194,37 @@ describe('tick', () => {
     expect(client.post).not.toHaveBeenCalledWith('/api/agent-binding/runtime-token', expect.anything());
   });
 
+  test('server runtime row wins when local adapter and model disagree', async () => {
+    let runtime = { runtimeType: 'wrapper', adapter: 'codex', model: 'local-model' };
+    const tokens = {
+      'wren-test': {
+        agentName: 'wren-test',
+        adapter: 'codex',
+        environment: { model: 'local-model' },
+      },
+    };
+    const { supervisor, children, saveToken } = makeHarness({
+      rows: () => [boundRow({ runtime })],
+      tokens,
+      resolveAdapter: async (rowRuntime) => rowRuntime?.adapter || 'claude',
+    });
+
+    await supervisor.tick();
+    expect(children).toHaveLength(1);
+    expect(saveToken).not.toHaveBeenCalled();
+
+    // Adoption/reload is server-authoritative: the next process must consume
+    // the row, never silently preserve stale local adapter/model values.
+    runtime = { runtimeType: 'wrapper', adapter: 'claude', model: 'server-model' };
+    await supervisor.tick();
+
+    expect(saveToken).toHaveBeenCalledWith('wren-test', expect.objectContaining({
+      adapter: 'claude',
+      environment: { model: 'server-model' },
+    }));
+    expect(children[0].child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
   test('a declared adapter that resolves to a fallback is rejected without spawning', async () => {
     const tokens = { 'wren-test': { agentName: 'wren-test', adapter: 'codex' } };
     const { supervisor, children, saveToken } = makeHarness({

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/cli",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/agent.js
+++ b/cli/src/commands/agent.js
@@ -395,27 +395,46 @@ export const setWakeOnMessage = async ({ client, record, enabled }) => {
 export const updateAgentConfiguration = async ({
   client,
   record,
+  adapter = null,
   model = null,
   effort = null,
   envPath = null,
   parseEnv = parseEnvironmentFile,
+  adapterRegistry = { getAdapter, listAdapterNames },
 }) => {
   if (!record?.podId || !record?.agentName) {
     throw new Error('token record is missing podId/agentName — re-attach the agent');
   }
   const instanceId = record.instanceId || 'default';
   const runtime = {};
+  const environmentRuntime = {};
+  if (adapter !== null && adapter !== undefined) {
+    const normalizedAdapter = String(adapter).trim().toLowerCase();
+    const knownAdapters = adapterRegistry.listAdapterNames();
+    const selectedAdapter = adapterRegistry.getAdapter(normalizedAdapter);
+    if (!selectedAdapter || !knownAdapters.includes(normalizedAdapter)) {
+      throw new Error(
+        `Unknown adapter '${normalizedAdapter}'. Known: ${knownAdapters.join(', ')}`,
+      );
+    }
+    if (!await selectedAdapter.detect()) {
+      throw new Error(`Adapter '${normalizedAdapter}' not found on PATH. Install it and retry.`);
+    }
+    runtime.adapter = normalizedAdapter;
+  }
   if (model !== null && model !== undefined) {
     const normalizedModel = String(model);
     const validation = validateEnvironmentSpec({ model: normalizedModel });
     if (!validation.ok) throw new Error(validation.errors.join('; '));
     runtime.model = normalizedModel;
+    environmentRuntime.model = normalizedModel;
   }
   if (effort !== null && effort !== undefined) {
     const normalizedEffort = String(effort);
     const validation = validateEnvironmentSpec({ effort: normalizedEffort });
     if (!validation.ok) throw new Error(validation.errors.join('; '));
     runtime.effort = normalizedEffort;
+    environmentRuntime.effort = normalizedEffort;
   }
   const config = {};
   if (Object.keys(runtime).length) config.runtime = runtime;
@@ -429,15 +448,15 @@ export const updateAgentConfiguration = async ({
   // an ADR-008 environment, a model/effort flag must update that declaration
   // too; otherwise the daemon would correctly prefer the old explicit value
   // over the new legacy runtime overlay.
-  if (environment && Object.keys(runtime).length) {
-    environment = { ...environment, ...runtime };
+  if (environment && Object.keys(environmentRuntime).length) {
+    environment = { ...environment, ...environmentRuntime };
   }
-  if (!environment && Object.keys(runtime).length) {
-    environment = { ...runtime };
+  if (!environment && Object.keys(environmentRuntime).length) {
+    environment = { ...environmentRuntime };
   }
   if (environment) config.environment = environment;
   if (!Object.keys(config).length) {
-    throw new Error('provide at least one of --model, --effort, or --env');
+    throw new Error('provide at least one of --adapter, --model, --effort, or --env');
   }
 
   await client.patch(
@@ -449,6 +468,7 @@ export const updateAgentConfiguration = async ({
     podId: record.podId,
     instanceId,
     changed: Object.keys(config),
+    ...(runtime.adapter ? { adapter: runtime.adapter } : {}),
     ...(environment ? { environment } : {}),
   };
 };
@@ -2077,6 +2097,7 @@ Examples:
 
   # List installed agents
   $ commonly agent list
+  $ commonly agent config my-claude --adapter claude --model gpt-5.4 --effort high
   $ commonly agent config my-claude --model gpt-5.4 --effort high
 
 Docs:
@@ -2704,6 +2725,7 @@ Use --local to find the name you'd pass to 'agent run' or 'agent detach'.
   agent
     .command('config <name>')
     .description('Update an attached agent\'s server-side runtime configuration')
+    .option('--adapter <name>', 'Local runtime adapter (must be installed on this machine)')
     .option('--model <id>', 'Model identifier to use on the next daemon restart')
     .option('--effort <level>', 'Reasoning effort (low|medium|high|xhigh|max)')
     .option('--env <path>', 'Replace the ADR-008 environment spec with this JSON file')
@@ -2722,12 +2744,17 @@ Use --local to find the name you'd pass to 'agent run' or 'agent detach'.
         const result = await updateAgentConfiguration({
           client,
           record,
+          adapter: opts.adapter,
           model: opts.model,
           effort: opts.effort,
           envPath: opts.env ? pathResolve(opts.env) : null,
         });
-        if (result.environment) {
-          saveAgentToken(name, { ...record, environment: result.environment });
+        if (result.environment || result.adapter) {
+          saveAgentToken(name, {
+            ...record,
+            ...(result.environment ? { environment: result.environment } : {}),
+            ...(result.adapter ? { adapter: result.adapter } : {}),
+          });
         }
         console.log(`✓ Updated ${result.agentName} in pod ${result.podId} (${result.changed.join(', ')})`);
         console.log('  The daemon will apply the change on its next poll; a standalone agent run needs a restart.');

--- a/cli/src/lib/adapters/claude.js
+++ b/cli/src/lib/adapters/claude.js
@@ -59,7 +59,7 @@ import {
   writeFile,
 } from 'fs/promises';
 import { homedir, tmpdir } from 'os';
-import { isAbsolute, join } from 'path';
+import { delimiter, isAbsolute, join } from 'path';
 
 import { mountSkills } from '../environment.js';
 import { wrapArgvWithBwrap } from '../sandbox/bwrap.js';
@@ -337,17 +337,39 @@ const createMcpConfig = async (mcpServers, ctx = {}) => {
 
 // ── argv preparation — environment-aware ────────────────────────────────────
 
+// Claude's npm installer commonly puts the binary in ~/.local/bin, while
+// launchd/supervisor environments intentionally use a small PATH. Keep the
+// command name for the legacy spawn contract, but add this directory to the
+// child environment and to every detection lookup so a daemon does not report
+// a false "adapter unavailable" (or hit spawn ENOENT) merely because it was
+// started outside an interactive shell.
+const withClaudePath = (input) => {
+  const output = { ...(input || process.env) };
+  const localBin = join(homedir(), '.local', 'bin');
+  const entries = String(output.PATH || '')
+    .split(delimiter)
+    .filter(Boolean);
+  if (!entries.includes(localBin)) entries.push(localBin);
+  output.PATH = entries.join(delimiter);
+  return output;
+};
+
 // Resolve the absolute path of `claude` so bwrap's execvp doesn't depend on
 // PATH being correctly populated inside the sandbox namespace. Surfaced live
 // during the 2026-04-17 demo validation: bwrap silently inherits parent
 // PATH but cannot reach the user's `~/.local/bin` without an absolute path
 // argv[0], even when that directory is bound read-only into the sandbox.
-const resolveClaudePath = () => {
+const resolveClaudePath = (env = process.env) => {
   // Defensive: spawnSync can return undefined under aggressive mocks (the
   // adapters.claude.environment.test.mjs suite stubs child_process so no real
   // process runs). Treat any failure mode as "use the bare command name."
   let which;
-  try { which = spawnSync('which', ['claude'], { encoding: 'utf8' }); } catch { /* ignore */ }
+  try {
+    which = spawnSync('which', ['claude'], {
+      encoding: 'utf8',
+      env: withClaudePath(env),
+    });
+  } catch { /* ignore */ }
   if (which && which.status === 0) {
     const p = (which.stdout || '').trim();
     if (p) {
@@ -363,7 +385,8 @@ const resolveClaudePath = () => {
 
 const prepareArgv = async (innerArgv, ctx) => {
   const env = ctx.environment;
-  if (!env) return { cmd: 'claude', args: innerArgv, env: ctx.claudeEnv };
+  const claudeEnv = withClaudePath(ctx.claudeEnv);
+  if (!env) return { cmd: 'claude', args: innerArgv, env: claudeEnv };
 
   let allowedPatterns = [];
   if (Array.isArray(env.mcp) && env.mcp.length > 0) {
@@ -407,7 +430,7 @@ const prepareArgv = async (innerArgv, ctx) => {
       ...innerArgv,
       ...buildPublicClaudePolicyArgs(allowedPatterns),
     ];
-    const claudeBin = resolveClaudePath();
+    const claudeBin = resolveClaudePath(claudeEnv);
     const mcpExecutables = (env.mcp || [])
       .map((server) => server?.command?.[0])
       .filter((command) => isAbsolute(command));
@@ -422,7 +445,7 @@ const prepareArgv = async (innerArgv, ctx) => {
     return {
       cmd: wrapped[0],
       args: wrapped.slice(1),
-      env: ctx.claudeEnv,
+      env: claudeEnv,
     };
   }
 
@@ -430,15 +453,15 @@ const prepareArgv = async (innerArgv, ctx) => {
     innerArgv = [...innerArgv, '--allowedTools', ...allowedPatterns];
   }
   if (sandboxMode === 'bwrap') {
-    const claudeBin = resolveClaudePath();
+    const claudeBin = resolveClaudePath(claudeEnv);
     const wrapped = wrapArgvWithBwrap([claudeBin, ...innerArgv], env, {
       workspacePath: ctx.cwd,
       readOnlyPaths: ctx.mcpConfigDir ? [ctx.mcpConfigDir] : [],
     });
-    return { cmd: wrapped[0], args: wrapped.slice(1), env: ctx.claudeEnv };
+    return { cmd: wrapped[0], args: wrapped.slice(1), env: claudeEnv };
   }
 
-  return { cmd: 'claude', args: innerArgv, env: ctx.claudeEnv };
+  return { cmd: 'claude', args: innerArgv, env: claudeEnv };
 };
 
 export default {
@@ -453,14 +476,21 @@ export default {
 
   async detect() {
     try {
-      const res = spawnSync('claude', ['--version'], { encoding: 'utf8' });
+      const claudeEnv = withClaudePath(process.env);
+      const res = spawnSync('claude', ['--version'], {
+        encoding: 'utf8',
+        env: claudeEnv,
+      });
       if (res.error || res.status !== 0) return null;
       // `claude --version` prints e.g. "2.5.1 (Claude Code)" — first token is enough
       const version = (res.stdout || '').trim().split(/\s+/)[0] || 'unknown';
       // Best-effort resolve of the binary path for clearer UX ("claude detected
       // at /usr/local/bin/claude"). Falls back to the bare command name on
       // platforms without `which` (e.g. Windows).
-      const where = spawnSync('which', ['claude'], { encoding: 'utf8' });
+      const where = spawnSync('which', ['claude'], {
+        encoding: 'utf8',
+        env: claudeEnv,
+      });
       const path = where.status === 0 ? (where.stdout || '').trim() || 'claude' : 'claude';
       return { path, version };
     } catch {

--- a/cli/src/lib/daemon-supervisor.js
+++ b/cli/src/lib/daemon-supervisor.js
@@ -133,6 +133,26 @@ export const createDaemonSupervisor = ({
       // once at boot). A row with NO declared model leaves the record alone —
       // never strip an operator's hand-set environment.
       const wanted = environmentFor(row);
+      const declaredAdapter = row.runtime && typeof row.runtime === 'object'
+        && typeof row.runtime.adapter === 'string'
+        ? row.runtime.adapter.trim().toLowerCase()
+        : null;
+      let adapterChanged = false;
+      let nextAdapter = existing.adapter;
+      if (declaredAdapter) {
+        const detectedAdapter = await resolveAdapter(row.runtime || null);
+        // resolveAdapterForRuntime historically probes fallbacks when a
+        // declared adapter is absent. A configuration edit must never accept
+        // that fallback: it would report claude while running codex (or vice
+        // versa). Keep the existing child/token untouched until the exact
+        // requested adapter is detected locally.
+        if (detectedAdapter !== declaredAdapter) {
+          log(`[${row.agentName}] requested adapter '${declaredAdapter}' is not available on this machine — keeping the current seat`);
+          return false;
+        }
+        nextAdapter = declaredAdapter;
+        adapterChanged = existing.adapter !== nextAdapter;
+      }
       if (wanted) {
         const nextEnvironment = wanted.declared
           ? wanted.value
@@ -140,17 +160,36 @@ export const createDaemonSupervisor = ({
         const workspacePath = workspacePathFor(nextEnvironment);
         const nextRecord = {
           ...existing,
+          ...(adapterChanged ? { adapter: nextAdapter } : {}),
           environment: nextEnvironment,
           ...(workspacePath ? { workspacePath } : {}),
         };
-        if (!isDeepStrictEqual(existing.environment || null, nextEnvironment)
+        if (adapterChanged
+          || !isDeepStrictEqual(existing.environment || null, nextEnvironment)
           || (workspacePath && existing.workspacePath !== workspacePath)) {
           saveToken(row.agentName, nextRecord);
           log('runtime config changed — restarting the seat to load it');
           return 'changed';
         }
       }
+      if (adapterChanged) {
+        saveToken(row.agentName, { ...existing, adapter: nextAdapter });
+        log('runtime adapter changed — restarting the seat to load it');
+        return 'changed';
+      }
       return 'ready';
+    }
+    const requestedAdapter = row.runtime && typeof row.runtime === 'object'
+      && typeof row.runtime.adapter === 'string'
+      ? row.runtime.adapter.trim().toLowerCase()
+      : null;
+    let adapter = null;
+    if (requestedAdapter) {
+      adapter = await resolveAdapter(row.runtime || null);
+      if (adapter !== requestedAdapter) {
+        log(`[${row.agentName}] requested adapter '${requestedAdapter}' is not available on this machine — skipping token mint`);
+        return false;
+      }
     }
     const body = { agentName: row.agentName, instanceId: row.instanceId };
     let minted;
@@ -174,7 +213,7 @@ export const createDaemonSupervisor = ({
       log(`[${row.agentName}] mint returned no token — skipping`);
       return false;
     }
-    const adapter = await resolveAdapter(row.runtime || null);
+    if (!adapter) adapter = await resolveAdapter(row.runtime || null);
     if (!adapter) {
       log(`[${row.agentName}] no usable CLI adapter on this machine — install claude or codex, or attach manually`);
       return false;

--- a/docs/plans/adr-026-d7-fleet-migration.md
+++ b/docs/plans/adr-026-d7-fleet-migration.md
@@ -23,6 +23,9 @@ runtime API.
    on fresh and
    resumed runs and passes reasoning effort as `model_reasoning_effort` through
    `-c`, which is the supported Codex CLI surface.
+   Claude detection and child launches also append the operator's
+   `~/.local/bin` to the child `PATH`; launchd daemon environments commonly omit
+   that directory even though the Claude executable is installed there.
 2. **Existing-agent editing.** The existing registry PATCH route remains the
    source of truth: `PATCH /api/registry/pods/:podId/agents/:name` with
    `config.runtime` (including `adapter`, `model`, and `effort`) and/or a
@@ -64,6 +67,9 @@ require moving the already-proven seats back.
 ## Acceptance evidence
 
 - Codex fresh and resume each receive the selected model and effort.
+- A Claude adapter configured through the daemon resolves and launches when its
+  binary is installed under `~/.local/bin`, including a launchd-style restricted
+  parent `PATH`.
 - An existing-agent model/config edit is visible through the UI and CLI and is
   applied by the daemon without replacing identity or memory.
 - Exactly one runner owns the migrated seat after handoff; old ownership is

--- a/docs/plans/adr-026-d7-fleet-migration.md
+++ b/docs/plans/adr-026-d7-fleet-migration.md
@@ -11,7 +11,10 @@ runtime API.
 
 1. **Runtime fidelity.** The daemon work list carries the complete supported
    ADR-008 `config.environment` projection (workspace, sandbox, skills, MCP,
-   model, and effort). Opaque keys and literal `mcp[].env` values are dropped
+   model, and effort). The separate `config.runtime.adapter` selector is a
+   machine-local edit: the CLI validates its name and `detect()` result before
+   PATCH, and the daemon accepts only an exact locally detected adapter (never
+   a fallback) before restarting the child. Opaque keys and literal `mcp[].env` values are dropped
    at the server boundary; only exact adapter-resolved Commonly placeholder
    values remain (embedded placeholder strings are dropped with a value-free
    warning), while provider secrets stay out-of-band per ADR-008. Older
@@ -22,10 +25,11 @@ runtime API.
    `-c`, which is the supported Codex CLI surface.
 2. **Existing-agent editing.** The existing registry PATCH route remains the
    source of truth: `PATCH /api/registry/pods/:podId/agents/:name` with
-   `config.runtime` and/or a validated ADR-008 `config.environment`. The
-   existing Agents Hub already uses this route; `commonly agent config` is the
-   CLI path for the same operation. The daemon observes the edit on its next
-   poll and restarts the affected child without minting a new identity.
+   `config.runtime` (including `adapter`, `model`, and `effort`) and/or a
+   validated ADR-008 `config.environment`. The existing Agents Hub already
+   uses this route; `commonly agent config` is the CLI path for the same
+   operation. The daemon observes the edit on its next poll and restarts the
+   affected child without minting a new identity.
 3. **One runner.** `me.commonly.daemon` is the supported machine service and
    owns one child per bound identity. During migration, the legacy seat plist
    and `revive-fleet` are still owners; neither is removed while a seat is


### PR DESCRIPTION
## Summary
- add `commonly agent config <name> --adapter <name>` with registry validation and local `detect()` gating
- persist `runtime.adapter` through the existing registry PATCH route and local token record without mixing it into ADR-008 environment
- restart a supervised seat when its declared adapter changes, while rejecting detect fallbacks and preserving identity/token lineage
- document adapter edits in the ADR-026 D7 migration plan

## Verification
- `npm test -- --runInBand --forceExit` (CLI: 30 suites passed; 449 passed, 10 skipped; one contract test requires backend `ts-node` dependencies absent in this lightweight checkout)
- focused adapter/config/supervisor suites: 52 passed
- `npm run lint`
