### PR TITLE
feat(attention): actorUserId at the three writers; agent listing carries description + userId (direction C PR 4a)

### DIFF
--- a/backend/__tests__/unit/routes/registry.description-and-userid.test.js
+++ b/backend/__tests__/unit/routes/registry.description-and-userid.test.js
@@ -1,0 +1,29 @@
+/**
+ * Direction C Your Team card (ux-lead 66163): line 3 is the curated
+ * `botMetadata.description`, or no line at all — never a quote. The payload
+ * also carries the bot User's id so a client can key per-agent attention on
+ * `AttentionItem.actorUserId` instead of matching names.
+ */
+
+const { buildAgentInstallationPayload } = require('../../../routes/registry/helpers');
+
+const install = { agentName: 'wren', instanceId: 'default', status: 'active', scopes: [], createdAt: new Date() };
+
+describe('agent listing description + principal id', () => {
+  test('description is the trimmed botMetadata.description and userId is the bot User id', () => {
+    const user = { _id: { toString: () => '507f191e810c19729de860ea' }, username: 'wren', botMetadata: { description: '  Connectors. Presses PRs, watches deploys.  ' } };
+    const p = buildAgentInstallationPayload(install, { user });
+    expect(p.description).toBe('Connectors. Presses PRs, watches deploys.');
+    expect(p.userId).toBe('507f191e810c19729de860ea');
+  });
+
+  test('no description, or a whitespace one, is null — the card renders no line', () => {
+    expect(buildAgentInstallationPayload(install).description).toBeNull();
+    expect(buildAgentInstallationPayload(install, { user: { _id: 'u1', botMetadata: {} } }).description).toBeNull();
+    expect(buildAgentInstallationPayload(install, { user: { _id: 'u1', botMetadata: { description: '   ' } } }).description).toBeNull();
+  });
+
+  test('no user row means no principal id, not a crash', () => {
+    expect(buildAgentInstallationPayload(install).userId).toBeNull();
+  });
+});

--- a/backend/__tests__/unit/services/attentionItemService.test.js
+++ b/backend/__tests__/unit/services/attentionItemService.test.js
@@ -111,6 +111,62 @@ describe('attentionItemService', () => {
     expect(rows[0]).toMatchObject({ status: 'resolved', source: { type: 'message', id: '42' } });
   });
 
+  // actorUserId (ux-lead 66164): actorName holds three shapes across the three
+  // writers (author username, runtime agentName, nothing on decisions), so the
+  // Your Team ring keys on the principal's id instead. Each writer is pinned.
+  it('a mention carries its author id as actorUserId', async () => {
+    mockPodFindById.mockReturnValue(chain({ _id: 'pod-1', name: 'Ship room', createdBy: 'owner', members: [{ userId: 'sam' }] }));
+    mockUserFind.mockReturnValue(chain([
+      { _id: 'owner', username: 'owner', isBot: false },
+      { _id: 'sam', username: 'Sam', isBot: false },
+    ]));
+    mockUpdateOne.mockResolvedValue({ matchedCount: 0, upsertedCount: 1 });
+
+    await AttentionItemService.recordMentionedUsers({ id: 42, podId: 'pod-1', userId: 'wren-user', username: 'Wren', content: '@sam pick one' });
+
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientUserId: 'sam' }),
+      expect.objectContaining({ $setOnInsert: expect.objectContaining({ actorName: 'Wren', actorUserId: 'wren-user' }) }),
+      expect.any(Object),
+    );
+  });
+
+  it('a decision carries the agent user id as actorUserId (it has no actorName at all)', async () => {
+    mockPodFindById.mockReturnValue(chain({ _id: 'pod-1', name: 'Ship room', createdBy: 'sam', members: [] }));
+    mockUserFind.mockReturnValue(chain([{ _id: 'sam', username: 'Sam', isBot: false }]));
+    mockUpdateOne.mockResolvedValue({ matchedCount: 0, upsertedCount: 1 });
+
+    await AttentionItemService.recordDecision({ _id: 'd-1', podId: 'pod-1', agentUserId: 'kai-user', title: 'Which cursor?', options: [{ label: 'A' }, { label: 'B' }] });
+
+    const [, update] = mockUpdateOne.mock.calls.at(-1);
+    expect(update.$setOnInsert).toEqual(expect.objectContaining({ kind: 'decision', actorUserId: 'kai-user' }));
+    expect(update.$setOnInsert.actorName).toBeUndefined();
+  });
+
+  it('an approval carries the requester id as actorUserId when the source has one', async () => {
+    mockPodFindById.mockReturnValue(chain({ _id: 'pod-1', name: 'Ship room', createdBy: 'sam', members: [] }));
+    mockUserFind.mockReturnValue(chain([{ _id: 'sam', username: 'Sam', isBot: false }]));
+    mockUpdateOne.mockResolvedValue({ matchedCount: 0, upsertedCount: 1 });
+
+    await AttentionItemService.recordApproval({ _id: 'a-1', podId: 'pod-1', agentMetadata: { agentName: 'openclaw' }, approval: { requestedBy: 'aria-user' }, content: 'needs repo scope' });
+
+    const [, update] = mockUpdateOne.mock.calls.at(-1);
+    expect(update.$setOnInsert).toEqual(expect.objectContaining({ kind: 'approval', actorName: 'openclaw', actorUserId: 'aria-user' }));
+  });
+
+  it('the queue item carries actorUserId as a string, and omits it when the row has none', async () => {
+    mockFind.mockReturnValue({ sort: () => ({ lean: async () => [
+      { _id: 'attention-1', recipientUserId: '507f191e810c19729de860ea', podId: 'pod-1', kind: 'decision', source: { type: 'decision_request', id: 'd-1' }, title: 'Which?', actorUserId: { toString: () => 'kai-user' }, createdAt: new Date() },
+      { _id: 'attention-2', recipientUserId: '507f191e810c19729de860ea', podId: 'pod-1', kind: 'mention', source: { type: 'message', id: '41' }, title: 'Mention', createdAt: new Date() },
+    ] }) });
+    mockPodFind.mockReturnValue(chain([{ _id: 'pod-1', name: 'Current', createdBy: '507f191e810c19729de860ea', members: [] }]));
+
+    const queue = await AttentionItemService.getOpenQueue('507f191e810c19729de860ea');
+    expect(queue.items.find((item) => item.id === 'd-1').actorUserId).toBe('kai-user');
+    // undefined, never a stringified 'undefined' — JSON drops it on the wire.
+    expect(queue.items.find((item) => item.id === '41').actorUserId).toBeUndefined();
+  });
+
   it('returns only rows whose recipient is still a member and resolves by recipient-owned id', async () => {
     mockFind.mockReturnValue({ sort: () => ({ lean: async () => [
       { _id: 'attention-1', recipientUserId: '507f191e810c19729de860ea', podId: 'pod-1', kind: 'mention', source: { type: 'message', id: '41' }, title: 'Mention', createdAt: new Date() },

--- a/backend/models/AttentionItem.ts
+++ b/backend/models/AttentionItem.ts
@@ -12,6 +12,13 @@ export interface IAttentionItem extends Document {
   detail?: string;
   podName?: string;
   actorName?: string;
+  /**
+   * The principal whose ask this item carries: the mention's author, the
+   * approval's requester, the decision's agent. Keyed by id because
+   * `actorName` holds three different shapes across the three writers and
+   * is absent on decisions entirely.
+   */
+  actorUserId?: Types.ObjectId;
   messageId?: string;
   threadRootId?: string;
   options?: Array<{ label: string; description?: string; recommended?: boolean }>;
@@ -48,6 +55,7 @@ const attentionItemSchema = new Schema<IAttentionItem>({
   detail: { type: String },
   podName: { type: String },
   actorName: { type: String },
+  actorUserId: { type: Schema.Types.ObjectId, ref: 'User' },
   messageId: { type: String },
   threadRootId: { type: String },
   options: [optionSchema],

--- a/backend/routes/registry/helpers.ts
+++ b/backend/routes/registry/helpers.ts
@@ -433,6 +433,16 @@ const buildAgentInstallationPayload = (installation: any, {
       ? { snippet: toSnippet(lastMessage.content), at: lastMessage.createdAt || null }
       : null,
     installedBy: installation.installedBy?.toString?.() || installation.installedBy,
+    // The portable principal's id, so a client can key per-agent attention
+    // (AttentionItem.actorUserId) on it instead of matching names — three
+    // writers store three different name shapes (ux-lead, Sharpen 66164).
+    userId: user?._id ? String(user._id) : null,
+    // Direction C Your Team card, line 3: one sentence from the curated
+    // `botMetadata.description`. Null when unset — the card renders no line,
+    // never a quote (ux-lead 66163).
+    description: typeof user?.botMetadata?.description === 'string' && user.botMetadata.description.trim()
+      ? user.botMetadata.description.trim()
+      : null,
     runtime: runtimeConfig,
     // Resolved at the boundary so the frontend doesn't need to know
     // about presets — `category` is the human-readable role family

--- a/backend/services/attentionItemService.ts
+++ b/backend/services/attentionItemService.ts
@@ -55,6 +55,7 @@ const recordForRecipients = async (
         detail: payload.detail,
         podName: payload.podName,
         actorName: payload.actorName,
+        actorUserId: payload.actorUserId,
         messageId: payload.messageId,
         threadRootId: payload.threadRootId,
         options: payload.options,
@@ -101,7 +102,7 @@ export const recordMentionedUsers = async (message: any, options: MentionOptions
     const authorName = message?.username || message?.userId?.username || await resolveAuthorName(authorId);
     await recordForRecipients(recipients, {
       podId, kind: 'mention' as Kind, sourceType: 'message' as SourceType, sourceId: sourceKey('message', messageId),
-      title: `${authorName} mentioned you`, actorName: authorName, detail: compact(content), podName: pod?.name || 'Pod',
+      title: `${authorName} mentioned you`, actorName: authorName, actorUserId: authorId || undefined, detail: compact(content), podName: pod?.name || 'Pod',
       messageId: String(messageId), threadRootId: String(message?.threadRootId || message?.thread_root_id || messageId),
       sourceCreatedAt: message?.createdAt || message?.created_at || undefined,
     });
@@ -246,7 +247,11 @@ export const recordApproval = async (approval: any): Promise<void> => {
     const agentName = approval?.agentMetadata?.agentName;
     await recordForRecipients(recipients, {
       podId, kind: 'approval' as Kind, sourceType: 'approval' as SourceType, sourceId: sourceKey('approval', id),
-      title: agentName ? `${agentName} requests approval` : 'Approval requested', actorName: agentName || undefined, detail: compact(approval?.content, 180), podName: pod?.name || 'Pod',
+      title: agentName ? `${agentName} requests approval` : 'Approval requested', actorName: agentName || undefined,
+      // The approval writer has no agent user id of its own today; take the
+      // requester when the source carries one, else leave it unset.
+      actorUserId: approval?.approval?.requestedBy || approval?.agentUserId || approval?.actorId || undefined,
+      detail: compact(approval?.content, 180), podName: pod?.name || 'Pod',
     });
   } catch (error) {
     console.warn('[attention] approval materialization failed:', (error as Error).message);
@@ -267,6 +272,7 @@ export const recordDecision = async (decision: any): Promise<void> => {
     await recordForRecipients(recipients, {
       podId, kind: 'decision' as Kind, sourceType: 'decision_request' as SourceType, sourceId: sourceKey('decision_request', id),
       title: String(decision.title || 'Decision requested'), detail: compact(decision.question || decision.context, 1000),
+      actorUserId: decision.agentUserId || undefined,
       podName: pod?.name || 'Pod', messageId: decision.messageId ? String(decision.messageId) : undefined,
       threadRootId: String(decision.threadRootId || decision.messageId || ''), options,
     });
@@ -412,7 +418,7 @@ export const getOpenQueue = async (recipientUserId: unknown, options: OpenQueueO
   const picked: any[] = [];
   for (const row of page) {
     picked.push({
-      id: String(row.source.id), attentionItemId: String(row._id), kind: renderKind(row), title: row.title, actorName: row.actorName || undefined, detail: row.detail || '',
+      id: String(row.source.id), attentionItemId: String(row._id), kind: renderKind(row), title: row.title, actorName: row.actorName || undefined, actorUserId: row.actorUserId ? String(row.actorUserId) : undefined, detail: row.detail || '',
       podId: String(row.podId), podName: (allowed.get(String(row.podId)) as any)?.name || row.podName || 'Pod',
       messageId: row.messageId, threadRootId: row.threadRootId, options: row.options || [], createdAt: row.createdAt,
     });


### PR DESCRIPTION
Backend half of the direction-C **Your Team** rebuild. Additive; no page change here (PR 4b builds on these fields).

Ruled by @ux-lead in Sharpen (66163–66165):

- **`description`** on the agent listing — the trimmed `botMetadata.description`, or `null` so the card renders no line, never a quote.
- **`userId`** on the agent listing — the bot User's id, so a client can key per-agent attention on an id rather than a name.
- **`AttentionItem.actorUserId`** — the principal whose ask the item carries. `actorName` holds three shapes across the three writers (author username on mentions, runtime agentName on approvals, nothing at all on decisions), so name matching was ruled out. Set at the mention writer (author id), the decision writer (`agentUserId`) and the approval writer (the requester when the source carries one); projected on the queue item as a string, omitted when absent.

## Proof
- `registry.description-and-userid.test.js` (3): trimmed description, null for unset/whitespace, null userId without a user row.
- `attentionItemService.test.js` (+4): each writer's `$setOnInsert` carries the right `actorUserId`; the decision writer carries it with **no** `actorName`; the queue projects it as a string and leaves it undefined otherwise.
- Attention suite 23/23, registry suites green, `tsc -p tsconfig.build.json` clean, eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX