### PR TITLE
feat(scripts): one-shot writer for the Your Team description sentences

### DIFF
--- a/backend/__tests__/unit/scripts/set-agent-descriptions.test.js
+++ b/backend/__tests__/unit/scripts/set-agent-descriptions.test.js
@@ -1,0 +1,30 @@
+jest.mock('mongoose', () => ({ connect: jest.fn(), disconnect: jest.fn() }));
+jest.mock('../../../models/User', () => ({ find: jest.fn(), updateOne: jest.fn() }));
+
+const { planDescriptions, DESCRIPTIONS } = require('../../../scripts/set-agent-descriptions');
+
+describe('set-agent-descriptions plan', () => {
+  test('matches by displayName first, then username, and reports what would change', () => {
+    const rows = [
+      { _id: 'u1', username: 'ux-lead', botMetadata: { displayName: 'UX Lead', description: '' } },
+      { _id: 'u2', username: 'hq-support', botMetadata: { displayName: 'Commonly Support', description: 'Answers strangers in HQ. Never quotes, never guesses; escalates with the thread link.' } },
+      { _id: 'u3', username: 'kai', botMetadata: { displayName: 'Kai (Connectors)' } },
+      { _id: 'u4', username: 'someone-else', botMetadata: { displayName: 'Scout' } },
+    ];
+    const { plan, unmatched } = planDescriptions(rows);
+    const byUser = Object.fromEntries(plan.map((p) => [p.username, p]));
+    expect(byUser['ux-lead'].changed).toBe(true);
+    expect(byUser['hq-support'].changed).toBe(false); // idempotent: same sentence already there
+    expect(byUser['kai'].userId).toBe('u3'); // displayName miss → username hit
+    expect(plan.some((p) => p.username === 'someone-else')).toBe(false); // never creates or guesses
+    expect(unmatched).toEqual(DESCRIPTIONS.map((d) => d.seat).filter((s) => !['UX Lead', 'Commonly Support', 'Kai'].includes(s)));
+  });
+
+  test('every sentence obeys the brief: one sentence, under 100 characters, no quotes, role first', () => {
+    for (const d of DESCRIPTIONS) {
+      expect(d.description.length).toBeLessThan(100);
+      expect(d.description).not.toMatch(/[“”"]/);
+      expect(d.description.trim().endsWith('.')).toBe(true);
+    }
+  });
+});

--- a/backend/__tests__/unit/scripts/set-agent-descriptions.test.js
+++ b/backend/__tests__/unit/scripts/set-agent-descriptions.test.js
@@ -20,6 +20,27 @@ describe('set-agent-descriptions plan', () => {
     expect(unmatched).toEqual(DESCRIPTIONS.map((d) => d.seat).filter((s) => !['UX Lead', 'Commonly Support', 'Kai'].includes(s)));
   });
 
+  test('a duplicate displayName is ambiguous: refused, reported, and never decided by row order', () => {
+    const rows = [
+      { _id: 'k1', username: 'kai', botMetadata: { displayName: 'Kai' } },
+      { _id: 'k2', username: 'kai-demo', botMetadata: { displayName: 'Kai' } },
+    ];
+    const a = planDescriptions(rows);
+    const b = planDescriptions([...rows].reverse());
+    expect(a.plan.find((p) => p.seat === 'Kai')).toBeUndefined();
+    expect(b.plan.find((p) => p.seat === 'Kai')).toBeUndefined();
+    expect(a.ambiguous).toEqual([{ seat: 'Kai', usernames: ['kai', 'kai-demo'] }]);
+  });
+
+  test('one row claimed by two seats is a conflict: neither writes, both are named', () => {
+    // The hq-support username with the Commonly Bot display name — the exact
+    // mapping flagged as uncertain — must not take two sentences.
+    const rows = [{ _id: 'h1', username: 'hq-support', botMetadata: { displayName: 'Commonly Bot' } }];
+    const { plan, conflicts } = planDescriptions(rows);
+    expect(plan.filter((p) => String(p.userId) === 'h1')).toHaveLength(0);
+    expect(conflicts).toEqual([{ userId: 'h1', username: 'hq-support', seats: ['Commonly Support', 'Commonly Bot'] }]);
+  });
+
   test('every sentence obeys the brief: one sentence, under 100 characters, no quotes, role first', () => {
     for (const d of DESCRIPTIONS) {
       expect(d.description.length).toBeLessThan(100);

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "bootstrap:clawd-bot": "node scripts/bootstrap-clawd-bot.js",
     "backfill:attention-items": "ts-node scripts/backfill-attention-items.ts",
     "sweep:resolved-mention-attention": "ts-node scripts/sweep-resolved-mention-attention.ts",
+    "set:agent-descriptions": "ts-node scripts/set-agent-descriptions.ts",
     "tsc:check": "tsc --noEmit -p tsconfig.typescheck.json",
     "tsc:check:all": "tsc --noEmit"
   },

--- a/backend/scripts/set-agent-descriptions.ts
+++ b/backend/scripts/set-agent-descriptions.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/*
+ * Write the Your Team line-3 sentences (ux-lead, Sharpen 66328, 2026-09-08)
+ * to `User.botMetadata.description` for the seats on the live page.
+ *
+ * The registry listing projects `botMetadata.description` as `description`
+ * (routes/registry/helpers.ts) and the card renders it as one 13/18 line or
+ * nothing. No route writes the field today, so this one-shot is the write
+ * path until the profile grows an editable description (Raft study, item 1).
+ *
+ * Matching: a seat is found by `botMetadata.displayName` (case-insensitive,
+ * trimmed) first, then by `username`. A sentence whose seat is not found is
+ * reported and skipped — nothing is created. Idempotent: a row already
+ * carrying the same sentence is counted as unchanged.
+ *
+ * Dry run by default:
+ *   node dist/scripts/set-agent-descriptions.js
+ * Apply:
+ *   node dist/scripts/set-agent-descriptions.js --apply
+ */
+import mongoose from 'mongoose';
+import User from '../models/User';
+
+export const DESCRIPTIONS: ReadonlyArray<{ seat: string; usernames: string[]; description: string }> = [
+  { seat: 'Wren', usernames: ['wren'], description: 'Connectors. Presses PRs, watches deploys, and says when a channel is lying.' },
+  { seat: 'Kai', usernames: ['kai'], description: 'Fixes. Takes the next scoped thing without being asked twice; small PRs with a test each.' },
+  { seat: 'Vera', usernames: ['vera'], description: 'Reviews Connectors. Reads the diff against the contract and names what it does not cover.' },
+  { seat: 'Juno', usernames: ['juno'], description: 'Outreach. Finds the people who already have the problem and drafts the first line.' },
+  { seat: 'Sprint Impl', usernames: ['sprint-impl'], description: 'Builds what the board says. One branch per task, tests at the right tier, reports the head.' },
+  { seat: 'Sprint Review', usernames: ['sprint-review'], description: 'The gate. Reviews by mutation, not by reading; nothing merges on its say-so alone.' },
+  { seat: 'UX Lead', usernames: ['ux-lead'], description: 'Design and the visual gate. Rules on the board, walks every PR at 1440 and 390, lists the misses.' },
+  { seat: 'Pod Architect', usernames: ['pod-architect'], description: 'Kernel and data shape. Answers where a record lives before anyone builds on it.' },
+  { seat: 'Fable (lead)', usernames: ['fable-lead'], description: 'Runs the pod. Keeps the goal and the next three tasks current, and closes what is done.' },
+  { seat: 'Commonly Support', usernames: ['commonly-support', 'hq-support'], description: 'Answers strangers in HQ. Never quotes, never guesses; escalates with the thread link.' },
+  { seat: 'Commonly Bot', usernames: ['commonly-bot'], description: "The instance's own seat. Posts what the system did and where to look." },
+  { seat: 'Commonly Summarizer', usernames: ['pod-summarizer', 'commonly-summarizer'], description: 'Digests. Turns a day of a pod into the lines worth reading back.' },
+];
+
+const norm = (v: unknown) => String(v || '').trim().toLowerCase();
+
+export type BotRow = { _id: unknown; username?: string; botMetadata?: { displayName?: string; description?: string } };
+
+/** Pure: which sentence applies to which row, and what would change. */
+export const planDescriptions = (rows: BotRow[]) => {
+  const plan: Array<{ seat: string; userId: unknown; username: string; from: string | undefined; to: string; changed: boolean }> = [];
+  const unmatched: string[] = [];
+  for (const entry of DESCRIPTIONS) {
+    const row = rows.find((r) => norm(r.botMetadata?.displayName) === norm(entry.seat))
+      || rows.find((r) => entry.usernames.includes(norm(r.username)));
+    if (!row) { unmatched.push(entry.seat); continue; }
+    const from = row.botMetadata?.description;
+    plan.push({ seat: entry.seat, userId: row._id, username: String(row.username || ''), from, to: entry.description, changed: (from || '').trim() !== entry.description });
+  }
+  return { plan, unmatched };
+};
+
+const APPLY = process.argv.includes('--apply');
+
+export const main = async (): Promise<void> => {
+  if (!process.env.MONGO_URI) throw new Error('MONGO_URI is required');
+  await mongoose.connect(process.env.MONGO_URI);
+  try {
+    const rows = await User.find({ isBot: true }).select('_id username botMetadata.displayName botMetadata.description').lean() as BotRow[];
+    const { plan, unmatched } = planDescriptions(rows);
+    let written = 0;
+    for (const p of plan) {
+      console.log(`${p.changed ? (APPLY ? 'WRITE ' : 'would ') : 'same  '} ${p.seat} (@${p.username}): ${p.changed ? JSON.stringify(p.from || '') + ' → ' : ''}${JSON.stringify(p.to)}`);
+      if (APPLY && p.changed) {
+        const r = await User.updateOne({ _id: p.userId, isBot: true }, { $set: { 'botMetadata.description': p.to } });
+        written += Number(r.modifiedCount || 0);
+      }
+    }
+    console.log(JSON.stringify({ matched: plan.length, changed: plan.filter((p) => p.changed).length, written, unmatched, apply: APPLY }));
+    if (!APPLY) console.log('DRY RUN — no User rows changed. Re-run with --apply after review.');
+  } finally {
+    await mongoose.disconnect();
+  }
+};
+
+if (require.main === module) {
+  main().catch((error) => { console.error('set-agent-descriptions failed:', error); process.exit(1); });
+}

--- a/backend/scripts/set-agent-descriptions.ts
+++ b/backend/scripts/set-agent-descriptions.ts
@@ -40,18 +40,45 @@ const norm = (v: unknown) => String(v || '').trim().toLowerCase();
 
 export type BotRow = { _id: unknown; username?: string; botMetadata?: { displayName?: string; description?: string } };
 
-/** Pure: which sentence applies to which row, and what would change. */
+/**
+ * Pure: which sentence applies to which row, and what would change.
+ *
+ * Refuses instead of guessing (sprint-review, PR #1636): a seat whose name
+ * matches MORE than one row is `ambiguous` and skipped, so result order can
+ * never decide the target; a row that two seats both claim is a `conflict`
+ * and neither writes, so one `_id` never takes two sentences. Both are
+ * reported, because the dry run cannot show either — an ambiguous match
+ * prints as one confident line and a double write as two ordinary ones.
+ */
 export const planDescriptions = (rows: BotRow[]) => {
   const plan: Array<{ seat: string; userId: unknown; username: string; from: string | undefined; to: string; changed: boolean }> = [];
   const unmatched: string[] = [];
+  const ambiguous: Array<{ seat: string; usernames: string[] }> = [];
+  const conflicts: Array<{ userId: unknown; username: string; seats: string[] }> = [];
+  const claimed = new Map<string, string>(); // _id → seat
+  const candidatesFor = (entry: typeof DESCRIPTIONS[number]) => {
+    const byName = rows.filter((r) => norm(r.botMetadata?.displayName) === norm(entry.seat));
+    if (byName.length) return byName;
+    return rows.filter((r) => entry.usernames.includes(norm(r.username)));
+  };
   for (const entry of DESCRIPTIONS) {
-    const row = rows.find((r) => norm(r.botMetadata?.displayName) === norm(entry.seat))
-      || rows.find((r) => entry.usernames.includes(norm(r.username)));
-    if (!row) { unmatched.push(entry.seat); continue; }
+    const found = candidatesFor(entry);
+    if (found.length === 0) { unmatched.push(entry.seat); continue; }
+    if (found.length > 1) { ambiguous.push({ seat: entry.seat, usernames: found.map((r) => String(r.username || '')) }); continue; }
+    const row = found[0];
+    const id = String(row._id);
+    const holder = claimed.get(id);
+    if (holder) {
+      conflicts.push({ userId: row._id, username: String(row.username || ''), seats: [holder, entry.seat] });
+      const i = plan.findIndex((p) => String(p.userId) === id);
+      if (i >= 0) plan.splice(i, 1);
+      continue;
+    }
+    claimed.set(id, entry.seat);
     const from = row.botMetadata?.description;
     plan.push({ seat: entry.seat, userId: row._id, username: String(row.username || ''), from, to: entry.description, changed: (from || '').trim() !== entry.description });
   }
-  return { plan, unmatched };
+  return { plan, unmatched, ambiguous, conflicts };
 };
 
 const APPLY = process.argv.includes('--apply');
@@ -61,7 +88,9 @@ export const main = async (): Promise<void> => {
   await mongoose.connect(process.env.MONGO_URI);
   try {
     const rows = await User.find({ isBot: true }).select('_id username botMetadata.displayName botMetadata.description').lean() as BotRow[];
-    const { plan, unmatched } = planDescriptions(rows);
+    const { plan, unmatched, ambiguous, conflicts } = planDescriptions(rows);
+    for (const a of ambiguous) console.log(`REFUSE ${a.seat}: ${a.usernames.length} rows match (@${a.usernames.join(', @')}) — fix the duplicate displayName first`);
+    for (const c of conflicts) console.log(`REFUSE @${c.username}: claimed by ${c.seats.join(' and ')} — one row, two sentences`);
     let written = 0;
     for (const p of plan) {
       console.log(`${p.changed ? (APPLY ? 'WRITE ' : 'would ') : 'same  '} ${p.seat} (@${p.username}): ${p.changed ? JSON.stringify(p.from || '') + ' → ' : ''}${JSON.stringify(p.to)}`);
@@ -70,7 +99,7 @@ export const main = async (): Promise<void> => {
         written += Number(r.modifiedCount || 0);
       }
     }
-    console.log(JSON.stringify({ matched: plan.length, changed: plan.filter((p) => p.changed).length, written, unmatched, apply: APPLY }));
+    console.log(JSON.stringify({ matched: plan.length, changed: plan.filter((p) => p.changed).length, written, unmatched, ambiguous: ambiguous.map((a) => a.seat), conflicts: conflicts.map((c) => c.username), apply: APPLY }));
     if (!APPLY) console.log('DRY RUN — no User rows changed. Re-run with --apply after review.');
   } finally {
     await mongoose.disconnect();


### PR DESCRIPTION
Your Team (#1629) renders `botMetadata.description` as each card's third line, or nothing. No route writes the field, so every live card is blank. @ux-lead delivered the twelve sentences in Sharpen (66328): role first, under 100 characters, no quotes.

## Script
`npm run set:agent-descriptions` — dry-run by default, `--apply` to write. Matches a seat by `botMetadata.displayName`, then username; never creates a row; idempotent. Runs inside the backend pod after deploy, like the other one-shots.

## Proof
- Pure planner test: displayName-first then username matching, idempotency (same sentence → unchanged), never guessing (a bot not in the table is untouched), unmatched seats reported.
- Brief test: every sentence < 100 chars, no quotes, ends as a sentence.
- Build tsc clean, eslint 0 errors.

The production `--apply` is Sam's call, after the dry run is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX