### PR TITLE
feat(activity): day zero is a Get started card above Needs you — a step is not an ask

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -92,28 +92,6 @@
       "countLabel": "{{count}} waiting on you",
       "emptyLast": "The last ask was answered {{age}} ago."
     },
-    "dayZero": {
-      "kind": "Get started",
-      "guide": {
-        "title": "Meet your Guide",
-        "description": "Get a short, guided path into your first agent conversation.",
-        "leaves": "Leaves when your Guide replies.",
-        "cta": "Meet your Guide"
-      },
-      "agent": {
-        "title": "Hire your first agent",
-        "description": "Add a teammate that can take work forward with you.",
-        "leaves": "Leaves when an agent joins your workspace.",
-        "cta": "Hire your first agent",
-        "secondary": "Connect my own"
-      },
-      "task": {
-        "title": "Give it something real to do",
-        "description": "Put the first concrete task where your team can pick it up.",
-        "leaves": "Leaves when a task is claimed.",
-        "cta": "Create a task"
-      }
-    },
     "approval": {
       "approve": "Approve",
       "deny": "Deny",
@@ -172,7 +150,27 @@
       "showLess": "Show less",
       "unknownPod": "Unknown pod"
     },
-    "footer": "Open the source thread to act; this recap leaves when the underlying fact changes."
+    "footer": "Open the source thread to act; this recap leaves when the underlying fact changes.",
+    "getStarted": {
+      "title": "Get started",
+      "kicker_one": "1 step · until your first ask arrives",
+      "kicker_other": "{{count}} steps · until your first ask arrives",
+      "hire": {
+        "title": "Hire your first agent",
+        "description": "Pick a persona. It gets a seat in this workspace and answers within seconds.",
+        "cta": "Hire an agent"
+      },
+      "speak": {
+        "title": "Say something to it",
+        "description": "@mention it in any pod. The first reply is the moment this becomes yours.",
+        "cta": "Open My Workspace"
+      },
+      "connect": {
+        "title": "Connect a channel",
+        "description": "Slack or Telegram — the agent answers where your team already talks.",
+        "cta": "Add a connector"
+      }
+    }
   },
   "auth": {
     "fields": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -92,28 +92,6 @@
       "countLabel": "{{count}} 项等你处理",
       "emptyLast": "上一个请求已在 {{age}} 前回复。"
     },
-    "dayZero": {
-      "kind": "开始使用",
-      "guide": {
-        "title": "认识你的向导",
-        "description": "通过简短引导，开始第一次与智能体的对话。",
-        "leaves": "向导回复后，此项会离开。",
-        "cta": "认识你的向导"
-      },
-      "agent": {
-        "title": "聘用你的第一个智能体",
-        "description": "添加一位能和你一起推进工作的队友。",
-        "leaves": "智能体加入工作区后，此项会离开。",
-        "cta": "聘用第一个智能体",
-        "secondary": "连接我自己的"
-      },
-      "task": {
-        "title": "给它一件真正要做的事",
-        "description": "把第一件具体任务放到团队能接手的地方。",
-        "leaves": "任务被认领后，此项会离开。",
-        "cta": "创建任务"
-      }
-    },
     "approval": {
       "approve": "批准",
       "deny": "拒绝",
@@ -172,7 +150,27 @@
       "showLess": "收起",
       "unknownPod": "未知 Pod"
     },
-    "footer": "请在源讨论中行动；底层事实变化后，这份回顾会自动离开。"
+    "footer": "请在源讨论中行动；底层事实变化后，这份回顾会自动离开。",
+    "getStarted": {
+      "title": "开始使用",
+      "kicker_one": "还有 1 步 · 直到你的第一个请求到来",
+      "kicker_other": "还有 {{count}} 步 · 直到你的第一个请求到来",
+      "hire": {
+        "title": "雇用你的第一个智能体",
+        "description": "选一个角色。它会在这个工作区拥有席位，几秒内回复。",
+        "cta": "雇用智能体"
+      },
+      "speak": {
+        "title": "对它说点什么",
+        "description": "在任意 Pod 中 @ 它。第一次回复，就是它真正属于你的时刻。",
+        "cta": "打开我的工作区"
+      },
+      "connect": {
+        "title": "连接一个渠道",
+        "description": "Slack 或 Telegram —— 智能体在你的团队已经在用的地方回复。",
+        "cta": "添加连接器"
+      }
+    }
   },
   "auth": {
     "fields": {

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -264,7 +264,8 @@ describe('V2ActivityPage', () => {
     first.unmount();
 
     // An agent exists but has not answered, no connector: steps 2 and 3, composer back, step 2 is the ink act.
-    mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: null }, { name: 'hosted-smoke', lastActiveAt: '2026-09-08T10:00:00.000Z', internal: true }], []));
+    // A provisioned seat has lastActiveAt (runtime-token use) but lastMessage null: it has never spoken.
+    mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z', lastMessage: null }, { name: 'hosted-smoke', lastMessage: { content: 'x' }, internal: true }], []));
     const second = renderPage();
     expect(await screen.findByText('2 steps · until your first ask arrives')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Hire an agent' })).not.toBeInTheDocument();
@@ -273,7 +274,7 @@ describe('V2ActivityPage', () => {
     second.unmount();
 
     // Everything done: no card at all — the 0-state board already gated.
-    mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z' }], [{ status: 'active' }]));
+    mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z', lastMessage: { content: 'Hi there', createdAt: '2026-09-08T10:00:03.000Z' } }], [{ status: 'active' }]));
     renderPage();
     expect(await screen.findByText('Nothing needs you.')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Get started' })).not.toBeInTheDocument();

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -237,13 +237,15 @@ describe('V2ActivityPage', () => {
 
   test('day zero: Get started is its own card above Needs you, the composer hides until an agent exists, and steps leave one by one (66658/66666)', async () => {
     const empty = { ...recap, needsYou: [], agents: [], board: [] };
-    const withAgent = (agent) => ({ ...empty, agents: [agent] });
-    const mockFor = (data, connectors) => (url: string) => {
+    // Facts come from the registry's per-pod agent list (what Your Team reads), never from the
+    // 24h recap window (sprint-review 66671): a hired seat that has not acted is absent from recap.
+    const mockFor = (seats, connectors) => (url: string) => {
       if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
       if (url === '/api/integrations/user/all') return Promise.resolve({ data: connectors });
-      return Promise.resolve({ data });
+      if (url.startsWith('/api/registry/pods/')) return Promise.resolve({ data: { agents: seats } });
+      return Promise.resolve({ data: empty });
     };
-    mockGet.mockImplementation(mockFor(empty, []));
+    mockGet.mockImplementation(mockFor([], []));
     const first = renderPage();
     expect(await screen.findByRole('heading', { name: 'Get started' })).toBeInTheDocument();
     expect(await screen.findByText('3 steps · until your first ask arrives')).toBeInTheDocument();
@@ -262,7 +264,7 @@ describe('V2ActivityPage', () => {
     first.unmount();
 
     // An agent exists but has not answered, no connector: steps 2 and 3, composer back, step 2 is the ink act.
-    mockGet.mockImplementation(mockFor(withAgent({ id: 'a1', name: 'Scout', lastActiveAt: null, messageCount: 0, recap: '', updates: [] }), []));
+    mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: null }, { name: 'hosted-smoke', lastActiveAt: '2026-09-08T10:00:00.000Z', internal: true }], []));
     const second = renderPage();
     expect(await screen.findByText('2 steps · until your first ask arrives')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Hire an agent' })).not.toBeInTheDocument();
@@ -271,7 +273,7 @@ describe('V2ActivityPage', () => {
     second.unmount();
 
     // Everything done: no card at all — the 0-state board already gated.
-    mockGet.mockImplementation(mockFor(withAgent({ id: 'a1', name: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z', messageCount: 3, recap: '', updates: [] }), [{ status: 'active' }]));
+    mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z' }], [{ status: 'active' }]));
     renderPage();
     expect(await screen.findByText('Nothing needs you.')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Get started' })).not.toBeInTheDocument();

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -5,7 +5,6 @@ import { MemoryRouter, useLocation } from 'react-router-dom';
 import axios from 'axios';
 import i18n, { i18nReady } from '../../i18n';
 import V2ActivityPage from '../components/V2ActivityPage';
-import { FIRST_RUN_REOPEN_EVENT } from '../firstRunGuide';
 import { ATTENTION_CHANGED } from '../hooks/useV2PodAttention';
 import { AuthContext } from '../../context/AuthContext';
 import { setupFocusManagement } from '../../utils/focusUtils';
@@ -236,23 +235,46 @@ describe('V2ActivityPage', () => {
     expect(screen.queryByText(/0 needs you/i)).not.toBeInTheDocument();
   });
 
-  test('turns a truly empty workspace into the three factual onboarding rows', async () => {
-    mockGet.mockImplementation((url: string) => Promise.resolve({ data: url === '/api/activity/decision-queue'
-      ? { items: [], count: 0, countsByPod: {} } : { ...recap, needsYou: [], agents: [], board: [] } }));
-    const onGuide = jest.fn();
-    window.addEventListener(FIRST_RUN_REOPEN_EVENT, onGuide);
+  test('day zero: Get started is its own card above Needs you, the composer hides until an agent exists, and steps leave one by one (66658/66666)', async () => {
+    const empty = { ...recap, needsYou: [], agents: [], board: [] };
+    const withAgent = (agent) => ({ ...empty, agents: [agent] });
+    const mockFor = (data, connectors) => (url: string) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
+      if (url === '/api/integrations/user/all') return Promise.resolve({ data: connectors });
+      return Promise.resolve({ data });
+    };
+    mockGet.mockImplementation(mockFor(empty, []));
+    const first = renderPage();
+    expect(await screen.findByRole('heading', { name: 'Get started' })).toBeInTheDocument();
+    expect(await screen.findByText('3 steps · until your first ask arrives')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hire an agent' })).toHaveClass('v2-activity__start-cta--current');
+    expect(screen.getByRole('button', { name: 'Open My Workspace' })).not.toHaveClass('v2-activity__start-cta--current');
+    expect(screen.getByRole('button', { name: 'Add a connector' })).toBeInTheDocument();
+    // Needs you still renders its panel underneath, with no count.
+    expect(screen.getByText('Nothing needs you.')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/waiting on you/)).not.toBeInTheDocument();
+    // Nobody to wake: the composer is hidden while step 1 is open.
+    expect(screen.queryByRole('heading', { name: /tell your agents/i })).not.toBeInTheDocument();
+    const card = screen.getByRole('heading', { name: 'Get started' }).closest('section') as HTMLElement;
+    expect(card.compareDocumentPosition(screen.getByRole('heading', { name: 'Needs you' })) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Hire an agent' }));
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/agents');
+    first.unmount();
+
+    // An agent exists but has not answered, no connector: steps 2 and 3, composer back, step 2 is the ink act.
+    mockGet.mockImplementation(mockFor(withAgent({ id: 'a1', name: 'Scout', lastActiveAt: null, messageCount: 0, recap: '', updates: [] }), []));
+    const second = renderPage();
+    expect(await screen.findByText('2 steps · until your first ask arrives')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Hire an agent' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open My Workspace' })).toHaveClass('v2-activity__start-cta--current');
+    expect(screen.getByRole('heading', { name: /tell your agents/i })).toBeInTheDocument();
+    second.unmount();
+
+    // Everything done: no card at all — the 0-state board already gated.
+    mockGet.mockImplementation(mockFor(withAgent({ id: 'a1', name: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z', messageCount: 3, recap: '', updates: [] }), [{ status: 'active' }]));
     renderPage();
-
-    expect(await screen.findByRole('button', { name: 'Meet your Guide' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Hire your first agent' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Create a task' })).toBeInTheDocument();
-    expect(screen.queryByText('Nothing needs you.')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Meet your Guide' }));
-    expect(onGuide).toHaveBeenCalledTimes(1);
-    fireEvent.click(screen.getByRole('button', { name: 'Create a task' }));
-    expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/pods/pod-1/board?createTask=1');
-    window.removeEventListener(FIRST_RUN_REOPEN_EVENT, onGuide);
+    expect(await screen.findByText('Nothing needs you.')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Get started' })).not.toBeInTheDocument();
   });
 
   test('keeps an approval actionable and refreshes the fact after approval', async () => {

--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -1842,6 +1842,13 @@ describe('v2 layout invariants (CSS rule presence)', () => {
       expect(lastRuleBody(v2, '.v2-activity__queue-row')).toContain('border: 2px solid var(--v2-accent)');
       expect(lastRuleBody(v2, '.v2-activity__queue-row--decision')).toContain('box-shadow: none');
       expect(v2).toContain('.v2-activity__queue-row--settled,\n.v2-activity__queue-row--onboarding { padding: 12px; border: 1px solid var(--v2-border); }');
+      // Day zero (66658/66666): Get started is its own card above Needs you; a step is not an ask.
+      expect(activityPage).toContain('className="v2-activity__start" aria-labelledby="activity-get-started"');
+      expect(activityPage).not.toContain('v2-activity__queue-row--onboarding');
+      expect(activityPage).toContain("{!startSteps.includes('hire') && (");
+      expect(ruleBody(v2, '.v2-activity__start-num')).toContain('background: var(--v2-ink)');
+      expect(ruleBody(v2, '.v2-root .v2-activity__start-act button')).toContain('min-height: 32px');
+      expect(v2).toMatch(/@media \(max-width: 760px\) \{[\s\S]*?\.v2-root \.v2-activity__start-act button \{ width: 100%; min-height: 44px; \}/);
       // One segment grammar (66400 fix 6): both groups bordered, active = tint + ink 600, inactive = white + secondary.
       expect(lastRuleBody(v2, '.v2-activity__scope')).toContain('border: 1px solid var(--v2-border)');
       expect(lastRuleBody(v2, '.v2-activity__scope')).toContain('background: var(--v2-surface)');

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -197,6 +197,10 @@ const V2ActivityPage: React.FC = () => {
   // not an ask — no actor, no ring, no count, no badge; a step leaves when the account does
   // something. hire ← an agent exists; speak ← an agent has answered; connect ← a connector row.
   const [connectorCount, setConnectorCount] = useState<number | null>(null);
+  // "Hired" and "has answered" are facts about the account's seats, not about the last 24h
+  // (sprint-review 66671: recap.agents only carries agents that acted inside the recap window).
+  // The registry's per-pod agent list is what Your Team reads; lastActiveAt is "ever".
+  const [hiredAgents, setHiredAgents] = useState<Array<{ name: string; lastActiveAt: string | null; internal?: boolean }> | null>(null);
   const [queueLoadingMore, setQueueLoadingMore] = useState(false);
   const [queueMoreError, setQueueMoreError] = useState(false);
   const [historyRemaining, setHistoryRemaining] = useState(0);
@@ -545,14 +549,26 @@ const V2ActivityPage: React.FC = () => {
       .catch(() => { if (active) setConnectorCount(0); });
     return () => { active = false; };
   }, [snapshotReady, reloadKey]);
+  useEffect(() => {
+    if (!recap || podId !== 'all') return undefined;
+    let active = true;
+    const token = localStorage.getItem('token');
+    const headers = { 'x-auth-token': token ?? '' };
+    Promise.all(recap.pods.slice(0, 20).map((pod) => axios
+      .get<{ agents?: Array<{ name: string; lastActiveAt: string | null; internal?: boolean }> }>(`/api/registry/pods/${pod.id}/agents`, { headers })
+      .then((res) => (Array.isArray(res.data?.agents) ? res.data.agents : []))
+      .catch(() => [])))
+      .then((lists) => { if (active) setHiredAgents(lists.flat().filter((agent) => !agent.internal)); });
+    return () => { active = false; };
+  }, [recap, podId]);
   const startSteps = useMemo(() => {
-    if (!recap || podId !== 'all') return [] as Array<'hire' | 'speak' | 'connect'>;
+    if (!recap || podId !== 'all' || hiredAgents === null) return [] as Array<'hire' | 'speak' | 'connect'>;
     const open: Array<'hire' | 'speak' | 'connect'> = [];
-    if (recap.agents.length === 0) open.push('hire');
-    if (!recap.agents.some((agent) => agent.messageCount > 0 || !!agent.lastActiveAt)) open.push('speak');
+    if (hiredAgents.length === 0) open.push('hire');
+    if (!hiredAgents.some((agent) => !!agent.lastActiveAt)) open.push('speak');
     if (connectorCount !== null && connectorCount === 0) open.push('connect');
     return open;
-  }, [recap, podId, connectorCount]);
+  }, [recap, podId, hiredAgents, connectorCount]);
   const startStepTarget = (step: 'hire' | 'speak' | 'connect') => {
     if (step === 'hire') return '/v2/agents';
     if (step === 'speak') return recap?.pods[0] ? `/v2/pods/${recap.pods[0].id}` : '/v2';

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -199,8 +199,11 @@ const V2ActivityPage: React.FC = () => {
   const [connectorCount, setConnectorCount] = useState<number | null>(null);
   // "Hired" and "has answered" are facts about the account's seats, not about the last 24h
   // (sprint-review 66671: recap.agents only carries agents that acted inside the recap window).
-  // The registry's per-pod agent list is what Your Team reads; lastActiveAt is "ever".
-  const [hiredAgents, setHiredAgents] = useState<Array<{ name: string; lastActiveAt: string | null; internal?: boolean }> | null>(null);
+  // The registry's per-pod agent list is what Your Team reads. `lastMessage` is proof of speech
+  // (null when the seat has never spoken in that pod); `lastActiveAt` is only proof of life —
+  // provisioning uses a runtime token and sets it (sprint-review 66678) — so it must not close
+  // the step whose job is to notice a seat that never answered.
+  const [hiredAgents, setHiredAgents] = useState<Array<{ name: string; lastMessage?: unknown; internal?: boolean }> | null>(null);
   const [queueLoadingMore, setQueueLoadingMore] = useState(false);
   const [queueMoreError, setQueueMoreError] = useState(false);
   const [historyRemaining, setHistoryRemaining] = useState(0);
@@ -555,7 +558,7 @@ const V2ActivityPage: React.FC = () => {
     const token = localStorage.getItem('token');
     const headers = { 'x-auth-token': token ?? '' };
     Promise.all(recap.pods.slice(0, 20).map((pod) => axios
-      .get<{ agents?: Array<{ name: string; lastActiveAt: string | null; internal?: boolean }> }>(`/api/registry/pods/${pod.id}/agents`, { headers })
+      .get<{ agents?: Array<{ name: string; lastMessage?: unknown; internal?: boolean }> }>(`/api/registry/pods/${pod.id}/agents`, { headers })
       .then((res) => (Array.isArray(res.data?.agents) ? res.data.agents : []))
       .catch(() => [])))
       .then((lists) => { if (active) setHiredAgents(lists.flat().filter((agent) => !agent.internal)); });
@@ -565,7 +568,7 @@ const V2ActivityPage: React.FC = () => {
     if (!recap || podId !== 'all' || hiredAgents === null) return [] as Array<'hire' | 'speak' | 'connect'>;
     const open: Array<'hire' | 'speak' | 'connect'> = [];
     if (hiredAgents.length === 0) open.push('hire');
-    if (!hiredAgents.some((agent) => !!agent.lastActiveAt)) open.push('speak');
+    if (!hiredAgents.some((agent) => agent.lastMessage != null)) open.push('speak');
     if (connectorCount !== null && connectorCount === 0) open.push('connect');
     return open;
   }, [recap, podId, hiredAgents, connectorCount]);

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -3,7 +3,6 @@ import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../../context/AuthContext';
-import { requestFirstRunGuide } from '../firstRunGuide';
 import { ATTENTION_CHANGED, notifyAttentionChanged } from '../hooks/useV2PodAttention';
 
 type ActivityWindow = 'today' | '7d';
@@ -194,6 +193,10 @@ const V2ActivityPage: React.FC = () => {
   // a stall, which the auto-load effect makes unreachable in practice
   // (sprint-review 66408: deterministic under the fold, never Loading).
   const [queueAutoPending, setQueueAutoPending] = useState(false);
+  // Day zero (ux-lead 66658/66666): Get started is its own card above Needs you and a step is
+  // not an ask — no actor, no ring, no count, no badge; a step leaves when the account does
+  // something. hire ← an agent exists; speak ← an agent has answered; connect ← a connector row.
+  const [connectorCount, setConnectorCount] = useState<number | null>(null);
   const [queueLoadingMore, setQueueLoadingMore] = useState(false);
   const [queueMoreError, setQueueMoreError] = useState(false);
   const [historyRemaining, setHistoryRemaining] = useState(0);
@@ -533,6 +536,29 @@ const V2ActivityPage: React.FC = () => {
     };
   }, [accountId, podId, reloadKey, snapshotReady, t, window]);
 
+  useEffect(() => {
+    if (!snapshotReady) return undefined;
+    let active = true;
+    const token = localStorage.getItem('token');
+    axios.get<Array<{ status?: string }>>('/api/integrations/user/all', { headers: { 'x-auth-token': token ?? '' } })
+      .then((res) => { if (active) setConnectorCount(Array.isArray(res.data) ? res.data.filter((row) => row.status !== 'error').length : 0); })
+      .catch(() => { if (active) setConnectorCount(0); });
+    return () => { active = false; };
+  }, [snapshotReady, reloadKey]);
+  const startSteps = useMemo(() => {
+    if (!recap || podId !== 'all') return [] as Array<'hire' | 'speak' | 'connect'>;
+    const open: Array<'hire' | 'speak' | 'connect'> = [];
+    if (recap.agents.length === 0) open.push('hire');
+    if (!recap.agents.some((agent) => agent.messageCount > 0 || !!agent.lastActiveAt)) open.push('speak');
+    if (connectorCount !== null && connectorCount === 0) open.push('connect');
+    return open;
+  }, [recap, podId, connectorCount]);
+  const startStepTarget = (step: 'hire' | 'speak' | 'connect') => {
+    if (step === 'hire') return '/v2/agents';
+    if (step === 'speak') return recap?.pods[0] ? `/v2/pods/${recap.pods[0].id}` : '/v2';
+    return '/v2/connectors';
+  };
+
   const loadMoreQueue = async (auto = false) => {
     if (queueMoreError && queueMoreFailureOffsetRef.current === null) {
       setReloadKey((value) => value + 1);
@@ -806,14 +832,6 @@ const V2ActivityPage: React.FC = () => {
     navigate(`/v2/pods/${targetPodId}${target}`);
   };
 
-  const openFirstBoard = () => {
-    const firstPod = recap?.pods[0];
-    if (firstPod) {
-      navigate(`/v2/pods/${firstPod.id}/board?createTask=1`);
-      return;
-    }
-    navigate('/v2');
-  };
 
   const captureActionFocus = (item: NeedsYouItem) => {
     const generation = ++actionFocusGenerationRef.current;
@@ -993,11 +1011,6 @@ const V2ActivityPage: React.FC = () => {
   const acknowledgeMention = (item: NeedsYouItem) => acknowledgeAttention(item, 'activity.mention.actionFailed');
   const markHandoffHandled = (item: NeedsYouItem) => acknowledgeAttention(item, 'activity.handoff.actionFailed');
 
-  const isDayZero = podId === 'all'
-    && queueCount === 0
-    && visibleQueue.length === 0
-    && recap?.agents.length === 0
-    && recap.board.length === 0;
 
   return (
     <div className="v2-activity" aria-busy={loading}>
@@ -1041,6 +1054,8 @@ const V2ActivityPage: React.FC = () => {
       </div>}
       {!loading && !error && recap && (
         <>
+          {/* The composer stays hidden while step 1 is open — nobody to wake — and returns the moment an agent exists. */}
+          {!startSteps.includes('hire') && (
           <section className="v2-activity__compose" aria-labelledby="activity-compose-title">
             <div className="v2-activity__compose-top">
               <h2 id="activity-compose-title" className="v2-activity__compose-label">{t('activity.compose.label')}</h2>
@@ -1131,11 +1146,32 @@ const V2ActivityPage: React.FC = () => {
             </div>
             {composeError && <div className="v2-activity__action-error" role="alert">{composeError}</div>}
           </section>
+          )}
+          {startSteps.length > 0 && (
+            <section className="v2-activity__start" aria-labelledby="activity-get-started">
+              <div className="v2-activity__start-head">
+                <h2 id="activity-get-started">{t('activity.getStarted.title')}</h2>
+                <span className="v2-activity__start-kicker">{t('activity.getStarted.kicker', { count: startSteps.length })}</span>
+              </div>
+              {startSteps.map((step, index) => (
+                <div key={step} className="v2-activity__start-row" data-step={step}>
+                  <span className="v2-activity__start-num" aria-hidden="true">{({ hire: 1, speak: 2, connect: 3 })[step]}</span>
+                  <div className="v2-activity__start-copy">
+                    <strong>{t(`activity.getStarted.${step}.title`)}</strong>
+                    <p>{t(`activity.getStarted.${step}.description`)}</p>
+                  </div>
+                  <div className="v2-activity__start-act">
+                    <button type="button" className={index === 0 ? 'v2-activity__start-cta--current' : ''} onClick={() => navigate(startStepTarget(step))}>{t(`activity.getStarted.${step}.cta`)}</button>
+                  </div>
+                </div>
+              ))}
+            </section>
+          )}
           <div className="v2-activity__sections">
           <section className="v2-activity__section" aria-labelledby="activity-needs-you">
             <div className="v2-activity__section-heading">
               <h2 id="activity-needs-you">{t('activity.needsYou.title')}</h2>
-              {!isDayZero && queueCount !== null && queueCount > 0 && <span className="v2-activity__count" aria-label={t('activity.needsYou.countLabel', { count: queueCount })}>{queueCount}</span>}
+              {queueCount !== null && queueCount > 0 && <span className="v2-activity__count" aria-label={t('activity.needsYou.countLabel', { count: queueCount })}>{queueCount}</span>}
               {queueCount !== 0 && <p>{queueCount === null
                 ? t('activity.needsYou.countUnavailable', { defaultValue: 'Count unavailable' })
                 : t(podId === 'all' ? 'activity.needsYou.countDescription' : 'activity.needsYou.scopedCountDescription', { count: queueCount })}</p>}
@@ -1143,47 +1179,7 @@ const V2ActivityPage: React.FC = () => {
             {queueFailed ? <>
               <p role="status">{t('activity.loadFailed')}</p>
               <button type="button" className="v2-activity__queue-more" onClick={() => setReloadKey((value) => value + 1)}>{t('activity.needsYou.retry', { defaultValue: 'Retry' })}</button>
-            </> : isDayZero ? (
-              <div className="v2-activity__queue">
-                <article className="v2-activity__queue-row v2-activity__queue-row--onboarding">
-                  <span className="v2-activity__queue-mark" aria-hidden="true">1</span>
-                  <div className="v2-activity__queue-copy">
-                    <div className="v2-activity__queue-kind">{t('activity.dayZero.kind')}</div>
-                    <strong>{t('activity.dayZero.guide.title')}</strong>
-                    <p>{t('activity.dayZero.guide.description')}</p>
-                    <span>{t('activity.dayZero.guide.leaves')}</span>
-                  </div>
-                  <div className="v2-activity__queue-actions">
-                    <button type="button" onClick={requestFirstRunGuide}>{t('activity.dayZero.guide.cta')}</button>
-                  </div>
-                </article>
-                <article className="v2-activity__queue-row v2-activity__queue-row--onboarding">
-                  <span className="v2-activity__queue-mark" aria-hidden="true">2</span>
-                  <div className="v2-activity__queue-copy">
-                    <div className="v2-activity__queue-kind">{t('activity.dayZero.kind')}</div>
-                    <strong>{t('activity.dayZero.agent.title')}</strong>
-                    <p>{t('activity.dayZero.agent.description')}</p>
-                    <span>{t('activity.dayZero.agent.leaves')}</span>
-                  </div>
-                  <div className="v2-activity__queue-actions">
-                    <button type="button" onClick={() => navigate('/v2/agents')}>{t('activity.dayZero.agent.cta')}</button>
-                    <button type="button" className="v2-activity__queue-action--secondary" onClick={() => navigate('/v2/agents/byo')}>{t('activity.dayZero.agent.secondary')}</button>
-                  </div>
-                </article>
-                <article className="v2-activity__queue-row v2-activity__queue-row--onboarding">
-                  <span className="v2-activity__queue-mark" aria-hidden="true">3</span>
-                  <div className="v2-activity__queue-copy">
-                    <div className="v2-activity__queue-kind">{t('activity.dayZero.kind')}</div>
-                    <strong>{t('activity.dayZero.task.title')}</strong>
-                    <p>{t('activity.dayZero.task.description')}</p>
-                    <span>{t('activity.dayZero.task.leaves')}</span>
-                  </div>
-                  <div className="v2-activity__queue-actions">
-                    <button type="button" onClick={openFirstBoard}>{t('activity.dayZero.task.cta')}</button>
-                  </div>
-                </article>
-              </div>
-            ) : (
+            </> : (
               <>
               {(queueCount === 0 || visibleQueue.length === 0) && (
                 <div className="v2-activity__empty v2-activity__empty--plain">

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -11716,6 +11716,29 @@ body.modern-ui.v2-canvas {
   .v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__option-choice button { width: 100%; min-height: 44px; }
   .v2-activity__queue-row.v2-activity__queue-row--decision .v2-activity__decision-footer > button { flex: 1 1 100%; min-height: 44px; }
 }
+/* Get started — day zero (ux-lead 66658/66666, board 66663/66664). One bordered card above
+   Needs you; a step is not an ask: no ring, no count, no badge. Ink numbered marks, dividers,
+   32px buttons at desktop (the current step ink, later steps bordered), 44 full width at ≤760. */
+.v2-activity__start { width: min(100%, 760px); margin: 20px auto 0; border: 1px solid var(--v2-border); border-radius: 6px; background: var(--v2-surface); overflow: hidden; }
+.v2-activity__start-head { display: flex; align-items: baseline; gap: 10px; padding: 10px 14px; border-bottom: 1px solid var(--v2-border-soft); }
+.v2-activity__start-head h2 { margin: 0; font: 600 14px/20px var(--v2-font); color: var(--v2-text-primary); }
+.v2-activity__start-kicker { color: var(--v2-text-muted); font: 500 11px/16px var(--v2-font-mono); }
+.v2-activity__start-row { display: grid; grid-template-columns: 28px minmax(0, 1fr) auto; gap: 12px; align-items: start; padding: 12px 14px; border-bottom: 1px solid var(--v2-border-soft); }
+.v2-activity__start-row:last-child { border-bottom: 0; }
+.v2-activity__start-num { display: grid; place-items: center; width: 28px; height: 28px; border-radius: var(--v2-radius-sm); background: var(--v2-ink); color: var(--v2-on-ink); font: 500 11px/16px var(--v2-font-mono); }
+.v2-activity__start-copy { min-width: 0; }
+.v2-activity__start-copy strong { display: block; color: var(--v2-text-primary); font: 600 14px/20px var(--v2-font); }
+.v2-activity__start-copy p { margin: 2px 0 0; color: var(--v2-text-secondary); font: 400 14px/20px var(--v2-font); }
+.v2-activity__start-act { display: flex; align-items: center; }
+.v2-root .v2-activity__start-act button { min-height: 32px; padding: 0 12px; border: 1px solid var(--v2-border); border-radius: var(--v2-radius-sm); background: var(--v2-surface); color: var(--v2-text-primary); font: 600 13px/18px var(--v2-font); white-space: nowrap; }
+.v2-root .v2-activity__start-act button.v2-activity__start-cta--current { border-color: var(--v2-ink); background: var(--v2-ink); color: var(--v2-on-ink); }
+@media (max-width: 760px) {
+  .v2-activity__start { width: auto; margin: 16px 12px 0; }
+  .v2-activity__start-head { flex-direction: column; align-items: flex-start; gap: 2px; }
+  .v2-activity__start-row { grid-template-columns: 28px minmax(0, 1fr); }
+  .v2-activity__start-act { grid-column: 1 / -1; }
+  .v2-root .v2-activity__start-act button { width: 100%; min-height: 44px; }
+}
 /* ---------------------------------------------------------------------------
    Your Team — direction C, Signal (docs/design/signal-identity.md §4 "Cards in a
    grid"). One card per agent; the mark's colour is the state; the one that


### PR DESCRIPTION
## What

The fourth Activity board (Sharpen 66663/66664, ruled 66658, gated 66666): a fresh account with nothing open sees **Get started** as its own bordered card above Needs you, not three onboarding rows inside the queue.

- Three steps — hire your first agent, say something to it, connect a channel — as rows with ink numbered marks and dividers; 32px buttons at desktop (the current step is the one ink act, later steps bordered), 44px full width under the copy at ≤760.
- A step is not an ask: no actor, no ring, no count, no badge. Each leaves when the account does something: hire ← an agent exists, speak ← an agent has answered, connect ← a connector row exists.
- Needs you keeps its `Nothing needs you.` panel underneath, count absent, no rail badge. Moved forward reads `Nothing yet today.`
- The composer is hidden while step 1 is open (nobody to wake) and returns the moment an agent exists.
- The old guide / task rows and their locale strings are removed (en + zh-CN).

## Proof

- `V2ActivityPage.test.tsx`: fresh account (3 steps, no composer, panel present, card above Needs you, Hire → /v2/agents), hired-not-answered (2 steps, composer back, step 2 is the ink act), everything done (no card). Invariants pin the card, the composer condition, the ink mark, 32/44 buttons; type floors green. 162/162 across the three suites, eslint + tsc clean.
- Real build at 1440 + 390 with recap / integrations fed by a route fixture (Lily's account has agents): state A 3 steps × 32 (390: 336×44), composer absent, panel `Nothing needs you.`, no badge, no count, card above Needs you, no sideways scroll; state B 2 steps, composer present. PNGs in Sharpen.

Gates: @ux-lead (against the board, live on the stranger-smoke account after deploy) and @sprint-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JavWvyVL478UfEhJjcfMgX
