### PR TITLE
fix(settings): give admins a way back into Users and Usage analytics

### DIFF
--- a/frontend/src/v2/__tests__/V2SettingsPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2SettingsPage.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '../../i18n';
 import axios from '../../utils/axiosConfig';
+import { MemoryRouter } from 'react-router-dom';
 import { AuthContext } from '../../context/AuthContext';
 import V2SettingsPage from '../components/V2SettingsPage';
 
@@ -47,9 +48,10 @@ const auth = {
   register: jest.fn(), login: jest.fn(), logout: jest.fn(), updateProfile: jest.fn(),
 };
 
+// The page links to the admin routes, so it renders under a router.
 const renderSettings = () => render(
   <AuthContext.Provider value={auth}>
-    <div className="v2-root"><V2SettingsPage /></div>
+    <MemoryRouter><div className="v2-root"><V2SettingsPage /></div></MemoryRouter>
   </AuthContext.Provider>,
 );
 
@@ -128,5 +130,23 @@ describe('V2SettingsPage', () => {
     expect(auth.updateProfile).toHaveBeenCalledTimes(1);
     expect(await screen.findByRole('status')).toHaveTextContent('Account saved.');
     expect(screen.queryByText(/re-verification; ask us for now/i)).not.toBeInTheDocument();
+  });
+
+  test('an admin gets an Administration section with the users and usage-analytics links; a member does not', () => {
+    // The routes survived the Settings consolidation (#1544); the way in did
+    // not, so both admin pages were reachable only by URL.
+    const { unmount } = renderSettings();
+    expect(screen.queryByRole('link', { name: 'Administration' })).toBeNull();
+    expect(screen.queryByText('Usage analytics')).toBeNull();
+    unmount();
+    const adminAuth = { ...auth, currentUser: { ...auth.currentUser, role: 'admin' }, user: { ...auth.user, role: 'admin' } };
+    render(
+      <AuthContext.Provider value={adminAuth}>
+        <MemoryRouter><V2SettingsPage /></MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    expect(screen.getByRole('link', { name: 'Administration' })).toHaveAttribute('href', '#v2-settings-admin');
+    expect(screen.getByRole('link', { name: /^Users/ })).toHaveAttribute('href', '/v2/admin/users');
+    expect(screen.getByRole('link', { name: /^Usage analytics/ })).toHaveAttribute('href', '/v2/admin/analytics');
   });
 });

--- a/frontend/src/v2/components/V2SettingsPage.tsx
+++ b/frontend/src/v2/components/V2SettingsPage.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import axios from '../../utils/axiosConfig';
@@ -31,6 +32,15 @@ const SETTINGS_SECTIONS = [
   { id: 'api-token', title: 'API token' },
   { id: 'connected-apps', title: 'Connected apps' },
   { id: 'language', title: 'Language' },
+] as const;
+
+// Admin-only: the instance's user list and usage analytics. Their routes
+// survived the Settings consolidation (#1544) but the way in did not — the
+// pages were reachable only by typing the URL (Sam, 2026-09-08).
+const ADMIN_SECTION = { id: 'admin', title: 'Administration' } as const;
+const ADMIN_LINKS = [
+  { to: '/v2/admin/users', label: 'Users', detail: 'Registered users, bans, invitation codes' },
+  { to: '/v2/admin/analytics', label: 'Usage analytics', detail: 'Signups, messages, active users, activation funnel' },
 ] as const;
 
 const settingsSectionId = (id: string) => `v2-settings-${id}`;
@@ -253,18 +263,33 @@ const V2LanguageSection: React.FC = () => {
   );
 };
 
+const V2AdminSection: React.FC = () => (
+  <div className="v2-settings__admin-links">
+    {ADMIN_LINKS.map((link) => (
+      <Link key={link.to} className="v2-settings__admin-link" to={link.to}>
+        <span className="v2-settings__admin-link-label">{link.label}</span>
+        <span className="v2-settings__admin-link-detail">{link.detail}</span>
+      </Link>
+    ))}
+  </div>
+);
+
 const V2SettingsPage: React.FC = () => {
+  const { currentUser } = useAuth();
+  const isAdmin = currentUser?.role === 'admin';
+  const sections = isAdmin ? [...SETTINGS_SECTIONS, ADMIN_SECTION] : [...SETTINGS_SECTIONS];
   const [activeSection, setActiveSection] = useState<string>('account');
 
   useEffect(() => {
     const syncActiveSection = () => {
-      const matchingSection = SETTINGS_SECTIONS.find(({ id }) => `#${settingsSectionId(id)}` === window.location.hash);
+      const matchingSection = sections.find(({ id }) => `#${settingsSectionId(id)}` === window.location.hash);
       if (matchingSection) setActiveSection(matchingSection.id);
     };
     syncActiveSection();
     window.addEventListener('hashchange', syncActiveSection);
     return () => window.removeEventListener('hashchange', syncActiveSection);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdmin]);
 
   return (
     <div className="v2-settings" aria-label="Settings">
@@ -272,7 +297,7 @@ const V2SettingsPage: React.FC = () => {
         <h1 className="v2-settings__title">Settings</h1>
         <nav className="v2-settings__nav" aria-label="Settings sections">
           <div className="v2-settings__nav-list">
-            {SETTINGS_SECTIONS.map(({ id, title }) => (
+            {sections.map(({ id, title }) => (
               <a
                 key={id}
                 className={`v2-settings__nav-link${activeSection === id ? ' v2-settings__nav-link--active' : ''}`}
@@ -292,6 +317,9 @@ const V2SettingsPage: React.FC = () => {
           <SettingsSection id="api-token" title="API token"><V2ApiTokenSection /></SettingsSection>
           <SettingsSection id="connected-apps" title="Connected apps"><AppsManagement variant="settings" /></SettingsSection>
           <SettingsSection id="language" title="Language"><V2LanguageSection /></SettingsSection>
+          {isAdmin && (
+            <SettingsSection id={ADMIN_SECTION.id} title={ADMIN_SECTION.title}><V2AdminSection /></SettingsSection>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -7568,6 +7568,23 @@ body.modern-ui.v2-canvas {
   line-height: var(--v2-lh-meta);
 }
 
+/* Administration (admin-only): two bordered link rows, ink label + muted detail. */
+.v2-settings__admin-links { display: flex; flex-direction: column; gap: 8px; }
+.v2-settings__admin-link {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--v2-border);
+  border-radius: 4px;
+  color: var(--v2-text-primary);
+  text-decoration: none;
+}
+.v2-settings__admin-link:hover { background: var(--v2-surface-hover); }
+.v2-settings__admin-link-label { font: 600 13px/18px var(--v2-font); }
+.v2-settings__admin-link-detail { font-size: 12px; color: var(--v2-text-muted); text-align: right; }
+
 .v2-settings__account-type {
   margin-left: auto;
   text-transform: lowercase;


### PR DESCRIPTION
**The admin user-stats view was not deleted, only orphaned.** The Settings consolidation (#1544) removed the last link to `/v2/admin/users` and `/v2/admin/analytics`; both routes survived and both pages still render (checked live in Sam's session: 142 users, 50 signups in 30 days, the activation funnel), but nothing in the shell led to them.

## Fix
An admin-only **Administration** section at the end of Settings, with two bordered link rows (Users · Usage analytics) and the matching left-nav entry. Members see nothing new; the pages keep their `ProtectedRoute requireAdmin`.

## Proof
- New test: a member renders no Administration link and no "Usage analytics" text; an admin gets the section and both links resolve to the existing routes.
- Settings suite + invariants 110/110, tsc clean, eslint 0 errors. The Settings suite now renders under a `MemoryRouter` because the page links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX