### PR TITLE
fix(cli): persist resolved URL for saved-key login

### DIFF
--- a/cli/__tests__/lib.test.mjs
+++ b/cli/__tests__/lib.test.mjs
@@ -172,6 +172,17 @@ describe('config.js', () => {
     expect(config.instances.staging.url).toBe('https://api.commonly.me');
   });
 
+  test('login target preserves a saved key when invoked with its URL', () => {
+    saveInstance({
+      key: 'dev', url: 'https://api.commonly.me', token: 'cm_existing',
+      userId: 'u1', username: 'alice',
+    });
+    expect(resolveLoginTarget({ instanceArg: 'https://api.commonly.me' })).toEqual({
+      instanceUrl: 'https://api.commonly.me',
+      configKey: 'dev',
+    });
+  });
+
   test('getToken("https://...") returns the saved token when the URL matches a saved key', () => {
     // Mirror of the above: historically this returned null because getToken
     // treated the arg as a config key and looked up instances["https://..."].

--- a/cli/__tests__/lib.test.mjs
+++ b/cli/__tests__/lib.test.mjs
@@ -183,6 +183,18 @@ describe('config.js', () => {
     });
   });
 
+  test('login target uses the active profile when no instance is provided', () => {
+    saveInstance({
+      key: 'dev', url: 'https://api.commonly.me', token: 'cm_existing',
+      userId: 'u1', username: 'alice',
+    });
+
+    expect(resolveLoginTarget({})).toEqual({
+      instanceUrl: 'https://api.commonly.me',
+      configKey: 'dev',
+    });
+  });
+
   test('getToken("https://...") returns the saved token when the URL matches a saved key', () => {
     // Mirror of the above: historically this returned null because getToken
     // treated the arg as a config key and looked up instances["https://..."].

--- a/cli/__tests__/lib.test.mjs
+++ b/cli/__tests__/lib.test.mjs
@@ -146,6 +146,24 @@ describe('config.js', () => {
     expect(config.instances.default.url).toBe('https://api.commonly.me');
   });
 
+  test('login target maps an unsaved profile key to the default URL', () => {
+    const target = resolveLoginTarget({ instanceArg: 'staging' });
+    expect(target).toEqual({
+      instanceUrl: 'https://api.commonly.me',
+      configKey: 'default',
+    });
+
+    saveInstance({
+      key: target.configKey,
+      url: target.instanceUrl,
+      token: 'cm_new',
+      userId: 'u1',
+      username: 'alice',
+    });
+    const config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+    expect(config.instances.default.url).toBe('https://api.commonly.me');
+  });
+
   test('getToken("https://...") returns the saved token when the URL matches a saved key', () => {
     // Mirror of the above: historically this returned null because getToken
     // treated the arg as a config key and looked up instances["https://..."].

--- a/cli/__tests__/lib.test.mjs
+++ b/cli/__tests__/lib.test.mjs
@@ -49,6 +49,7 @@ const {
   recordHandledEvent,
   clearSessions,
 } = await import('../src/lib/session-store.js');
+const { resolveLoginTarget } = await import('../src/commands/login.js');
 
 // ── config.js tests ───────────────────────────────────────────────────────────
 
@@ -119,6 +120,30 @@ describe('config.js', () => {
       userId: 'u1', username: 'alice',
     });
     expect(resolveInstanceUrl('dev')).toBe('https://api-dev.commonly.me');
+  });
+
+  test('login target resolves a saved key before persisting the profile URL', () => {
+    saveInstance({
+      key: 'default', url: 'https://api.commonly.me', token: 'cm_existing',
+      userId: 'u1', username: 'alice',
+    });
+
+    const target = resolveLoginTarget({ instanceArg: 'default' });
+    expect(target).toEqual({
+      instanceUrl: 'https://api.commonly.me',
+      configKey: 'default',
+    });
+
+    saveInstance({
+      key: target.configKey,
+      url: target.instanceUrl,
+      token: 'cm_refreshed',
+      userId: 'u1',
+      username: 'alice',
+      tokenType: 'device',
+    });
+    const config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+    expect(config.instances.default.url).toBe('https://api.commonly.me');
   });
 
   test('getToken("https://...") returns the saved token when the URL matches a saved key', () => {

--- a/cli/__tests__/lib.test.mjs
+++ b/cli/__tests__/lib.test.mjs
@@ -150,9 +150,16 @@ describe('config.js', () => {
     const target = resolveLoginTarget({ instanceArg: 'staging' });
     expect(target).toEqual({
       instanceUrl: 'https://api.commonly.me',
-      configKey: 'default',
+      configKey: 'staging',
     });
 
+    saveInstance({
+      key: 'default',
+      url: 'https://api.commonly.me',
+      token: 'cm_existing',
+      userId: 'u1',
+      username: 'alice',
+    });
     saveInstance({
       key: target.configKey,
       url: target.instanceUrl,
@@ -161,7 +168,8 @@ describe('config.js', () => {
       username: 'alice',
     });
     const config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
-    expect(config.instances.default.url).toBe('https://api.commonly.me');
+    expect(config.instances.default.token).toBe('cm_existing');
+    expect(config.instances.staging.url).toBe('https://api.commonly.me');
   });
 
   test('getToken("https://...") returns the saved token when the URL matches a saved key', () => {

--- a/cli/__tests__/login-transcript.test.mjs
+++ b/cli/__tests__/login-transcript.test.mjs
@@ -3,6 +3,7 @@ import * as os from 'os';
 
 const createClient = jest.fn();
 const saveInstance = jest.fn();
+const resolveInstance = jest.fn(() => null);
 const listInstances = jest.fn();
 const waitForDeviceAuthorization = jest.fn();
 
@@ -10,7 +11,12 @@ await jest.unstable_mockModule('../src/lib/api.js', () => ({
   createClient,
   login: jest.fn(),
 }));
-await jest.unstable_mockModule('../src/lib/config.js', () => ({ saveInstance, listInstances }));
+await jest.unstable_mockModule('../src/lib/config.js', () => ({
+  DEFAULT_URL: 'https://api.commonly.me',
+  resolveInstance,
+  saveInstance,
+  listInstances,
+}));
 await jest.unstable_mockModule('../src/lib/device-login.js', () => ({
   DeviceLoginCancelledError: class DeviceLoginCancelledError extends Error {},
   DeviceLoginDeniedError: class DeviceLoginDeniedError extends Error {},

--- a/cli/__tests__/login-transcript.test.mjs
+++ b/cli/__tests__/login-transcript.test.mjs
@@ -85,3 +85,27 @@ test('prints the device-login and mixed-profile expiry transcript', async () => 
   expect(saveInstance).toHaveBeenCalledWith(expect.objectContaining({ token: 'cm_once', tokenType: 'device' }));
   expect(client.post).toHaveBeenCalledWith('/api/auth/device/start', expect.objectContaining({ hostname: 'sam-laptop' }));
 });
+
+test('resolves a saved profile key before the device flow and config write', async () => {
+  const { program, commands } = fakeProgram();
+  const client = { post: jest.fn().mockResolvedValue({
+    deviceCode: 'private-device-code',
+    userCode: 'ABCD-EFGH',
+    verifyUrl: 'https://commonly.example/cli/authorize',
+    expiresIn: 600,
+    interval: 5,
+  }) };
+  createClient.mockReturnValue(client);
+  resolveInstance.mockReturnValue({ key: 'default', url: 'https://api.example.test' });
+  waitForDeviceAuthorization.mockResolvedValue({ token: 'cm_once', username: 'lily', userId: 'u1' });
+
+  registerLogin(program);
+  await commands[0].handler({ instance: 'default' });
+
+  expect(createClient).toHaveBeenCalledWith({ instance: 'https://api.example.test', token: null });
+  expect(saveInstance).toHaveBeenCalledWith(expect.objectContaining({
+    key: 'default',
+    url: 'https://api.example.test',
+    token: 'cm_once',
+  }));
+});

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@commonlyai/cli",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^12.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonlyai/cli",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "license": "Apache-2.0",
   "description": "The Commonly CLI — connect agents, manage pods, iterate fast",
   "type": "module",

--- a/cli/src/commands/login.js
+++ b/cli/src/commands/login.js
@@ -51,9 +51,10 @@ const promptSecret = (question) => new Promise((resolve) => {
  */
 export const resolveLoginTarget = ({ instanceArg, keyArg }) => {
   const resolved = instanceArg ? resolveInstance(instanceArg) : null;
-  const instanceUrl = (resolved?.url || instanceArg || DEFAULT_URL).replace(/\/$/, '');
+  const isUrl = /^https?:\/\//i.test(instanceArg || '');
+  const instanceUrl = (resolved?.url || (isUrl ? instanceArg : DEFAULT_URL)).replace(/\/$/, '');
   const isLocal = instanceUrl.includes('localhost') || instanceUrl.includes('127.0.0.1');
-  const isSavedKey = instanceArg && !/^https?:\/\//i.test(instanceArg) && resolved?.key;
+  const isSavedKey = instanceArg && !isUrl && resolved?.key;
   const configKey = keyArg || (isSavedKey ? resolved.key : (isLocal ? 'local' : 'default'));
 
   return { instanceUrl, configKey };

--- a/cli/src/commands/login.js
+++ b/cli/src/commands/login.js
@@ -50,7 +50,10 @@ const promptSecret = (question) => new Promise((resolve) => {
  * (for example, "default") into the URL field and break every later command.
  */
 export const resolveLoginTarget = ({ instanceArg, keyArg }) => {
-  const resolved = instanceArg ? resolveInstance(instanceArg) : null;
+  // A missing --instance means "the active profile", just like the other
+  // config helpers. Resolve it before choosing the key so a login without
+  // flags refreshes that profile instead of silently forking `default`.
+  const resolved = resolveInstance(instanceArg);
   const isUrl = /^https?:\/\//i.test(instanceArg || '');
   const instanceUrl = (resolved?.url || (isUrl ? instanceArg : DEFAULT_URL)).replace(/\/$/, '');
   const isLocal = instanceUrl.includes('localhost') || instanceUrl.includes('127.0.0.1');

--- a/cli/src/commands/login.js
+++ b/cli/src/commands/login.js
@@ -8,7 +8,7 @@
 import { createInterface } from 'readline';
 import { hostname } from 'os';
 import { createClient, login as apiLogin } from '../lib/api.js';
-import { saveInstance } from '../lib/config.js';
+import { DEFAULT_URL, resolveInstance, saveInstance } from '../lib/config.js';
 import {
   DeviceLoginCancelledError,
   DeviceLoginDeniedError,
@@ -42,11 +42,28 @@ const promptSecret = (question) => new Promise((resolve) => {
   stdin.on('data', onData);
 });
 
+/**
+ * Resolve the login target before making the request or writing config.
+ *
+ * `--instance` accepts either a URL or a saved profile key. The API client
+ * resolves keys internally, but persisting the raw argument would write a key
+ * (for example, "default") into the URL field and break every later command.
+ */
+export const resolveLoginTarget = ({ instanceArg, keyArg }) => {
+  const resolved = instanceArg ? resolveInstance(instanceArg) : null;
+  const instanceUrl = (resolved?.url || instanceArg || DEFAULT_URL).replace(/\/$/, '');
+  const isLocal = instanceUrl.includes('localhost') || instanceUrl.includes('127.0.0.1');
+  const isSavedKey = instanceArg && !/^https?:\/\//i.test(instanceArg) && resolved?.key;
+  const configKey = keyArg || (isSavedKey ? resolved.key : (isLocal ? 'local' : 'default'));
+
+  return { instanceUrl, configKey };
+};
+
 export const registerLogin = (program) => {
   program
     .command('login')
     .description('Authenticate to a Commonly instance')
-    .option('--instance <url>', 'Instance URL (default: https://api.commonly.me)')
+    .option('--instance <url-or-key>', 'Instance URL or saved profile key (default: https://api.commonly.me)')
     .option('--key <name>', 'Config key to save as (default: "default" or "local")')
     .option('--password', 'Use the legacy email/password prompt instead of device authorization')
     .addHelpText('after', `
@@ -59,12 +76,10 @@ Tokens are stored in ~/.commonly/config.json. Other commands take
 --instance <url-or-key> to target the right profile.
 `)
     .action(async (opts) => {
-      const instanceUrl = opts.instance
-        ? opts.instance.replace(/\/$/, '')
-        : 'https://api.commonly.me';
-
-      const isLocal = instanceUrl.includes('localhost') || instanceUrl.includes('127.0.0.1');
-      const configKey = opts.key || (isLocal ? 'local' : 'default');
+      const { instanceUrl, configKey } = resolveLoginTarget({
+        instanceArg: opts.instance,
+        keyArg: opts.key,
+      });
 
       try {
         if (!opts.password) {

--- a/cli/src/commands/login.js
+++ b/cli/src/commands/login.js
@@ -55,7 +55,10 @@ export const resolveLoginTarget = ({ instanceArg, keyArg }) => {
   const instanceUrl = (resolved?.url || (isUrl ? instanceArg : DEFAULT_URL)).replace(/\/$/, '');
   const isLocal = instanceUrl.includes('localhost') || instanceUrl.includes('127.0.0.1');
   const isKey = instanceArg && !isUrl;
-  const configKey = keyArg || (isKey ? (resolved?.key || instanceArg) : (isLocal ? 'local' : 'default'));
+  // A URL may resolve back to an existing named profile too. Prefer that key
+  // regardless of input shape, or a URL login can fork a second profile onto
+  // the same endpoint and leave the original token stale.
+  const configKey = keyArg || resolved?.key || (isKey ? instanceArg : (isLocal ? 'local' : 'default'));
 
   return { instanceUrl, configKey };
 };

--- a/cli/src/commands/login.js
+++ b/cli/src/commands/login.js
@@ -54,8 +54,8 @@ export const resolveLoginTarget = ({ instanceArg, keyArg }) => {
   const isUrl = /^https?:\/\//i.test(instanceArg || '');
   const instanceUrl = (resolved?.url || (isUrl ? instanceArg : DEFAULT_URL)).replace(/\/$/, '');
   const isLocal = instanceUrl.includes('localhost') || instanceUrl.includes('127.0.0.1');
-  const isSavedKey = instanceArg && !isUrl && resolved?.key;
-  const configKey = keyArg || (isSavedKey ? resolved.key : (isLocal ? 'local' : 'default'));
+  const isKey = instanceArg && !isUrl;
+  const configKey = keyArg || (isKey ? (resolved?.key || instanceArg) : (isLocal ? 'local' : 'default'));
 
   return { instanceUrl, configKey };
 };

--- a/cli/src/commands/login.js
+++ b/cli/src/commands/login.js
@@ -70,12 +70,12 @@ export const registerLogin = (program) => {
   program
     .command('login')
     .description('Authenticate to a Commonly instance')
-    .option('--instance <url-or-key>', 'Instance URL or saved profile key (default: https://api.commonly.me)')
-    .option('--key <name>', 'Config key to save as (default: "default" or "local")')
+    .option('--instance <url-or-key>', 'Instance URL or saved profile key (default: active profile; production on first run)')
+    .option('--key <name>', 'Config key to save as (default: active profile key; otherwise derived from the instance)')
     .option('--password', 'Use the legacy email/password prompt instead of device authorization')
     .addHelpText('after', `
 Examples:
-  $ commonly login                                                   # production (default key)
+  $ commonly login                                                   # active profile (production on first run)
   $ commonly login --instance https://api.commonly.me --key dev  # named profile
   $ commonly login --instance http://localhost:5000                  # saved as "local"
 


### PR DESCRIPTION
## Summary
- resolve --instance <saved-key> before device/password login requests and config persistence
- preserve the saved key as the profile name while storing the resolved URL
- add regression coverage for the saved-key persistence path and update CLI help

## Verification
- npm test -- --runInBand --forceExit login-transcript.test.mjs lib.test.mjs
- npm run lint

Full CLI suite has one unrelated environment failure in mention-event-types.contract.test.mjs because this checkout lacks backend/node_modules/ts-node/register/transpile-only.