### PR TITLE
fix(hosted): provision resolves the caller's own installation when no instanceId is sent — every persona hire was 404ing

### DIFF
--- a/backend/__tests__/unit/routes/hosted.test.js
+++ b/backend/__tests__/unit/routes/hosted.test.js
@@ -4,6 +4,7 @@ const request = require('supertest');
 const express = require('express');
 
 const mockFindOne = jest.fn();
+const mockFind = jest.fn();
 const mockUserFindOne = jest.fn();
 const mockIssueToken = jest.fn();
 const mockHosted = {
@@ -26,7 +27,7 @@ jest.mock('../../../middleware/auth', () => (req, _res, next) => {
   next();
 });
 jest.mock('../../../models/AgentRegistry', () => ({
-  AgentInstallation: { findOne: (...args) => mockFindOne(...args) },
+  AgentInstallation: { findOne: (...args) => mockFindOne(...args), find: (...args) => mockFind(...args) },
 }));
 jest.mock('../../../models/User', () => ({ findOne: (...args) => mockUserFindOne(...args) }));
 const mockCredentialUpdateMany = jest.fn();
@@ -57,6 +58,10 @@ const makeInstallation = (overrides = {}) => ({
 describe('/api/hosted', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Requests without an instanceId now resolve through find(); the older
+    // tests mock findOne, so by default find() answers with that same row.
+    mockFind.mockReset();
+    mockFind.mockImplementation(async () => { const one = await mockFindOne(); return one ? [one] : []; });
     mockHosted.isConfigured.mockReturnValue(true);
     mockHosted.isHostedInstallation.mockReturnValue(true);
     mockHosted.countHostedAgentsForUser.mockResolvedValue(1);
@@ -90,13 +95,41 @@ describe('/api/hosted', () => {
   });
 
   it('404s unless the caller is the installer of an active installation', async () => {
-    mockFindOne.mockResolvedValue(null);
+    mockFind.mockResolvedValue([]);
     const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
     expect(res.status).toBe(404);
     expect(res.body.code).toBe('not_owner_or_missing');
-    expect(mockFindOne).toHaveBeenCalledWith({
-      agentName: 'scout', instanceId: 'default', status: 'active', installedBy: 'owner-1',
-    });
+    // No instanceId in the request → the lookup is by owner + agent, never by an assumed "default".
+    expect(mockFind).toHaveBeenCalledWith({ agentName: 'scout', status: 'active', installedBy: 'owner-1' });
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
+
+  it('a persona hire provisions without an instanceId: the install derived "scout" from the display name and the UI sends only agentName (stranger smoke, 2026-09-08)', async () => {
+    mockFind.mockResolvedValue([makeInstallation({ agentName: 'scout-678386', instanceId: 'scout' })]);
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout-678386' });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ provisioned: true, agentName: 'scout-678386', instanceId: 'scout', podId: 'pod-1' });
+    expect(mockHosted.provisionAgent).toHaveBeenCalledWith({ agentName: 'scout-678386', instanceId: 'scout', runtimeToken: 'cm_agent_secret' });
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
+
+  it('with two owned instances and no instanceId, prefers "default" and otherwise asks for one (409)', async () => {
+    mockFind.mockResolvedValue([makeInstallation({ instanceId: 'scout' }), makeInstallation({ instanceId: 'default' })]);
+    const ok = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(ok.status).toBe(200);
+    expect(ok.body.instanceId).toBe('default');
+    mockFind.mockResolvedValue([makeInstallation({ instanceId: 'scout' }), makeInstallation({ instanceId: 'demo' })]);
+    const amb = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(amb.status).toBe(409);
+    expect(amb.body).toMatchObject({ code: 'ambiguous_instance', instanceIds: ['scout', 'demo'] });
+  });
+
+  it('an explicit instanceId still resolves by findOne exactly as before', async () => {
+    mockFindOne.mockResolvedValue(makeInstallation({ instanceId: 'demo' }));
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout', instanceId: 'demo' });
+    expect(res.status).toBe(200);
+    expect(mockFindOne).toHaveBeenCalledWith({ agentName: 'scout', instanceId: 'demo', status: 'active', installedBy: 'owner-1' });
+    expect(mockFind).not.toHaveBeenCalled();
   });
 
   it('409s when the owned installation is not a hosted one', async () => {

--- a/backend/__tests__/unit/routes/hosted.test.js
+++ b/backend/__tests__/unit/routes/hosted.test.js
@@ -124,6 +124,29 @@ describe('/api/hosted', () => {
     expect(amb.body).toMatchObject({ code: 'ambiguous_instance', instanceIds: ['scout', 'demo'] });
   });
 
+  it('prefers the hosted row over a non-hosted "default" when no instanceId is sent (sprint-review on #1644)', async () => {
+    const hosted = makeInstallation({ instanceId: 'scout' });
+    const byo = makeInstallation({ instanceId: 'default', config: new Map([['runtime', { runtimeType: 'byo' }]]) });
+    mockHosted.isHostedInstallation.mockImplementation((row) => row.config.get('runtime').runtimeType === 'hosted');
+    mockFind.mockResolvedValue([byo, hosted]);
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(res.status).toBe(200);
+    expect(res.body.instanceId).toBe('scout');
+    expect(mockHosted.provisionAgent).toHaveBeenCalledWith(expect.objectContaining({ instanceId: 'scout' }));
+    // Nothing hosted at all → the honest not_hosted answer survives.
+    mockFind.mockResolvedValue([byo]);
+    const none = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(none.status).toBe(409);
+    expect(none.body.code).toBe('not_hosted');
+  });
+
+  it('deprovision without an instanceId resolves the same single owned seat — deliberate symmetry, caller-scoped', async () => {
+    mockFind.mockResolvedValue([makeInstallation({ instanceId: 'scout' })]);
+    const res = await request(app).post('/api/hosted/deprovision').send({ agentName: 'scout' });
+    expect(res.status).toBe(200);
+    expect(mockFind).toHaveBeenCalledWith({ agentName: 'scout', status: 'active', installedBy: 'owner-1' });
+  });
+
   it('an explicit instanceId still resolves by findOne exactly as before', async () => {
     mockFindOne.mockResolvedValue(makeInstallation({ instanceId: 'demo' }));
     const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout', instanceId: 'demo' });

--- a/backend/routes/hosted.ts
+++ b/backend/routes/hosted.ts
@@ -79,6 +79,9 @@ const resolveOwnedHostedInstallation = async (req: any, source: Record<string, a
   } else {
     // No instanceId in the request: resolve the caller's own active
     // installation of this agent, whatever instanceId the install derived.
+    // This resolver serves deprovision too, deliberately: the same client
+    // that provisioned without an instanceId must be able to tear the seat
+    // down without one, and both verbs stay caller-scoped (installedBy).
     // The install route derives instanceId from displayName (a persona hire
     // named "Scout" becomes instanceId "scout"), while the hire UI sends only
     // agentName — so defaulting to "default" here made every persona hire
@@ -88,7 +91,13 @@ const resolveOwnedHostedInstallation = async (req: any, source: Record<string, a
       status: 'active',
       installedBy: getUserId(req),
     });
-    const rows: any[] = Array.isArray(owned) ? owned : [];
+    // Hosted rows first (sprint-review on #1644): a non-hosted "default" beside
+    // a hosted "scout" must resolve to the seat that can actually be
+    // provisioned, not 409 not_hosted about the wrong row. Falling back to
+    // every row keeps the honest not_hosted answer when nothing is hosted.
+    const all: any[] = Array.isArray(owned) ? owned : [];
+    const hostedRows = all.filter((row: any) => hostedRuntime.isHostedInstallation(row));
+    const rows: any[] = hostedRows.length ? hostedRows : all;
     if (rows.length === 1) [installation] = rows;
     else if (rows.length > 1) {
       installation = rows.find((row: any) => String(row.instanceId || '') === 'default') || null;

--- a/backend/routes/hosted.ts
+++ b/backend/routes/hosted.ts
@@ -58,7 +58,8 @@ const resolveOwnedHostedInstallation = async (req: any, source: Record<string, a
   // (a name that lost characters had invalid ones → 400, never a lookup of
   // a different identity). Same pattern as registry/install.
   const rawAgentName = String(source.agentName || '').toLowerCase();
-  const rawInstanceId = String(source.instanceId || 'default').toLowerCase();
+  const instanceGiven = source.instanceId !== undefined && source.instanceId !== null && String(source.instanceId) !== '';
+  const rawInstanceId = String(instanceGiven ? source.instanceId : 'default').toLowerCase();
   const agentName = rawAgentName.replace(/[^a-z0-9@/-]/g, '');
   const instanceId = rawInstanceId.replace(/[^a-z0-9-]/g, '');
   if (!agentName || agentName !== rawAgentName || !AGENT_NAME_RE.test(agentName)) {
@@ -67,19 +68,43 @@ const resolveOwnedHostedInstallation = async (req: any, source: Record<string, a
   if (!instanceId || instanceId !== rawInstanceId || !INSTANCE_RE.test(instanceId)) {
     return { error: { status: 400, body: { code: 'invalid_instance_id', message: 'instanceId must match /^[a-z0-9-]+$/' } } };
   }
-  const installation = await AgentInstallation.findOne({
-    agentName,
-    instanceId,
-    status: 'active',
-    installedBy: getUserId(req),
-  });
+  let installation: any = null;
+  if (instanceGiven) {
+    installation = await AgentInstallation.findOne({
+      agentName,
+      instanceId,
+      status: 'active',
+      installedBy: getUserId(req),
+    });
+  } else {
+    // No instanceId in the request: resolve the caller's own active
+    // installation of this agent, whatever instanceId the install derived.
+    // The install route derives instanceId from displayName (a persona hire
+    // named "Scout" becomes instanceId "scout"), while the hire UI sends only
+    // agentName — so defaulting to "default" here made every persona hire
+    // 404 at provision and never run. Found by the stranger smoke, 2026-09-08.
+    const owned = await AgentInstallation.find({
+      agentName,
+      status: 'active',
+      installedBy: getUserId(req),
+    });
+    const rows: any[] = Array.isArray(owned) ? owned : [];
+    if (rows.length === 1) [installation] = rows;
+    else if (rows.length > 1) {
+      installation = rows.find((row: any) => String(row.instanceId || '') === 'default') || null;
+      if (!installation) {
+        return { error: { status: 409, body: { code: 'ambiguous_instance', message: 'You own more than one instance of that agent; pass instanceId', instanceIds: rows.map((row: any) => String(row.instanceId || '')) } } };
+      }
+    }
+  }
   if (!installation) {
     return { error: { status: 404, body: { code: 'not_owner_or_missing', message: 'No active installation of that agent is owned by you' } } };
   }
   if (!hostedRuntime.isHostedInstallation(installation)) {
     return { error: { status: 409, body: { code: 'not_hosted', message: 'That agent was not installed with runtimeType "hosted"' } } };
   }
-  return { installation, agentName, instanceId };
+  // An explicit instanceId was the lookup key; a resolved row carries its own.
+  return { installation, agentName, instanceId: instanceGiven ? instanceId : String(installation.instanceId || instanceId) };
 };
 
 const requireConfigured = (res: express.Response): boolean => {


### PR DESCRIPTION
## What

A P0 on the hero path, found by the new stranger smoke (`scratchpad/pw/smoke-stranger.js`, run as Lily against production on 2026-09-08):

1. The hire UI posts `/api/registry/install` with `displayName: "Scout"` for a persona hire.
2. The install route derives `instanceId` from the display name → `"scout"`.
3. The UI then posts `/api/hosted/provision` with only `agentName`; provision defaulted `instanceId` to `"default"` → **404 `not_owner_or_missing`** → the hosted seat is never provisioned → the first message is enqueued and nobody ever answers.

Provisioning the same seat by hand with `instanceId: "scout"` replied in **3 seconds**, so the runtime is fine; the lookup key was wrong. A no-persona hire (display name = agent name → `default`) was never affected, which is why the 08-28 stranger path passed.

## Fix

Without an `instanceId`, the resolver (shared by provision and deprovision) finds the caller's active installations of that agent and takes the single row; with several it prefers `default`, otherwise 409 `ambiguous_instance` naming them. An explicit `instanceId` behaves exactly as before.

## Proof

`hosted.test.js` + `registry.hosted-cap-gate.test.js`: 19/19 under Node 22 — the persona case (install row `scout`, request without id → provisions `scout`), the two-instance case (prefers `default`; 409 otherwise), the explicit case (findOne, unchanged), and the 404 lookup shape (by owner + agent, never an assumed default). Live: seat `scout-678386` in Lily's smoke pod, provisioned with the right id → reply in 3s.

After deploy the stranger smoke re-runs end to end; the two FAILs it currently reports are exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX
