### PR TITLE
fix(activity): hide Get started after first ask

### DIFF
--- a/backend/__tests__/unit/services/activityService.attentionQueue.test.js
+++ b/backend/__tests__/unit/services/activityService.attentionQueue.test.js
@@ -1,4 +1,5 @@
 const mockGetOpenQueue = jest.fn();
+const mockHasEverHadAttention = jest.fn();
 const mockPodFind = jest.fn();
 const mockTaskFind = jest.fn();
 const mockDecisionFind = jest.fn();
@@ -16,6 +17,7 @@ jest.mock('../../../models/DecisionRequest', () => ({
 }));
 jest.mock('../../../services/attentionItemService', () => ({
   getOpenQueue: (...args) => mockGetOpenQueue(...args),
+  hasEverHadAttention: (...args) => mockHasEverHadAttention(...args),
 }));
 
 const ActivityService = require('../../../services/activityService');
@@ -34,6 +36,7 @@ const decisionChain = (value) => ({
 describe('ActivityService.getDecisionQueue', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockHasEverHadAttention.mockResolvedValue(false);
   });
 
   it('reads the recipient-owned AttentionItem projection without a source-store fallback', async () => {

--- a/backend/__tests__/unit/services/activityService.recap.test.js
+++ b/backend/__tests__/unit/services/activityService.recap.test.js
@@ -2,10 +2,12 @@ jest.mock('../../../models/Pod', () => ({ find: jest.fn(), findById: jest.fn() }
 jest.mock('../../../models/Task', () => ({ find: jest.fn() }));
 
 const mockGetOpenQueue = jest.fn();
+const mockHasEverHadAttention = jest.fn();
 const mockAcknowledgeAttention = jest.fn();
 const mockResolve = jest.fn();
 jest.mock('../../../services/attentionItemService', () => ({
   getOpenQueue: (...args) => mockGetOpenQueue(...args),
+  hasEverHadAttention: (...args) => mockHasEverHadAttention(...args),
   acknowledgeAttention: (...args) => mockAcknowledgeAttention(...args),
   resolve: (...args) => mockResolve(...args),
 }));
@@ -37,6 +39,7 @@ describe('ActivityService recap and legacy approval authorization', () => {
     Pod.findById.mockReturnValue({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(pod) })) });
     Task.find.mockReturnValue(taskQuery([]));
     mockGetOpenQueue.mockResolvedValue({ items: [], count: 0, composePodId: null });
+    mockHasEverHadAttention.mockResolvedValue(false);
     mockAcknowledgeAttention.mockResolvedValue({ success: true });
     mockResolve.mockResolvedValue(undefined);
     feedSpy = jest.spyOn(ActivityService, 'getUserFeed').mockResolvedValue({ activities: [] });
@@ -67,7 +70,29 @@ describe('ActivityService recap and legacy approval authorization', () => {
     const result = await ActivityService.getRecap(ownerId, { window: 'today' });
 
     expect(result.needsYou).toEqual([]);
+    expect(result.hasEverHadAttention).toBe(false);
     expect(mockGetOpenQueue).toHaveBeenCalledWith(ownerId);
+  });
+
+  test('returns the durable ever-had-attention fact for the account', async () => {
+    mockHasEverHadAttention.mockResolvedValue(true);
+
+    const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+
+    expect(result.hasEverHadAttention).toBe(true);
+    expect(mockHasEverHadAttention).toHaveBeenCalledWith(ownerId);
+  });
+
+  test('keeps day-zero onboarding gated when the durable history check fails', async () => {
+    mockHasEverHadAttention.mockRejectedValue(new Error('history unavailable'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+      expect(result.hasEverHadAttention).toBeNull();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   test('acknowledges attention only through the recipient-owned attention record', async () => {

--- a/backend/__tests__/unit/services/attentionItemService.test.js
+++ b/backend/__tests__/unit/services/attentionItemService.test.js
@@ -1,11 +1,12 @@
 const mockUpdateOne = jest.fn();
 const mockUpdateMany = jest.fn();
 const mockFind = jest.fn();
+const mockExists = jest.fn();
 const mockPodFindById = jest.fn();
 const mockPodFind = jest.fn();
 const mockUserFind = jest.fn();
 
-jest.mock('../../../models/AttentionItem', () => ({ updateOne: mockUpdateOne, updateMany: mockUpdateMany, find: mockFind }));
+jest.mock('../../../models/AttentionItem', () => ({ updateOne: mockUpdateOne, updateMany: mockUpdateMany, find: mockFind, exists: mockExists }));
 jest.mock('../../../models/Pod', () => ({ findById: mockPodFindById, find: mockPodFind }));
 const mockUserFindById = jest.fn();
 jest.mock('../../../models/User', () => ({ find: mockUserFind, findById: mockUserFindById }));
@@ -27,6 +28,19 @@ describe('attentionItemService', () => {
     jest.clearAllMocks();
     mockUpdateOne.mockResolvedValue({ modifiedCount: 1 });
     mockUpdateMany.mockResolvedValue({ modifiedCount: 1 });
+  });
+
+  it('checks durable attention history without filtering by current status', async () => {
+    mockExists.mockResolvedValue({ _id: 'attention-1' });
+
+    await expect(AttentionItemService.hasEverHadAttention('recipient-1')).resolves.toBe(true);
+    expect(mockExists).toHaveBeenCalledWith({ recipientUserId: 'recipient-1' });
+  });
+
+  it('treats an empty attention history as day zero', async () => {
+    mockExists.mockResolvedValue(null);
+
+    await expect(AttentionItemService.hasEverHadAttention('recipient-1')).resolves.toBe(false);
   });
 
   it('materializes a mention only for mentioned human members other than the author', async () => {

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -228,6 +228,20 @@ class ActivityService {
     const attention = requestedPodId
       ? await AttentionItemService.getOpenQueue(userId, { podId: requestedPodId })
       : await AttentionItemService.getOpenQueue(userId);
+    // Day-zero onboarding is account-level: once any ask has existed for the
+    // recipient, the "until your first ask" card must stay gone even after
+    // every item is handled. AttentionItem rows are durable, so this remains
+    // true across queue resolution and does not depend on the recap window.
+    let hasEverHadAttention: boolean | null = requestedPodId ? false : null;
+    if (!requestedPodId) {
+      try {
+        hasEverHadAttention = await AttentionItemService.hasEverHadAttention(userId);
+      } catch (error) {
+        // Keep the recap readable if the advisory onboarding check is
+        // unavailable; the queue itself remains authoritative below.
+        console.warn('[activity] day-zero attention check failed:', (error as Error).message);
+      }
+    }
     const needsYou = attention.items
       .filter((item: any) => !requestedPodId || item.podId === requestedPodId)
       .map((item: any) => ({
@@ -276,6 +290,7 @@ class ActivityService {
       generatedAt: new Date().toISOString(),
       scope: requestedPodId || 'all',
       pods: pods.map((pod) => ({ id: String(pod._id), name: pod.name })),
+      hasEverHadAttention,
       needsYou,
       agents: agentRecaps,
       board,

--- a/backend/services/attentionItemService.ts
+++ b/backend/services/attentionItemService.ts
@@ -455,11 +455,23 @@ export const acknowledgeAttention = async (recipientUserId: unknown, attentionIt
   return result.modifiedCount === 1 ? { success: true } : { success: false, error: 'Attention item not found' };
 };
 
+/**
+ * Whether this recipient has ever had an attention item, regardless of its
+ * current status. Resolved rows are retained deliberately, so this answers
+ * the Activity day-zero question without reconstructing history from source
+ * stores (or imposing a retention window).
+ */
+export const hasEverHadAttention = async (recipientUserId: unknown): Promise<boolean> => {
+  if (!recipientUserId) return false;
+  const row = await AttentionItem.exists({ recipientUserId });
+  return Boolean(row);
+};
+
 // Kept as the public name for the existing Activity route. The selector is
 // now deliberately recipient-owned and covers mentions plus handoffs while
 // excluding true decisions and approvals.
 export const acknowledgeMention = acknowledgeAttention;
 
-export default { recordMentionedUsers, resolveMentionAttentionForReply, sweepResolvedMentionAttention, recordApproval, recordDecision, recordTaskAttention, resolveTaskAttention, resolve, resolveMany, getOpenQueue, acknowledgeAttention, acknowledgeMention };
+export default { recordMentionedUsers, resolveMentionAttentionForReply, sweepResolvedMentionAttention, recordApproval, recordDecision, recordTaskAttention, resolveTaskAttention, resolve, resolveMany, getOpenQueue, hasEverHadAttention, acknowledgeAttention, acknowledgeMention };
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-module.exports = { recordMentionedUsers, resolveMentionAttentionForReply, sweepResolvedMentionAttention, recordApproval, recordDecision, recordTaskAttention, resolveTaskAttention, resolve, resolveMany, getOpenQueue, acknowledgeAttention, acknowledgeMention, TASK_HANDOFF_RE };
+module.exports = { recordMentionedUsers, resolveMentionAttentionForReply, sweepResolvedMentionAttention, recordApproval, recordDecision, recordTaskAttention, resolveTaskAttention, resolve, resolveMany, getOpenQueue, hasEverHadAttention, acknowledgeAttention, acknowledgeMention, TASK_HANDOFF_RE };

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -236,7 +236,7 @@ describe('V2ActivityPage', () => {
   });
 
   test('day zero: Get started is its own card above Needs you, the composer hides until an agent exists, and steps leave one by one (66658/66666)', async () => {
-    const empty = { ...recap, needsYou: [], agents: [], board: [] };
+    const empty = { ...recap, hasEverHadAttention: false, needsYou: [], agents: [], board: [] };
     // Facts come from the registry's per-pod agent list (what Your Team reads), never from the
     // 24h recap window (sprint-review 66671): a hired seat that has not acted is absent from recap.
     const mockFor = (seats, connectors) => (url: string) => {
@@ -277,6 +277,46 @@ describe('V2ActivityPage', () => {
     mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z', lastMessage: { content: 'Hi there', createdAt: '2026-09-08T10:00:03.000Z' } }], [{ status: 'active' }]));
     renderPage();
     expect(await screen.findByText('Nothing needs you.')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Get started' })).not.toBeInTheDocument();
+  });
+
+  test('hides Get started after any historical attention item, even with unfinished steps', async () => {
+    const handledAskRecap = { ...recap, hasEverHadAttention: true, needsYou: [], agents: [], board: [] };
+    let releaseRegistry: ((value: { data: { agents: unknown[] } }) => void) | null = null;
+    const registryResponse = new Promise<{ data: { agents: unknown[] } }>((resolve) => { releaseRegistry = resolve; });
+    const mockFor = (url: string) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
+      if (url === '/api/integrations/user/all') return Promise.resolve({ data: [] });
+      if (url.startsWith('/api/registry/pods/')) return registryResponse;
+      return Promise.resolve({ data: handledAskRecap });
+    };
+    mockGet.mockImplementation(mockFor);
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: /tell your agents/i })).toBeInTheDocument();
+    await act(async () => { releaseRegistry?.({ data: { agents: [] } }); });
+    await waitFor(() => expect(screen.queryByRole('heading', { name: /tell your agents/i })).not.toBeInTheDocument());
+    expect(screen.queryByRole('heading', { name: 'Get started' })).not.toBeInTheDocument();
+    expect(screen.getByText('Nothing needs you.')).toBeInTheDocument();
+  });
+
+  test('fails closed when attention history is unavailable', async () => {
+    const unknownAskRecap = { ...recap, hasEverHadAttention: null, needsYou: [], agents: [], board: [] };
+    let releaseRegistry: ((value: { data: { agents: unknown[] } }) => void) | null = null;
+    const registryResponse = new Promise<{ data: { agents: unknown[] } }>((resolve) => { releaseRegistry = resolve; });
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
+      if (url === '/api/integrations/user/all') return Promise.resolve({ data: [] });
+      if (url.startsWith('/api/registry/pods/')) return registryResponse;
+      return Promise.resolve({ data: unknownAskRecap });
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: /tell your agents/i })).toBeInTheDocument();
+    await act(async () => { releaseRegistry?.({ data: { agents: [] } }); });
+    await waitFor(() => expect(screen.queryByRole('heading', { name: /tell your agents/i })).not.toBeInTheDocument());
     expect(screen.queryByRole('heading', { name: 'Get started' })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -70,6 +70,9 @@ interface BoardItem {
 
 interface ActivityRecap {
   pods: Array<{ id: string; name: string }>;
+  // Account-level durable fact: once any attention item has existed, the
+  // first-ask onboarding card should not return after the queue is resolved.
+  hasEverHadAttention?: boolean | null;
   needsYou: NeedsYouItem[];
   agents: AgentRecap[];
   board: BoardItem[];
@@ -1166,7 +1169,7 @@ const V2ActivityPage: React.FC = () => {
             {composeError && <div className="v2-activity__action-error" role="alert">{composeError}</div>}
           </section>
           )}
-          {startSteps.length > 0 && (
+          {queueCount === 0 && recap.hasEverHadAttention === false && startSteps.length > 0 && (
             <section className="v2-activity__start" aria-labelledby="activity-get-started">
               <div className="v2-activity__start-head">
                 <h2 id="activity-get-started">{t('activity.getStarted.title')}</h2>


### PR DESCRIPTION
## Summary
- gate the Activity Get started card on the account's durable attention history
- keep the card hidden after any mention, approval, decision, or handoff has existed, including resolved rows
- retain queue count gating and existing onboarding step behavior

## Verification
- backend focused services: 39/39
- frontend V2ActivityPage: 50/50
- backend TypeScript lint + typecheck
- frontend eslint (2 existing JSX extension warnings) + typecheck
- mutation check: removing the historical-attention guard fails the new frontend test
