### PR TITLE
fix(auth): restore the /cli/authorize page the device-code login sends you to

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import V2LandingPage from './v2/landing/V2LandingPage';
 import { setupFocusManagement } from './utils/focusUtils';
 import { checkAndRefresh } from './utils/refreshUtils';
 import './App.css';
+import V2CliAuthorize from './v2/components/V2CliAuthorize';
 
 class AppErrorBoundary extends React.Component<{ children: React.ReactNode }, { error: Error | null }> {
   constructor(props: { children: React.ReactNode }) {
@@ -277,6 +278,10 @@ function App(): React.ReactElement {
                     <Route path="/register" element={<Register />} />
                     <Route path="/register/invite-required" element={<RegistrationInviteRequired />} />
                     <Route path="/verify-email" element={<VerifyEmail />} />
+                    {/* Device-code sign-in (#1405): the backend's /api/auth/device/start
+                        answers with `verifyUrl: <origin>/cli/authorize`. Deleting this
+                        route 404'd every `commonly login` (#1534, 2026-09-04 → 09-08). */}
+                    <Route path="/cli/authorize" element={<V2CliAuthorize />} />
                     <Route path="/discord/callback" element={<DiscordCallback />} />
                     <Route path="/discord/success" element={<DiscordCallback type="success" />} />
                     <Route path="/discord/error" element={<DiscordCallback type="error" />} />

--- a/frontend/src/v2/__tests__/V2CliAuthorize.test.tsx
+++ b/frontend/src/v2/__tests__/V2CliAuthorize.test.tsx
@@ -1,0 +1,83 @@
+// @ts-nocheck
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import { AuthContext } from '../../context/AuthContext';
+import V2CliAuthorize from '../components/V2CliAuthorize';
+
+jest.mock('axios', () => {
+  const mock = {
+    get: jest.fn(), post: jest.fn(), delete: jest.fn(), patch: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: { request: { use: jest.fn(), eject: jest.fn() }, response: { use: jest.fn(), eject: jest.fn() } },
+  };
+  return { __esModule: true, default: mock, ...mock };
+});
+
+const auth = {
+  currentUser: { _id: 'u1', username: 'lily', email: 'lily@example.com' },
+  user: { _id: 'u1', username: 'lily', email: 'lily@example.com' },
+  token: 'jwt', loading: false, error: null, isAuthenticated: true,
+  register: jest.fn(), login: jest.fn(), logout: jest.fn(), updateProfile: jest.fn(),
+};
+
+const renderPage = (path = '/cli/authorize?code=ABCD-EFGH', value = auth) => render(
+  <AuthContext.Provider value={value}>
+    <MemoryRouter initialEntries={[path]}><V2CliAuthorize /></MemoryRouter>
+  </AuthContext.Provider>,
+);
+
+afterEach(() => jest.clearAllMocks());
+
+describe('V2CliAuthorize', () => {
+  test('prefills a terminal code, confirms the device facts, then completes approval', async () => {
+    axios.post
+      .mockResolvedValueOnce({ data: { status: 'pending', request: { hostname: 'sam-laptop', clientName: 'commonly-cli', clientVersion: '0.1.26', createdAt: '2026-08-31T00:00:00.000Z' } } })
+      .mockResolvedValueOnce({ data: { status: 'authorized' } });
+    renderPage();
+
+    expect(screen.getByLabelText('Device code')).toHaveValue('ABCD-EFGH');
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    await waitFor(() => expect(axios.post).toHaveBeenCalledWith('/api/auth/device/authorize', { userCode: 'ABCD-EFGH' }));
+    expect(await screen.findByText('Authorize sam-laptop as @lily?')).toBeInTheDocument();
+    expect(screen.getByText('CLI SIGN-IN')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
+    await waitFor(() => expect(axios.post).toHaveBeenLastCalledWith('/api/auth/device/authorize', {
+      userCode: 'ABCD-EFGH', decision: 'authorize',
+    }));
+    expect(await screen.findByText('Device authorized')).toBeInTheDocument();
+  });
+
+  test('signed-out users get an explicit return path after sign-in', () => {
+    renderPage('/cli/authorize?code=ABCD-EFGH', { ...auth, currentUser: null, user: null, token: null, isAuthenticated: false });
+    expect(screen.getByRole('link', { name: 'Sign in to continue' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('next=%2Fcli%2Fauthorize%3Fcode%3DABCD-EFGH'),
+    );
+    expect(screen.getByLabelText('Device code')).toBeDisabled();
+  });
+
+  test('shows the request instance and the expired state for signed-in users', async () => {
+    axios.defaults.baseURL = 'https://self-hosted.example/api';
+    axios.post
+      .mockResolvedValueOnce({ data: { status: 'pending', request: { hostname: 'sam-laptop', clientName: 'commonly-cli', createdAt: '2026-08-31T00:00:00.000Z' } } })
+      .mockRejectedValueOnce({ response: { status: 410 } });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(await screen.findByText('self-hosted.example')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
+    expect(await screen.findByText('Code expired')).toBeInTheDocument();
+    axios.defaults.baseURL = '';
+  });
+
+  test('labels an already-consumed code instead of calling it expired', async () => {
+    axios.post.mockResolvedValue({ data: { status: 'consumed' } });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(await screen.findByText('Code already used')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
+++ b/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
@@ -78,4 +78,16 @@ describe('the connect flow states what it does not do', () => {
     expect(src).toMatch(/commonly agent run/);
     expect(src).toMatch(/agentByo\.listen\.title/);
   });
+
+  test('the device-login verify page the backend points at exists as a frontend route', () => {
+    // #1534 deleted /cli/authorize as "retired UI" while backend/routes/auth.ts
+    // still answered device/start with `verifyUrl: <origin>/cli/authorize`, so
+    // every `commonly login` 404'd for four days. The backend path is the source;
+    // the route must match it.
+    const backendAuth = fs.readFileSync(path.join(__dirname, '../../../../backend/routes/auth.ts'), 'utf8');
+    const verify = backendAuth.match(/verifyUrl: `\$\{origin\}(\/[^`]+)`/);
+    expect(verify).not.toBeNull();
+    const app = read('../../App.tsx');
+    expect(app).toContain(`<Route path="${verify![1]}" element={<V2CliAuthorize />} />`);
+  });
 });

--- a/frontend/src/v2/components/V2CliAuthorize.css
+++ b/frontend/src/v2/components/V2CliAuthorize.css
@@ -1,0 +1,56 @@
+.v2-cli-authorize {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: #f8f8fb;
+  color: #111827;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.v2-cli-authorize__card {
+  width: min(100%, 460px);
+  padding: 32px;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 12px 32px rgba(17, 24, 39, 0.08);
+}
+
+.v2-cli-authorize__card form { margin: 0; padding: 0; border: 0; background: transparent; box-shadow: none; }
+
+.v2-cli-authorize__mark {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 10px;
+  background: #2f6feb;
+  color: #fff;
+  font-weight: 800;
+}
+
+.v2-cli-authorize__eyebrow { margin: 16px 0 0 !important; color: #2f6feb !important; font-size: 11px; font-weight: 800; letter-spacing: .11em; }
+.v2-cli-authorize__card h1 { margin: 18px 0 8px; font-size: 24px; }
+.v2-cli-authorize__card p { margin: 0 0 20px; color: #4b5563; line-height: 1.5; }
+.v2-cli-authorize__field { display: grid; gap: 7px; margin-bottom: 18px; font-size: 13px; font-weight: 700; }
+.v2-cli-authorize__field input { width: 100%; box-sizing: border-box; padding: 12px; border: 1px solid #d7dce7; border-radius: 9px; font: 600 18px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .08em; }
+.v2-cli-authorize__field input:focus { outline: none; border-color: #2f6feb; box-shadow: 0 0 0 3px rgba(47, 111, 235, .18); }
+.v2-cli-authorize__primary, .v2-cli-authorize__secondary { display: inline-flex; justify-content: center; align-items: center; min-height: 42px; padding: 0 16px; border-radius: 9px; font: inherit; font-weight: 700; text-decoration: none; cursor: pointer; }
+.v2-cli-authorize__primary { border: 1px solid #2f6feb; background: #2f6feb; color: #fff; }
+.v2-cli-authorize__primary:disabled { cursor: wait; opacity: .65; }
+.v2-cli-authorize__secondary { border: 1px solid #d7dce7; background: #fff; color: #374151; }
+.v2-cli-authorize__facts { margin: 0 0 18px; padding: 14px; border-radius: 10px; background: #f7f7fa; }
+.v2-cli-authorize__facts div { display: flex; justify-content: space-between; gap: 18px; padding: 5px 0; }
+.v2-cli-authorize__facts dt { color: #6b7280; }
+.v2-cli-authorize__facts dd { margin: 0; font-weight: 600; text-align: right; }
+.v2-cli-authorize__warning { padding: 10px 12px; border-radius: 8px; background: #fdefdc; color: #7c4a03 !important; font-size: 13px; }
+.v2-cli-authorize__actions { display: flex; justify-content: flex-end; gap: 10px; }
+
+@media (max-width: 480px) {
+  .v2-cli-authorize { padding: 16px; align-items: start; }
+  .v2-cli-authorize__card { padding: 24px 20px; }
+  .v2-cli-authorize__facts div { display: grid; gap: 2px; }
+  .v2-cli-authorize__facts dd { text-align: left; }
+  .v2-cli-authorize__actions { display: grid; grid-template-columns: 1fr 1fr; }
+}

--- a/frontend/src/v2/components/V2CliAuthorize.tsx
+++ b/frontend/src/v2/components/V2CliAuthorize.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import axios from '../../utils/axiosConfig';
+import { useAuth } from '../../context/AuthContext';
+import './V2CliAuthorize.css';
+
+interface AuthorizationRequest {
+  hostname: string;
+  clientName: string;
+  clientVersion?: string | null;
+  createdAt: string;
+}
+
+type Screen = 'code' | 'confirm' | 'done' | 'denied' | 'expired' | 'used' | 'error';
+
+const normalizeCode = (value: string): string => {
+  const compact = value.toUpperCase().replace(/[^A-Z2-9]/g, '').slice(0, 8);
+  return compact.length > 4 ? `${compact.slice(0, 4)}-${compact.slice(4)}` : compact;
+};
+
+const errorScreen = (error: unknown): Screen => {
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  return status === 410 ? 'expired' : 'error';
+};
+
+const requestAge = (createdAt: string): string => {
+  const seconds = Math.max(0, Math.floor((Date.now() - new Date(createdAt).getTime()) / 1000));
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+};
+
+const currentInstance = () => {
+  const baseUrl = String(axios.defaults.baseURL || window.location.origin);
+  try { return new URL(baseUrl, window.location.origin).host; } catch { return baseUrl; }
+};
+
+const V2CliAuthorize: React.FC = () => {
+  const { isAuthenticated, loading, user } = useAuth();
+  const location = useLocation();
+  const queryCode = useMemo(() => normalizeCode(new URLSearchParams(location.search).get('code') || ''), [location.search]);
+  const [code, setCode] = useState(queryCode);
+  const [screen, setScreen] = useState<Screen>('code');
+  const [request, setRequest] = useState<AuthorizationRequest | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => setCode(queryCode), [queryCode]);
+
+  const lookup = async (event?: React.FormEvent) => {
+    event?.preventDefault();
+    if (code.replace('-', '').length !== 8) return;
+    setSubmitting(true);
+    try {
+      const response = await axios.post<{ status: string; request?: AuthorizationRequest }>('/api/auth/device/authorize', {
+        userCode: code,
+      });
+      if (response.data.status === 'pending' && response.data.request) {
+        setRequest(response.data.request);
+        setScreen('confirm');
+      } else {
+        setScreen(
+          response.data.status === 'denied'
+            ? 'denied'
+            : response.data.status === 'consumed' || response.data.status === 'authorized'
+              ? 'used'
+              : 'expired',
+        );
+      }
+    } catch (error) {
+      setScreen(errorScreen(error));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const decide = async (decision: 'authorize' | 'deny') => {
+    setSubmitting(true);
+    try {
+      const response = await axios.post<{ status: string }>('/api/auth/device/authorize', {
+        userCode: code,
+        decision,
+      });
+      setScreen(response.data.status === 'authorized' ? 'done' : 'denied');
+    } catch (error) {
+      setScreen(errorScreen(error));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const next = `/cli/authorize${code ? `?code=${encodeURIComponent(code)}` : ''}`;
+
+  return (
+    <main className="v2-cli-authorize">
+      <section className="v2-cli-authorize__card" aria-live="polite">
+        <div className="v2-cli-authorize__mark" aria-hidden="true">C</div>
+        <p className="v2-cli-authorize__eyebrow">CLI SIGN-IN</p>
+        {loading && <p>Checking your session…</p>}
+        {!loading && !isAuthenticated && (
+          <>
+            <h1>Authorize Commonly CLI</h1>
+            <p>Sign in to approve this device. The code stays tied to this browser tab.</p>
+            <label className="v2-cli-authorize__field">
+              <span>Device code</span>
+              <input value={code} disabled aria-label="Device code" />
+            </label>
+            <Link className="v2-cli-authorize__primary" to={`/v2/login?next=${encodeURIComponent(next)}`}>Sign in to continue</Link>
+          </>
+        )}
+        {!loading && isAuthenticated && screen === 'code' && (
+          <form onSubmit={lookup}>
+            <h1>Authorize Commonly CLI</h1>
+            <p>Enter the code shown in your terminal.</p>
+            <label className="v2-cli-authorize__field">
+              <span>Device code</span>
+              <input
+                value={code}
+                onChange={(event) => setCode(normalizeCode(event.target.value))}
+                placeholder="ABCD-EFGH"
+                autoComplete="one-time-code"
+                aria-label="Device code"
+                required
+              />
+            </label>
+            <button className="v2-cli-authorize__primary" type="submit" disabled={submitting || code.replace('-', '').length !== 8}>
+              {submitting ? 'Checking…' : 'Continue'}
+            </button>
+          </form>
+        )}
+        {!loading && isAuthenticated && screen === 'confirm' && request && (
+          <>
+            <h1>Authorize {request.hostname} as @{user?.username || 'you'}?</h1>
+            <p>This device is asking to use your Commonly account.</p>
+            <dl className="v2-cli-authorize__facts">
+              <div><dt>Client</dt><dd>{request.clientName}{request.clientVersion ? ` ${request.clientVersion}` : ''}</dd></div>
+              <div><dt>Instance</dt><dd>{currentInstance()}</dd></div>
+              <div><dt>Requested</dt><dd>{requestAge(request.createdAt)}</dd></div>
+            </dl>
+            <p className="v2-cli-authorize__warning">Only approve a code you requested from your own terminal.</p>
+            <div className="v2-cli-authorize__actions">
+              <button className="v2-cli-authorize__secondary" type="button" onClick={() => decide('deny')} disabled={submitting}>Deny</button>
+              <button className="v2-cli-authorize__primary" type="button" onClick={() => decide('authorize')} disabled={submitting}>
+                {submitting ? 'Authorizing…' : 'Authorize'}
+              </button>
+            </div>
+          </>
+        )}
+        {!loading && isAuthenticated && screen === 'done' && <><h1>Device authorized</h1><p>You can return to your terminal.</p></>}
+        {!loading && isAuthenticated && screen === 'denied' && <><h1>Authorization denied</h1><p>No token was issued for this device.</p></>}
+        {!loading && isAuthenticated && screen === 'expired' && <><h1>Code expired</h1><p>Return to your terminal and run <code>commonly login</code> again.</p></>}
+        {!loading && isAuthenticated && screen === 'used' && <><h1>Code already used</h1><p>This code was already approved or completed. Return to your terminal.</p></>}
+        {!loading && isAuthenticated && screen === 'error' && <><h1>Couldn’t authorize this device</h1><p>Check the code and try again from your terminal.</p></>}
+      </section>
+    </main>
+  );
+};
+
+export default V2CliAuthorize;


### PR DESCRIPTION
**Every `commonly login` has 404'd since 2026-09-04.** #1534 deleted `V2CliAuthorize` and its `/cli/authorize` route as retired UI, while `backend/routes/auth.ts` still answers `POST /api/auth/device/start` with `verifyUrl: <origin>/cli/authorize`. The browser lands on the marketing 404. Sam hit it today.

## Fix
- Page, stylesheet and its four tests restored verbatim from the parent of #1534.
- Route re-registered in `App.tsx` beside `/verify-email`, with a comment naming the backend contract.

## Guard
`V2ConnectHonesty` reads the backend's `verifyUrl` path out of `auth.ts` and asserts `App.tsx` registers exactly that route. The backend is the source; the frontend must match it. Deleting the route again → 1 red (checked by mutation; restored 16/16).

## Proof
`V2CliAuthorize` 4/4, `V2ConnectHonesty` 12/12, tsc clean, eslint 0 errors. Live check after deploy: `https://commonly.me/cli/authorize?code=…` renders the device prompt instead of the 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX