### PR TITLE
fix: place runtime label beside chat author

### DIFF
--- a/frontend/src/v2/__tests__/V2MessageRow.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageRow.test.tsx
@@ -18,7 +18,8 @@ describe('V2MessageRow', () => {
     render(
       <MemoryRouter>
         <V2MessageRow
-          message={{ id: 'runtime-label', content: 'Review complete.',
+          message={{ id: 'runtime-label', pod_id: 'pod-1', user_id: 'vale-1',
+            message_type: 'text', content: 'Review complete.',
             created_at: '2026-09-08T20:00:00.000Z',
             user: { username: 'vale', isBot: true } }}
           agentTags={new Map([['vale', 'claude']])}

--- a/frontend/src/v2/__tests__/V2MessageRow.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageRow.test.tsx
@@ -20,7 +20,7 @@ describe('V2MessageRow', () => {
         <V2MessageRow
           message={{ id: 'runtime-label', content: 'Review complete.',
             created_at: '2026-09-08T20:00:00.000Z',
-            user: { username: 'vale', displayName: 'Vale', isBot: true } }}
+            user: { username: 'vale', isBot: true } }}
           agentTags={new Map([['vale', 'claude']])}
           agentDisplayNames={new Map([['vale', 'Vale']])}
         />

--- a/frontend/src/v2/__tests__/V2MessageRow.test.tsx
+++ b/frontend/src/v2/__tests__/V2MessageRow.test.tsx
@@ -14,6 +14,23 @@ describe('V2MessageRow', () => {
     process.env.REACT_APP_API_URL = previousApiUrl;
   });
 
+  it('keeps the runtime beside the agent name before its timestamp', () => {
+    render(
+      <MemoryRouter>
+        <V2MessageRow
+          message={{ id: 'runtime-label', content: 'Review complete.',
+            created_at: '2026-09-08T20:00:00.000Z',
+            user: { username: 'vale', displayName: 'Vale', isBot: true } }}
+          agentTags={new Map([['vale', 'claude']])}
+          agentDisplayNames={new Map([['vale', 'Vale']])}
+        />
+      </MemoryRouter>,
+    );
+    const tag = screen.getByText('claude');
+    expect(tag.previousElementSibling).toHaveTextContent('Vale');
+    expect(tag.nextElementSibling).toHaveClass('v2-msg__time');
+  });
+
   it('resolves relative uploaded images against the configured API origin', () => {
     process.env.REACT_APP_API_URL = 'https://api.commonly.me';
 

--- a/frontend/src/v2/components/V2MessageRow.tsx
+++ b/frontend/src/v2/components/V2MessageRow.tsx
@@ -614,8 +614,8 @@ const V2MessageRow: React.FC<V2MessageRowProps> = ({ message, sourceMessageId, d
             <span className="v2-msg__author">{author}</span>
           )}
           {isLead && <span className="v2-msg__lead-badge">{t('podChat.leadBadge')}</span>}
-          {time && <span className="v2-msg__time">{time}</span>}
           {runtimeTag && <span className="v2-msg__tag">{runtimeTag}</span>}
+          {time && <span className="v2-msg__time">{time}</span>}
           {isDecisionRuling && <span className="v2-msg__ruled">· {t('activity.decision.ruledShort')}</span>}
         </div>
         )}


### PR DESCRIPTION
Chat runtime labels followed the timestamp, separating an agent's name from its runtime. Put the runtime immediately after the author/lead label and before the timestamp so mixed-runtime conversations are easier to scan.

Validation: the focused message-row suite passes (5 tests), including rendered author → runtime → timestamp order. No CSS or token changes. Production visual verification will follow deployment.
