### PR TITLE
fix(nginx): let /cli/authorize and /settings/devices reach the app

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -29,7 +29,11 @@ server {
     # legacy application routes. Public marketing, guide, and use-case routes
     # are intentionally excluded because they have pre-rendered static output
     # and should 404 when no matching directory exists.
-    location ~ ^/(?:v2(?:/|$)|login/?$|register(?:/|$)|verify-email/?$|discord/(?:callback|success|error)/?$|feed/?$|thread/|dashboard/?$|digest/?$|agents/?$|skills/?$|activity/?$|apps/?$|profile(?:/|$)|admin/(?:users|integrations/global)/?$|dev/(?:api|pod-context)/?$|pods(?:/|$)|chat/) {
+    # SPA routes that must reach index.html. Two of them are printed by the
+    # backend/CLI, not typed by people: /cli/authorize (device-code login,
+    # backend/routes/auth.ts verifyUrl) and /settings/devices (the CLI's
+    # manage-devices line). V2ConnectHonesty.test.ts asserts both stay here.
+    location ~ ^/(?:v2(?:/|$)|login/?$|register(?:/|$)|verify-email/?$|cli/authorize/?$|settings/devices/?$|discord/(?:callback|success|error)/?$|feed/?$|thread/|dashboard/?$|digest/?$|agents/?$|skills/?$|activity/?$|apps/?$|profile(?:/|$)|admin/(?:users|integrations/global)/?$|dev/(?:api|pod-context)/?$|pods(?:/|$)|chat/) {
         try_files $uri $uri/ /index.html;
     }
 

--- a/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
+++ b/frontend/src/v2/__tests__/V2ConnectHonesty.test.ts
@@ -90,4 +90,24 @@ describe('the connect flow states what it does not do', () => {
     const app = read('../../App.tsx');
     expect(app).toContain(`<Route path="${verify![1]}" element={<V2CliAuthorize />} />`);
   });
+
+  test('nginx lets the two URLs the backend and CLI print reach the app', () => {
+    // The real-404 change (58294673, 2026-08-24) made nginx an allowlist of
+    // SPA routes. /cli/authorize was never on it, so the device-code login
+    // 404'd in the browser from that day — the React route restore (#1627)
+    // alone changed nothing live. Same for /settings/devices, which the CLI
+    // prints after a login. The regex is read from the real config and run.
+    const nginx = fs.readFileSync(path.join(__dirname, '../../../nginx.conf'), 'utf8');
+    const location = nginx.match(/location ~ \^\/\((.*)\) \{\n\s*try_files \$uri \$uri\/ \/index\.html;/);
+    expect(location).not.toBeNull();
+    const spa = new RegExp(`^/(${location![1]})`);
+    const backendAuth = fs.readFileSync(path.join(__dirname, '../../../../backend/routes/auth.ts'), 'utf8');
+    const verify = backendAuth.match(/verifyUrl: `\$\{origin\}(\/[^`]+)`/)![1];
+    const cliLogin = fs.readFileSync(path.join(__dirname, '../../../../cli/src/commands/login.js'), 'utf8');
+    const devices = cliLogin.match(/new URL\('(\/[^']+)'/)![1];
+    for (const route of [verify, devices, '/verify-email', '/v2/settings']) {
+      expect(spa.test(route)).toBe(true);
+    }
+    expect(spa.test('/definitely-not-a-route')).toBe(false);
+  });
 });


### PR DESCRIPTION
#1627 restored the React route for the device-code login page and deployed at ec4939ef — and `https://commonly.me/cli/authorize` **still** returns the marketing 404.

**Cause:** the real-404 change (58294673, 2026-08-24) made `frontend/nginx.conf` an allowlist of SPA routes, and `/cli/authorize` was never on it. So the browser half of `commonly login` has been dead since **August 24**, not since #1534; the page deletion on Sep 4 was a second, independent break. `/settings/devices`, the URL the CLI prints after a login, has the same gap (404 live today).

## Fix
Both paths added to the SPA `location` regex, with a comment naming the contract.

## Guard
`V2ConnectHonesty` now reads the real nginx regex, the backend's `verifyUrl` path and the CLI's devices URL, and runs the regex against all of them plus a known-bad path. Removing `cli/authorize` from nginx → 1 red (mutation-checked); 13/13 restored.

Correction to #1627's description: the "since 2026-09-04" there was the React half only. Live, it never worked after Aug 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX