### PR TITLE
fix(scripts): the description writer matches by username only; both Bot and Summarizer sentences stand

### DIFF
--- a/backend/__tests__/unit/scripts/set-agent-descriptions.test.js
+++ b/backend/__tests__/unit/scripts/set-agent-descriptions.test.js
@@ -4,41 +4,43 @@ jest.mock('../../../models/User', () => ({ find: jest.fn(), updateOne: jest.fn()
 const { planDescriptions, DESCRIPTIONS } = require('../../../scripts/set-agent-descriptions');
 
 describe('set-agent-descriptions plan', () => {
-  test('matches by displayName first, then username, and reports what would change', () => {
+  test('matches by username only, is idempotent, never guesses, and reports the unmatched', () => {
     const rows = [
       { _id: 'u1', username: 'ux-lead', botMetadata: { displayName: 'UX Lead', description: '' } },
-      { _id: 'u2', username: 'hq-support', botMetadata: { displayName: 'Commonly Support', description: 'Answers strangers in HQ. Never quotes, never guesses; escalates with the thread link.' } },
-      { _id: 'u3', username: 'kai', botMetadata: { displayName: 'Kai (Connectors)' } },
-      { _id: 'u4', username: 'someone-else', botMetadata: { displayName: 'Scout' } },
+      { _id: 'u2', username: 'hq-support-commonly-support', botMetadata: { displayName: 'Commonly Support', description: 'Answers strangers in HQ. Never quotes, never guesses; escalates with the thread link.' } },
+      // A display name that matches a seat on a row whose username does not: never matched.
+      { _id: 'u3', username: 'someone-else', botMetadata: { displayName: 'Kai' } },
     ];
-    const { plan, unmatched } = planDescriptions(rows);
+    const { plan, unmatched, ambiguous, conflicts } = planDescriptions(rows);
     const byUser = Object.fromEntries(plan.map((p) => [p.username, p]));
     expect(byUser['ux-lead'].changed).toBe(true);
-    expect(byUser['hq-support'].changed).toBe(false); // idempotent: same sentence already there
-    expect(byUser['kai'].userId).toBe('u3'); // displayName miss → username hit
-    expect(plan.some((p) => p.username === 'someone-else')).toBe(false); // never creates or guesses
-    expect(unmatched).toEqual(DESCRIPTIONS.map((d) => d.seat).filter((s) => !['UX Lead', 'Commonly Support', 'Kai'].includes(s)));
+    expect(byUser['hq-support-commonly-support'].changed).toBe(false);
+    expect(plan.some((p) => p.username === 'someone-else')).toBe(false);
+    expect(unmatched).toContain('Kai');
+    expect(ambiguous).toEqual([]);
+    expect(conflicts).toEqual([]);
   });
 
-  test('a duplicate displayName is ambiguous: refused, reported, and never decided by row order', () => {
+  test('the live pair (ux-lead 66353): @commonly-bot takes the Commonly Bot line, @commonly-summarizer the Summarizer line, @pod-summarizer nothing — display names ignored', () => {
     const rows = [
-      { _id: 'k1', username: 'kai', botMetadata: { displayName: 'Kai' } },
-      { _id: 'k2', username: 'kai-demo', botMetadata: { displayName: 'Kai' } },
+      { _id: 'b', username: 'commonly-bot', botMetadata: { displayName: 'Commonly Summarizer', description: 'Built-in summary bot' } },
+      { _id: 's', username: 'commonly-summarizer', botMetadata: { displayName: 'Commonly Summarizer (Commonly-Summarizer)' } },
+      { _id: 'p', username: 'pod-summarizer', botMetadata: { displayName: 'Pod Summarizer', description: 'Posts a TLDR of recent pod activity on a schedule.' } },
     ];
-    const a = planDescriptions(rows);
-    const b = planDescriptions([...rows].reverse());
-    expect(a.plan.find((p) => p.seat === 'Kai')).toBeUndefined();
-    expect(b.plan.find((p) => p.seat === 'Kai')).toBeUndefined();
-    expect(a.ambiguous).toEqual([{ seat: 'Kai', usernames: ['kai', 'kai-demo'] }]);
+    const { plan, conflicts, ambiguous } = planDescriptions(rows);
+    expect(plan.map((p) => `${p.username}→${p.seat}`).sort()).toEqual(['commonly-bot→Commonly Bot', 'commonly-summarizer→Commonly Summarizer']);
+    expect(plan.some((p) => p.username === 'pod-summarizer')).toBe(false);
+    expect(conflicts).toEqual([]);
+    expect(ambiguous).toEqual([]);
   });
 
   test('one row claimed by two seats is a conflict: neither writes, both are named', () => {
-    // The hq-support username with the Commonly Bot display name — the exact
-    // mapping flagged as uncertain — must not take two sentences.
-    const rows = [{ _id: 'h1', username: 'hq-support', botMetadata: { displayName: 'Commonly Bot' } }];
-    const { plan, conflicts } = planDescriptions(rows);
-    expect(plan.filter((p) => String(p.userId) === 'h1')).toHaveLength(0);
-    expect(conflicts).toEqual([{ userId: 'h1', username: 'hq-support', seats: ['Commonly Support', 'Commonly Bot'] }]);
+    const rows = [{ _id: 'h1', username: 'hq-support', botMetadata: {} }];
+    // Force a second claim on the same row by giving Commonly Bot the same username in a copy of the table.
+    const { planDescriptions: plan2 } = jest.requireActual('../../../scripts/set-agent-descriptions');
+    const result = plan2(rows.concat([{ _id: 'h1', username: 'commonly-bot', botMetadata: {} }]));
+    expect(result.conflicts).toEqual([{ userId: 'h1', username: 'commonly-bot', seats: ['Commonly Support', 'Commonly Bot'] }]);
+    expect(result.plan.filter((p) => String(p.userId) === 'h1')).toHaveLength(0);
   });
 
   test('every sentence obeys the brief: one sentence, under 100 characters, no quotes, role first', () => {

--- a/backend/__tests__/unit/scripts/set-agent-descriptions.test.js
+++ b/backend/__tests__/unit/scripts/set-agent-descriptions.test.js
@@ -35,7 +35,7 @@ describe('set-agent-descriptions plan', () => {
   });
 
   test('one row claimed by two seats is a conflict: neither writes, both are named', () => {
-    const rows = [{ _id: 'h1', username: 'hq-support', botMetadata: {} }];
+    const rows = [{ _id: 'h1', username: 'hq-support-commonly-support', botMetadata: {} }];
     // Force a second claim on the same row by giving Commonly Bot the same username in a copy of the table.
     const { planDescriptions: plan2 } = jest.requireActual('../../../scripts/set-agent-descriptions');
     const result = plan2(rows.concat([{ _id: 'h1', username: 'commonly-bot', botMetadata: {} }]));

--- a/backend/scripts/set-agent-descriptions.ts
+++ b/backend/scripts/set-agent-descriptions.ts
@@ -31,7 +31,7 @@ export const DESCRIPTIONS: ReadonlyArray<{ seat: string; usernames: string[]; de
   { seat: 'UX Lead', usernames: ['ux-lead'], description: 'Design and the visual gate. Rules on the board, walks every PR at 1440 and 390, lists the misses.' },
   { seat: 'Pod Architect', usernames: ['pod-architect'], description: 'Kernel and data shape. Answers where a record lives before anyone builds on it.' },
   { seat: 'Fable (lead)', usernames: ['fable-lead'], description: 'Runs the pod. Keeps the goal and the next three tasks current, and closes what is done.' },
-  { seat: 'Commonly Support', usernames: ['hq-support-commonly-support', 'commonly-support', 'hq-support'], description: 'Answers strangers in HQ. Never quotes, never guesses; escalates with the thread link.' },
+  { seat: 'Commonly Support', usernames: ['hq-support-commonly-support'], description: 'Answers strangers in HQ. Never quotes, never guesses; escalates with the thread link.' },
   { seat: 'Commonly Bot', usernames: ['commonly-bot'], description: "The instance's own seat. Posts what the system did and where to look." },
   // Live rows (grep 2026-09-08 11:12Z): @commonly-bot carries displayName
   // "Commonly Summarizer" and is the card labelled "Commonly Bot"; the row

--- a/backend/scripts/set-agent-descriptions.ts
+++ b/backend/scripts/set-agent-descriptions.ts
@@ -8,10 +8,10 @@
  * nothing. No route writes the field today, so this one-shot is the write
  * path until the profile grows an editable description (Raft study, item 1).
  *
- * Matching: a seat is found by `botMetadata.displayName` (case-insensitive,
- * trimmed) first, then by `username`. A sentence whose seat is not found is
- * reported and skipped — nothing is created. Idempotent: a row already
- * carrying the same sentence is counted as unchanged.
+ * Matching: by `username` only — display names are labels and diverge from
+ * identity on live rows. A sentence whose seat is not found is reported and
+ * skipped — nothing is created. Idempotent: a row already carrying the same
+ * sentence is counted as unchanged.
  *
  * Dry run by default:
  *   node dist/scripts/set-agent-descriptions.js
@@ -31,9 +31,14 @@ export const DESCRIPTIONS: ReadonlyArray<{ seat: string; usernames: string[]; de
   { seat: 'UX Lead', usernames: ['ux-lead'], description: 'Design and the visual gate. Rules on the board, walks every PR at 1440 and 390, lists the misses.' },
   { seat: 'Pod Architect', usernames: ['pod-architect'], description: 'Kernel and data shape. Answers where a record lives before anyone builds on it.' },
   { seat: 'Fable (lead)', usernames: ['fable-lead'], description: 'Runs the pod. Keeps the goal and the next three tasks current, and closes what is done.' },
-  { seat: 'Commonly Support', usernames: ['commonly-support', 'hq-support'], description: 'Answers strangers in HQ. Never quotes, never guesses; escalates with the thread link.' },
+  { seat: 'Commonly Support', usernames: ['hq-support-commonly-support', 'commonly-support', 'hq-support'], description: 'Answers strangers in HQ. Never quotes, never guesses; escalates with the thread link.' },
   { seat: 'Commonly Bot', usernames: ['commonly-bot'], description: "The instance's own seat. Posts what the system did and where to look." },
-  { seat: 'Commonly Summarizer', usernames: ['pod-summarizer', 'commonly-summarizer'], description: 'Digests. Turns a day of a pod into the lines worth reading back.' },
+  // Live rows (grep 2026-09-08 11:12Z): @commonly-bot carries displayName
+  // "Commonly Summarizer" and is the card labelled "Commonly Bot"; the row
+  // whose page label reads "Commonly Summarizer" is @commonly-summarizer.
+  // @pod-summarizer is a different first-party app with its own sentence and
+  // is not in this table on purpose. ux-lead 66353: two rows, two sentences.
+  { seat: 'Commonly Summarizer', usernames: ['commonly-summarizer'], description: 'Digests. Turns a day of a pod into the lines worth reading back.' },
 ];
 
 const norm = (v: unknown) => String(v || '').trim().toLowerCase();
@@ -56,11 +61,11 @@ export const planDescriptions = (rows: BotRow[]) => {
   const ambiguous: Array<{ seat: string; usernames: string[] }> = [];
   const conflicts: Array<{ userId: unknown; username: string; seats: string[] }> = [];
   const claimed = new Map<string, string>(); // _id → seat
-  const candidatesFor = (entry: typeof DESCRIPTIONS[number]) => {
-    const byName = rows.filter((r) => norm(r.botMetadata?.displayName) === norm(entry.seat));
-    if (byName.length) return byName;
-    return rows.filter((r) => entry.usernames.includes(norm(r.username)));
-  };
+  // Username only. Display names are labels, not identity: on live data a
+  // displayName match outranked a username match and the username's own row
+  // was reported nowhere (sprint-review 66350). Usernames are unique, so the
+  // ambiguity guard below is defensive; the claim guard still does real work.
+  const candidatesFor = (entry: typeof DESCRIPTIONS[number]) => rows.filter((r) => entry.usernames.includes(norm(r.username)));
   for (const entry of DESCRIPTIONS) {
     const found = candidatesFor(entry);
     if (found.length === 0) { unmatched.push(entry.seat); continue; }


### PR DESCRIPTION
The dry run at e096ddb7 refused the `@commonly-bot` row because a displayName match and a username match claimed it together. The grep behind it shows **two rows**: `@commonly-bot` (displayName "Commonly Summarizer", the card labelled "Commonly Bot") and `@commonly-summarizer` (the row the page labels "Commonly Summarizer"). So @ux-lead's amended ruling (Sharpen 66353) applies — two rows, two sentences — and the earlier version of this PR, which folded the username, was wrong.

## Fix
- Match by **username only**. Display names are labels, not identity: on live data a displayName match outranked a username match and the username's own row was reported nowhere (@sprint-review 66350).
- That rule exposed Commonly Support's live username `hq-support-commonly-support`, which had only ever matched through its label — added.
- `@pod-summarizer` is a different first-party app with its own sentence; not in the table on purpose.

## Proof
Tests: username-only (a label match with the wrong username never matches); the live pair resolves to exactly two writes, no conflict, nothing on `@pod-summarizer`; the double-claim guard still refuses; every sentence holds the brief. Mutation: restoring the displayName door → 2 red. Build tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX