### PR TITLE
fix: keep agent avatars on live messages

### DIFF
--- a/backend/__tests__/unit/services/agentMessageService.threadRootBroadcast.test.js
+++ b/backend/__tests__/unit/services/agentMessageService.threadRootBroadcast.test.js
@@ -22,6 +22,7 @@ const AgentIdentityService = require('../../../services/agentIdentityService');
 const socketConfig = require('../../../config/socket');
 const DMService = require('../../../services/dmService');
 const PGMessage = require('../../../models/pg/Message');
+const Message = require('../../../models/Message');
 const File = require('../../../models/File');
 
 jest.mock('../../../models/Message');
@@ -146,6 +147,11 @@ describe('agent broadcast carries thread_root_id', () => {
     const msg = emitted.find((e) => e.event === 'newMessage');
     expect(msg).toBeTruthy();
     expect(msg.payload.thread_root_id).toBe('57475');
+    // Live viewers must get the same agent identity as the joined history row.
+    expect(msg.payload.userId).toEqual(expect.objectContaining({
+      _id: 'agent-user-1',
+      isBot: true,
+    }));
   });
 
   it('a non-reply row emits an explicit null root, never an absent field', async () => {
@@ -165,5 +171,38 @@ describe('agent broadcast carries thread_root_id', () => {
     expect(msg).toBeTruthy();
     expect(msg.payload).toHaveProperty('thread_root_id');
     expect(msg.payload.thread_root_id).toBeNull();
+  });
+});
+
+describe('agent broadcast carries author identity', () => {
+  it('preserves the bot marker through Mongo population and the socket whitelist', async () => {
+    delete process.env.PG_HOST;
+    const populate = jest.fn(async function populateAuthor(_path, fields) {
+      this.userId = {
+        _id: 'agent-user-1',
+        username: 'sprint-review',
+        ...(fields.split(' ').includes('isBot') ? { isBot: true } : {}),
+      };
+    });
+    Message.mockImplementation((data) => ({
+      ...data,
+      _id: 'mongo-message-1',
+      createdAt: new Date(),
+      save: jest.fn().mockResolvedValue(undefined),
+      populate,
+    }));
+
+    await AgentMessageService.postMessage({
+      agentName: 'sprint-review',
+      instanceId: 'default',
+      podId: POD,
+      content: 'A live agent message',
+    });
+
+    const msg = emitted.find((e) => e.event === 'newMessage');
+    expect(msg.payload.userId).toEqual(expect.objectContaining({
+      _id: 'agent-user-1',
+      isBot: true,
+    }));
   });
 });

--- a/backend/services/agentMessageService.ts
+++ b/backend/services/agentMessageService.ts
@@ -224,7 +224,7 @@ interface MessageNormalized {
   id: unknown;
   content: string;
   messageType: string;
-  userId: { _id: unknown; username: string; profilePicture?: string };
+  userId: { _id: unknown; username: string; profilePicture?: string; isBot?: boolean };
   username: string;
   isBot?: boolean;
   // Present ONLY when the caller identified itself via `selfUserId`. An
@@ -1683,6 +1683,7 @@ class AgentMessageService {
             _id: agentUser._id,
             username: senderDisplayName || 'Unknown',
             profilePicture: agentUser.profilePicture,
+            isBot: true,
           },
           username: senderDisplayName || 'Unknown',
           profile_picture: agentUser.profilePicture,
@@ -1717,7 +1718,7 @@ class AgentMessageService {
       });
 
       await mongoMessage.save();
-      await mongoMessage.populate('userId', 'username profilePicture');
+      await mongoMessage.populate('userId', 'username profilePicture isBot');
       message = mongoMessage as MessageNormalized;
     }
 
@@ -1780,6 +1781,7 @@ class AgentMessageService {
           _id: agentUser._id,
           username: senderDisplayName,
           profilePicture: agentUser.profilePicture,
+          isBot: true,
         },
         username: (message as MessageNormalized).username || senderDisplayName,
         profile_picture: (message as MessageNormalized).profile_picture || agentUser.profilePicture,

--- a/docs/design/signal-identity.md
+++ b/docs/design/signal-identity.md
@@ -16,6 +16,8 @@ A screen is done when it matches its artboard at 1440 and 390 in a real browser.
 4. **Hard edges, no shadows.** Radius 4 on controls, rows, chips, avatars and marks; 6 on cards, panels and the content card. No shadow anywhere; elevation is a border. Avatars keep the 4px square frame and render uploaded photos or stable Big Smile faces for people and agents, including chat, thread previews and the pod inspector (Sam, 2026-09-08). Initials are a fallback, not a replacement for a known identity.
 5. **Engagement is behaviour, not paint.** A card settles when you pick; a row flips when an agent takes it; presence is a pulsing dot (1.6s, respects reduced motion). Energy comes from things changing, never from adding colour. When a screen feels flat, remove something.
 
+Agent identity must survive both history reads and live message broadcasts: `userId.isBot` identifies the author before a refresh. Verify a newly arriving agent message as well as a reloaded thread; a history-only check misses incomplete socket payloads.
+
 ## 2. The grey ramp (complete — do not add greys)
 
 | role | hex | used for |


### PR DESCRIPTION
New agent messages showed initials until the page was refreshed because their socket payload omitted the author’s bot marker. Preserve `userId.isBot` on both PostgreSQL and Mongo message paths so live messages render the same Big Smile avatar as loaded history.

Validation: three focused broadcast tests pass, backend TypeScript lint and build typecheck pass. The regression tests inspect the actual socket payload for both storage paths. The design reference now calls for checking new arrivals before refresh.
