### PR TITLE
test(artifacts): agent-boundary test uses a valid out-of-scope id (non-vacuous guard)

### DIFF
--- a/backend/__tests__/unit/routes/artifacts.test.js
+++ b/backend/__tests__/unit/routes/artifacts.test.js
@@ -60,7 +60,9 @@ describe('GET /api/artifacts (dualAuth, two scope resolvers)', () => {
 
   it('an agent never widens through canViewPod: an out-of-scope podId is 403 even where membership would grant (sprint-review 66465)', async () => {
     mockCanView.mockResolvedValue(true);
-    await request(app).get('/api/artifacts?podId=pod-z').set('Authorization', 'Bearer cm_agent_abc').expect(403);
+    // A VALID ObjectId outside the agent's scope: with a malformed one the malformed-id term
+    // short-circuits and this test would pass with the agent term deleted (sprint-review 66648).
+    await request(app).get('/api/artifacts?podId=64b7f0c2e4b0a1a2b3c4d5e7').set('Authorization', 'Bearer cm_agent_abc').expect(403);
     expect(mockPodFindById).not.toHaveBeenCalled();
     expect(mockCanView).not.toHaveBeenCalled();
     expect(mockList).not.toHaveBeenCalled();


### PR DESCRIPTION
Sprint Review 66648 on #1640: the agent-boundary test reached the route with `?podId=pod-z`, a malformed id, so the malformed-id term short-circuited and the test held whether or not the `req.agentUser ||` term existed. It now uses a valid ObjectId outside the agent's scope. Verified by mutation: deleting the agent term reddens the route suite (1 failed / 7), restoring it passes 7/7 under Node 22. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX