### PR TITLE
fix(hosted): identify installations holding user cap

### DIFF
--- a/backend/__tests__/unit/routes/hosted.test.js
+++ b/backend/__tests__/unit/routes/hosted.test.js
@@ -13,6 +13,7 @@ const mockHosted = {
   isHostedInstallation: jest.fn(),
   hostedCaps: jest.fn(() => ({ agentsPerUser: 1, turnsPerDay: 200 })),
   countHostedAgentsForUser: jest.fn(),
+  listHostedInstallationsForUser: jest.fn(),
   meterAllowsTurn: jest.fn(),
   provisionAgent: jest.fn(),
   deprovisionAgent: jest.fn(),
@@ -65,6 +66,7 @@ describe('/api/hosted', () => {
     mockHosted.isConfigured.mockReturnValue(true);
     mockHosted.isHostedInstallation.mockReturnValue(true);
     mockHosted.countHostedAgentsForUser.mockResolvedValue(1);
+    mockHosted.listHostedInstallationsForUser.mockResolvedValue([]);
     mockUserFindOne.mockResolvedValue({ _id: 'bot-1', username: 'scout', agentRuntimeTokens: [] });
     mockCredentialUpdateMany.mockResolvedValue({ modifiedCount: 0 });
     mockIssueToken.mockResolvedValue({ token: 'cm_agent_secret', existing: false });
@@ -167,10 +169,28 @@ describe('/api/hosted', () => {
   it('403s when the owner is over the (possibly lowered) per-user cap', async () => {
     mockFindOne.mockResolvedValue(makeInstallation());
     mockHosted.countHostedAgentsForUser.mockResolvedValue(2);
+    mockHosted.listHostedInstallationsForUser.mockResolvedValue([
+      { agentName: 'scout', instanceId: 'default', podId: 'pod-1' },
+    ]);
     const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
     expect(res.status).toBe(403);
-    expect(res.body).toMatchObject({ code: 'hosted_cap_reached', used: 2, cap: 1 });
+    expect(res.body).toMatchObject({
+      code: 'hosted_cap_reached',
+      used: 2,
+      cap: 1,
+      holders: [{ agentName: 'scout', instanceId: 'default', podId: 'pod-1' }],
+    });
+    expect(mockHosted.listHostedInstallationsForUser).toHaveBeenCalledWith('owner-1');
     expect(mockIssueToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps the cap response when holder diagnostics fail', async () => {
+    mockFindOne.mockResolvedValue(makeInstallation());
+    mockHosted.countHostedAgentsForUser.mockResolvedValue(2);
+    mockHosted.listHostedInstallationsForUser.mockRejectedValue(new Error('diagnostic timeout'));
+    const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: 'hosted_cap_reached', used: 2, cap: 1, holders: [] });
   });
 
   it('mints server-side with owner lineage, provisions, records, and never returns the token', async () => {

--- a/backend/__tests__/unit/routes/registry.hosted-cap-gate.test.js
+++ b/backend/__tests__/unit/routes/registry.hosted-cap-gate.test.js
@@ -3,6 +3,7 @@
 // synth path (no registry row) with runtimeType 'hosted' and the per-user cap.
 // Mirrors the harness in registry.cloud-entitlement-gate.test.js.
 const mockCountHosted = jest.fn();
+const mockListHosted = jest.fn();
 
 jest.mock('../../../models/AgentRegistry', () => ({
   AgentRegistry: {
@@ -36,6 +37,7 @@ jest.mock('../../../services/hostedRuntimeService', () => ({
   HOSTED_RUNTIME_TYPE: 'hosted',
   hostedCaps: () => ({ agentsPerUser: 1, turnsPerDay: 200 }),
   countHostedAgentsForUser: (...args) => mockCountHosted(...args),
+  listHostedInstallationsForUser: (...args) => mockListHosted(...args),
 }));
 
 const { AgentRegistry, AgentInstallation } = require('../../../models/AgentRegistry');
@@ -77,6 +79,7 @@ describe('registry install — hosted runtime cap gate', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockListHosted.mockResolvedValue([]);
     Pod.findById.mockReturnValue(buildLeanChain({
       _id: 'pod-1', createdBy: 'user-1', members: ['user-1'], type: 'chat',
     }));
@@ -129,11 +132,20 @@ describe('registry install — hosted runtime cap gate', () => {
 
   it('403s hosted_cap_reached at the cap, before any row is written', async () => {
     mockCountHosted.mockResolvedValue(1);
+    mockListHosted.mockResolvedValue([
+      { agentName: 'existing-agent', instanceId: 'default', podId: 'pod-2' },
+    ]);
     const res = makeRes();
     await installHandler(makeReq('hosted'), res);
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'hosted_cap_reached', used: 1, cap: 1 }));
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'hosted_cap_reached',
+      used: 1,
+      cap: 1,
+      holders: [{ agentName: 'existing-agent', instanceId: 'default', podId: 'pod-2' }],
+    }));
+    expect(mockListHosted).toHaveBeenCalledWith('user-1');
     expect(AgentInstallation.install).not.toHaveBeenCalled();
   });
 

--- a/backend/__tests__/unit/services/hostedRuntimeService.test.js
+++ b/backend/__tests__/unit/services/hostedRuntimeService.test.js
@@ -1,10 +1,14 @@
 // ADR-023 W2 hosted runtime — kernel-side half: config, Map-vs-lean reads,
 // the two D3.1 caps, and the worker client (auth header, timeout, non-2xx).
 const mockInstallationCount = jest.fn();
+const mockInstallationFind = jest.fn();
 const mockEventCount = jest.fn();
 
 jest.mock('../../../models/AgentRegistry', () => ({
-  AgentInstallation: { countDocuments: (...args) => mockInstallationCount(...args) },
+  AgentInstallation: {
+    countDocuments: (...args) => mockInstallationCount(...args),
+    find: (...args) => mockInstallationFind(...args),
+  },
 }));
 jest.mock('../../../models/AgentEvent', () => ({
   countDocuments: (...args) => mockEventCount(...args),
@@ -19,6 +23,7 @@ describe('hostedRuntimeService', () => {
   beforeEach(() => {
     ENV_KEYS.forEach((k) => { saved[k] = process.env[k]; delete process.env[k]; });
     mockInstallationCount.mockReset();
+    mockInstallationFind.mockReset();
     mockEventCount.mockReset();
     global.fetch = jest.fn();
   });
@@ -65,6 +70,25 @@ describe('hostedRuntimeService', () => {
         status: 'active',
         'config.runtime.runtimeType': 'hosted',
       });
+    });
+
+    it('lists only owner-safe identity fields for active hosted installs', async () => {
+      const lean = jest.fn().mockResolvedValue([
+        { agentName: 'scout', instanceId: 'default', podId: 'pod-1', config: { secret: 'nope' } },
+        { agentName: '', instanceId: 'bad', podId: 'pod-2' },
+      ]);
+      const select = jest.fn().mockReturnValue({ lean });
+      mockInstallationFind.mockReturnValue({ select });
+
+      await expect(hosted.listHostedInstallationsForUser('user-1')).resolves.toEqual([
+        { agentName: 'scout', instanceId: 'default', podId: 'pod-1' },
+      ]);
+      expect(mockInstallationFind).toHaveBeenCalledWith({
+        installedBy: 'user-1',
+        status: 'active',
+        'config.runtime.runtimeType': 'hosted',
+      });
+      expect(select).toHaveBeenCalledWith('agentName instanceId podId');
     });
 
     it('meters acked events by ACK time (deliveredAt) since the UTC day start and reports the reset', async () => {

--- a/backend/routes/hosted.ts
+++ b/backend/routes/hosted.ts
@@ -163,11 +163,20 @@ router.post('/provision', hostedRateLimit, auth, async (req: any, res: any) => {
     const { agentsPerUser } = hostedRuntime.hostedCaps();
     const owned = await hostedRuntime.countHostedAgentsForUser(userId);
     if (owned > agentsPerUser) {
+      let holders: any[] = [];
+      try {
+        holders = await hostedRuntime.listHostedInstallationsForUser(userId);
+      } catch (error: any) {
+        // The cap is still authoritative if the diagnostic lookup is down;
+        // omit holder metadata rather than turning a useful 403 into a 500.
+        console.warn('[hosted] cap holder lookup failed:', error?.message || error);
+      }
       return res.status(403).json({
         code: 'hosted_cap_reached',
         message: `Hosted agents are capped at ${agentsPerUser} per user in beta`,
         used: owned,
         cap: agentsPerUser,
+        holders,
       });
     }
 

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -423,11 +423,19 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
       const { agentsPerUser } = HostedRuntime.hostedCaps();
       const used = await HostedRuntime.countHostedAgentsForUser(userId);
       if (used >= agentsPerUser) {
+        let holders: any[] = [];
+        try {
+          holders = await HostedRuntime.listHostedInstallationsForUser(userId);
+        } catch (error: any) {
+          // Keep the cap response authoritative if diagnostics are unavailable.
+          console.warn('[registry/install] cap holder lookup failed:', error?.message || error);
+        }
         return res.status(403).json({
           code: 'hosted_cap_reached',
           message: `Hosted agents are capped at ${agentsPerUser} per user in beta; connect your own agent for more.`,
           used,
           cap: agentsPerUser,
+          holders,
         });
       }
     }

--- a/backend/services/hostedRuntimeService.ts
+++ b/backend/services/hostedRuntimeService.ts
@@ -75,14 +75,39 @@ export const isHostedInstallation = (installation: any): boolean => (
   String(readRuntimeConfig(installation).runtimeType || '').trim().toLowerCase() === HOSTED_RUNTIME_TYPE
 );
 
+const hostedInstallationFilter = (userId: any) => ({
+  installedBy: userId,
+  status: 'active',
+  'config.runtime.runtimeType': HOSTED_RUNTIME_TYPE,
+});
+
 /** Active hosted installations owned by a user. Same path the install route writes. */
 export const countHostedAgentsForUser = async (userId: any): Promise<number> => (
-  AgentInstallation.countDocuments({
-    installedBy: userId,
-    status: 'active',
-    'config.runtime.runtimeType': HOSTED_RUNTIME_TYPE,
-  })
+  AgentInstallation.countDocuments(hostedInstallationFilter(userId))
 );
+
+export interface HostedInstallationSummary {
+  agentName: string;
+  instanceId: string;
+  podId: string;
+}
+
+/**
+ * Return only the owner-safe identity needed to recover from a cap error.
+ * Failed provisioning leaves the active installation in place, so a count
+ * alone strands the user with no way to tell which seat must be removed.
+ * Never return config or runtime tokens from this helper.
+ */
+export const listHostedInstallationsForUser = async (userId: any): Promise<HostedInstallationSummary[]> => {
+  const rows = await AgentInstallation.find(hostedInstallationFilter(userId))
+    .select('agentName instanceId podId')
+    .lean();
+  return (Array.isArray(rows) ? rows : []).map((row: any) => ({
+    agentName: String(row.agentName || ''),
+    instanceId: String(row.instanceId || 'default'),
+    podId: String(row.podId || ''),
+  })).filter((row) => row.agentName && row.podId);
+};
 
 const utcDayStart = (now = new Date()): Date => new Date(Date.UTC(
   now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(),
@@ -203,6 +228,7 @@ module.exports = {
   readRuntimeConfig,
   isHostedInstallation,
   countHostedAgentsForUser,
+  listHostedInstallationsForUser,
   turnsToday,
   meterAllowsTurn,
   HostedRuntimeError,


### PR DESCRIPTION
## Summary
- return owner-scoped hosted installation summaries when the per-user cap rejects install or provision
- keep the cap authoritative if the diagnostic lookup fails
- cover the active-install filter, redaction, both cap gates, and diagnostic failure

A failed hosted provision leaves its active installation in place; the old 403 only returned the count, leaving users unable to identify the seat to remove. The new `holders` array contains only `agentName`, `instanceId`, and `podId`.

## Verification
- backend hosted runtime + hosted route: 26/26
- registry hosted-cap gate: 5/5 (Node 26 shim for legacy buffer dependency)
- backend TypeScript check
- targeted ESLint