### PR TITLE
fix(hire): a persona hire carries its own card sentence; identity never invents one (#1649)

### DIFF
--- a/backend/__tests__/unit/routes/registry.install-runtime-type.test.js
+++ b/backend/__tests__/unit/routes/registry.install-runtime-type.test.js
@@ -228,14 +228,14 @@ describe('registry install runtimeType fallback', () => {
       manifest: { context: { required: [] }, runtime: { type: 'standalone', runtimeType: 'hosted' } },
     });
     const req = {
-      body: { agentName: 'sample-agent', podId: 'pod-1', version: '1.0.0', config: {}, scopes: [], displayName: 'Scout', description: '  Your first teammate.   Answers how things work here. ' },
+      body: { agentName: 'sample-agent', podId: 'pod-1', version: '1.0.0', config: {}, scopes: [], displayName: 'Scout', description: `  Your first teammate.   Answers how things work here. ${'x'.repeat(200)}` },
       user: { id: 'user-1', username: 'installer' }, userId: 'user-1',
     };
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await installHandler(req, res);
-    expect(AgentIdentityService.getOrCreateAgentUser).toHaveBeenCalledWith('sample-agent', expect.objectContaining({
-      description: 'Your first teammate. Answers how things work here.',
-    }));
+    const passed = AgentIdentityService.getOrCreateAgentUser.mock.calls.find(([name]) => name === 'sample-agent')[1].description;
+    expect(passed.startsWith('Your first teammate. Answers how things work here. xxx')).toBe(true);
+    expect(passed).toHaveLength(160);
   });
 
   it('keeps install successful when the first-contact trigger fails', async () => {

--- a/backend/__tests__/unit/routes/registry.install-runtime-type.test.js
+++ b/backend/__tests__/unit/routes/registry.install-runtime-type.test.js
@@ -222,6 +222,22 @@ describe('registry install runtimeType fallback', () => {
     expect(res.status).not.toHaveBeenCalledWith(500);
   });
 
+  it('passes a hire\'s description to the identity service, trimmed and capped (#1649)', async () => {
+    AgentRegistry.getByName.mockResolvedValue({
+      agentName: 'sample-agent', displayName: 'Sample Agent', description: 'Native first-party app', latestVersion: '1.0.0',
+      manifest: { context: { required: [] }, runtime: { type: 'standalone', runtimeType: 'hosted' } },
+    });
+    const req = {
+      body: { agentName: 'sample-agent', podId: 'pod-1', version: '1.0.0', config: {}, scopes: [], displayName: 'Scout', description: '  Your first teammate.   Answers how things work here. ' },
+      user: { id: 'user-1', username: 'installer' }, userId: 'user-1',
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await installHandler(req, res);
+    expect(AgentIdentityService.getOrCreateAgentUser).toHaveBeenCalledWith('sample-agent', expect.objectContaining({
+      description: 'Your first teammate. Answers how things work here.',
+    }));
+  });
+
   it('keeps install successful when the first-contact trigger fails', async () => {
     AgentRegistry.getByName.mockResolvedValue({
       agentName: 'sample-agent',

--- a/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
+++ b/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
@@ -77,6 +77,17 @@ const reset = () => {
 describe('inline displayName collision resolver (sticky dedup)', () => {
   beforeEach(reset);
 
+  test('a hire that carries a description stores it; one that does not gets no line, never "<name> agent" (#1649)', async () => {
+    await AgentIdentityService.getOrCreateAgentUser('scout-1', {
+      instanceId: 'scout', displayName: 'Scout', description: 'Your first teammate. Answers how things work here.',
+    });
+    expect(mockSaved[0].botMetadata.description).toBe('Your first teammate. Answers how things work here.');
+    reset();
+    await AgentIdentityService.getOrCreateAgentUser('scout-2', { instanceId: 'scout', displayName: 'Scout' });
+    expect(mockSaved[0].botMetadata.description).toBe('');
+    expect(mockSaved[0].botMetadata.description).not.toMatch(/ agent$/);
+  });
+
   test('new install with no peers — bare displayName is kept', async () => {
     await AgentIdentityService.getOrCreateAgentUser('openclaw', {
       instanceId: 'pixel',

--- a/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
+++ b/backend/__tests__/unit/services/agentIdentityService.collisionResolver.test.js
@@ -88,6 +88,17 @@ describe('inline displayName collision resolver (sticky dedup)', () => {
     expect(mockSaved[0].botMetadata.description).not.toMatch(/ agent$/);
   });
 
+  test('the upgrade branch (existing non-bot user) and the repair branch (bot user with stale meta) store no placeholder either (#1649)', async () => {
+    mockExisting = { _id: 'human-id', username: 'scout-3-scout', isBot: false };
+    await AgentIdentityService.getOrCreateAgentUser('scout-3', { instanceId: 'scout', displayName: 'Scout' });
+    expect(mockSaved[0].botMetadata.description).toBe('');
+    reset();
+    mockExisting = { _id: 'bot-id', username: 'scout-4-scout', isBot: true, botMetadata: { agentName: 'scout-4', instanceId: 'scout', displayName: 'Scout' } };
+    await AgentIdentityService.getOrCreateAgentUser('scout-4', { instanceId: 'scout', displayName: 'Scout' });
+    expect(mockSaved[0].botMetadata.description).toBe('');
+    expect(mockSaved[0].botMetadata.description).not.toMatch(/ agent$/);
+  });
+
   test('new install with no peers — bare displayName is kept', async () => {
     await AgentIdentityService.getOrCreateAgentUser('openclaw', {
       instanceId: 'pixel',

--- a/backend/routes/registry/install.ts
+++ b/backend/routes/registry/install.ts
@@ -108,8 +108,12 @@ const findExistingAgentInstance = async (agentName: any, instanceId: any) => {
 installRouter.post('/install', installRateLimit, auth, async (req: any, res: any) => {
   try {
     const {
-      agentName, podId, version, config = {}, scopes = [], instanceId, displayName, gatewayId,
+      agentName, podId, version, config = {}, scopes = [], instanceId, displayName, gatewayId, description,
     } = req.body;
+    // #1649: a hire may carry the seat's card sentence; it is the only thing that
+    // can make botMetadata.description true, since the identity service no longer
+    // invents one. One line, capped, never a quote.
+    const explicitDescription = typeof description === 'string' ? description.trim().replace(/\s+/g, ' ').slice(0, 160) : '';
     const userId = getUserId(req);
     if (!userId) {
       return res.status(401).json({ error: 'Unauthorized' });
@@ -600,6 +604,7 @@ installRouter.post('/install', installRateLimit, auth, async (req: any, res: any
       const agentUser = await AgentIdentityService.getOrCreateAgentUser(agent.agentName, {
         instanceId: normalizedInstanceId,
         ...(explicitDisplayName ? { displayName: explicitDisplayName } : {}),
+        ...(explicitDescription ? { description: explicitDescription } : {}),
         ...(avatarSeed ? { profilePicture: avatarSeed } : {}),
       });
       await AgentIdentityService.ensureAgentInPod(agentUser, podId);

--- a/backend/services/agentIdentityService.ts
+++ b/backend/services/agentIdentityService.ts
@@ -400,7 +400,9 @@ class AgentIdentityService {
       const rawDisplayName = options.displayName || typeConfig?.officialDisplayName || resolvedType;
       const botMetadata = {
         displayName: await resolveCollisionFreeDisplayName(rawDisplayName, instanceId),
-        description: options.description || typeConfig?.officialDescription || `${resolvedType} agent`,
+        // No invented sentence (#1649): a seat without a description shows no line on
+        // Your Team, never "<name> agent". The hire flow supplies the persona's sentence.
+        description: options.description || typeConfig?.officialDescription || '',
         icon: typeConfig?.icon || '🤖',
         runtimeId: options.runtimeId || null,
         officialAgent: isOfficial,
@@ -431,7 +433,7 @@ class AgentIdentityService {
       const upgradeRawDisplayName = options.displayName || typeConfig?.officialDisplayName || agentUser.username;
       agentUser.botMetadata = {
         displayName: await resolveCollisionFreeDisplayName(upgradeRawDisplayName, instanceId, agentUser._id),
-        description: options.description || typeConfig?.officialDescription || `${resolvedType} agent`,
+        description: options.description || typeConfig?.officialDescription || '',
         icon: typeConfig?.icon || '🤖',
         runtimeId: options.runtimeId || agentUser.botMetadata?.runtimeId || undefined,
         officialAgent: isOfficial,
@@ -467,7 +469,7 @@ class AgentIdentityService {
         agentUser.botMetadata = {
           ...existingMeta,
           displayName: await resolveCollisionFreeDisplayName(refreshRawDisplayName, instanceId, agentUser._id),
-          description: options.description || existingMeta.description || typeConfig?.officialDescription || `${resolvedType} agent`,
+          description: options.description || existingMeta.description || typeConfig?.officialDescription || '',
           icon: existingMeta.icon || typeConfig?.icon || '🤖',
           runtimeId: options.runtimeId || existingMeta.runtimeId || undefined,
           officialAgent: instanceId === 'default' && !!typeConfig,

--- a/frontend/src/v2/__tests__/V2AgentBYOHosted.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOHosted.test.tsx
@@ -140,6 +140,22 @@ describe('V2AgentBYO — Run it here', () => {
     expect(axios.post.mock.calls.some(([url]) => url === '/api/hosted/provision')).toBe(false);
   });
 
+  test('a persona hired as a webhook seat carries the sentence too (#1649)', async () => {
+    mockGet({ configured: false });
+    axios.post.mockResolvedValue({ data: { token: 'cm_agent_x', agentName: 'planner-1' } });
+    window.history.pushState({}, '', '/v2/agents/byo?persona=planner&pod=p1');
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Workspace (chat)')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /install \+ generate token/i }));
+    await waitFor(() => expect(axios.post.mock.calls.some(([url]) => url === '/api/registry/install')).toBe(true));
+    const installCall = axios.post.mock.calls.find(([url]) => url === '/api/registry/install');
+    expect(installCall[1]).toMatchObject({
+      description: 'Sequences the board. What runs in parallel, what blocks what, who is waiting on whom.',
+      config: { persona: 'planner', runtime: { runtimeType: 'webhook' } },
+    });
+    window.history.pushState({}, '', '/');
+  });
+
   test('without hosting the page is the BYO page: no mode picker, webhook install', async () => {
     mockGet({ configured: false });
     axios.post

--- a/frontend/src/v2/__tests__/V2AgentBYOHosted.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOHosted.test.tsx
@@ -84,6 +84,30 @@ describe('V2AgentBYO — Run it here', () => {
     expect(screen.getByText(/sam-agent is live in Workspace/i)).toBeInTheDocument();
   });
 
+  test('a persona hire sends the persona\'s card sentence as the seat description (#1649)', async () => {
+    mockGet({ configured: true, status: { runtime: { lastPollAt: 1 } } });
+    axios.post.mockResolvedValue({ data: { ok: true } });
+    // The page reads its deep-link prefill from window.location, not the router.
+    window.history.pushState({}, '', '/v2/agents/byo?persona=scout&pod=p1');
+    render(
+      <AuthContext.Provider value={authValue}>
+        <MemoryRouter initialEntries={['/v2/agents/byo?persona=scout&pod=p1']}>
+          <V2AgentBYO />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('byo-mode-hosted')).toHaveAttribute('aria-pressed', 'true'));
+    fireEvent.click(screen.getByRole('button', { name: /^run it here$/i }));
+    await screen.findByTestId('byo-hosted-result');
+    const installCall = axios.post.mock.calls.find(([url]) => url === '/api/registry/install');
+    expect(installCall[1]).toMatchObject({
+      displayName: 'Scout',
+      description: 'Your first teammate. Answers how things work here, sets up agents, keeps what you decide.',
+      config: { persona: 'scout', runtime: { runtimeType: 'hosted' } },
+    });
+    window.history.pushState({}, '', '/');
+  });
+
   test('flips from starting to listening once the runtime reports a poll', async () => {
     jest.useFakeTimers();
     mockGet({ configured: true, status: { runtime: { lastPollAt: null } } });

--- a/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
+++ b/frontend/src/v2/__tests__/V2AgentBYOMachine.test.tsx
@@ -143,6 +143,22 @@ describe('BYO on-my-computer mode', () => {
     expect(screen.getByTestId('byo-machine-waiting')).toBeInTheDocument();
   });
 
+  test('a persona hire onto a machine carries the persona sentence too (#1649)', async () => {
+    mockGet();
+    axios.post.mockResolvedValue({ data: {} });
+    window.history.pushState({}, '', '/v2/agents/byo?persona=recorder&pod=p1');
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('byo-mode-machine')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('byo-mode-machine'));
+    fireEvent.click(screen.getByText('Add to this computer'));
+    await waitFor(() => expect(screen.getByTestId('byo-machine-result')).toBeInTheDocument());
+    expect(axios.post).toHaveBeenCalledWith('/api/registry/install', expect.objectContaining({
+      description: "The room's memory. Keeps decisions, corrections and who asked for what.",
+      config: expect.objectContaining({ persona: 'recorder', runtime: { runtimeType: 'wrapper' } }),
+    }), expect.anything());
+    window.history.pushState({}, '', '/');
+  });
+
   test('a chosen model rides the install as config.runtime.model; the default sends none', async () => {
     mockGet();
     axios.post.mockResolvedValue({ data: {} });

--- a/frontend/src/v2/__tests__/personaCatalogCard.test.ts
+++ b/frontend/src/v2/__tests__/personaCatalogCard.test.ts
@@ -1,0 +1,17 @@
+// #1649 — every persona carries the sentence its seat will show on Your Team, in the brief
+// the fleet's twelve seats follow (#1636): one sentence, under 100 characters, no quotes,
+// ends with a period. The card renders this line or nothing; never a fallback string.
+import { PERSONA_CARDS } from '../agents/personaCatalogData';
+
+describe('persona card sentences', () => {
+  test('every persona has a card sentence in the brief', () => {
+    expect(PERSONA_CARDS.length).toBeGreaterThan(0);
+    for (const persona of PERSONA_CARDS) {
+      expect(persona.card).toBeTruthy();
+      expect(persona.card.length).toBeLessThan(100);
+      expect(persona.card.trim().endsWith('.')).toBe(true);
+      expect(persona.card).not.toMatch(/[“”"]/);
+      expect(persona.card).not.toMatch(/ agent$/);
+    }
+  });
+});

--- a/frontend/src/v2/agents/personaCatalogData.ts
+++ b/frontend/src/v2/agents/personaCatalogData.ts
@@ -44,11 +44,19 @@ export interface PersonaCard {
    *  - 'soon':      hosted seat opens with the where-step; button disabled.
    */
   availability: 'workspace' | 'connect' | 'soon';
+  /**
+   * The Your Team card sentence — what this seat is for, in the brief the fleet's
+   * twelve seats follow (#1636): one sentence, under 100 characters, role first, no
+   * quotes. Sent as `description` at hire so the seat never lands with a placeholder
+   * (#1649). The card renders this line or nothing; never a fallback string.
+   */
+  card: string;
 }
 
 export const PERSONA_CARDS: PersonaCard[] = [
   {
     key: 'scout',
+    card: 'Your first teammate. Answers how things work here, sets up agents, keeps what you decide.',
     avatarSeed: 'scout:default',
     name: 'Scout',
     role: 'Your first teammate',
@@ -66,6 +74,7 @@ export const PERSONA_CARDS: PersonaCard[] = [
   },
   {
     key: 'code-reviewer',
+    card: 'Reviews pull requests. Findings first, each anchored to the lines that earned it.',
     avatarSeed: 'code-reviewer:default',
     name: 'Code Reviewer',
     role: 'Pull-request review',
@@ -83,6 +92,7 @@ export const PERSONA_CARDS: PersonaCard[] = [
   },
   {
     key: 'recorder',
+    card: "The room's memory. Keeps decisions, corrections and who asked for what.",
     avatarSeed: 'recorder:default',
     name: 'Recorder',
     role: 'The room’s memory',
@@ -100,6 +110,7 @@ export const PERSONA_CARDS: PersonaCard[] = [
   },
   {
     key: 'planner',
+    card: 'Sequences the board. What runs in parallel, what blocks what, who is waiting on whom.',
     avatarSeed: 'planner:default',
     name: 'Planner',
     role: 'Board sequencing',

--- a/frontend/src/v2/components/V2AgentBYO.tsx
+++ b/frontend/src/v2/components/V2AgentBYO.tsx
@@ -303,6 +303,8 @@ const V2AgentBYO: React.FC = () => {
           scopes: DEFAULT_SCOPES,
           config: { runtime: { runtimeType: 'hosted' }, ...(personaCard ? { persona: personaCard.key } : {}) },
           displayName: personaCard?.name || cleanName,
+          // #1649: the seat carries the persona's own sentence, so Your Team never shows a placeholder.
+          ...(personaCard ? { description: personaCard.card } : {}),
         });
       } catch (installErr) {
         const data = (installErr as { response?: { data?: { error?: string; code?: string; cap?: number } } })
@@ -347,6 +349,8 @@ const V2AgentBYO: React.FC = () => {
             ...(personaCard ? { persona: personaCard.key } : {}),
           },
           displayName: personaCard?.name || cleanName,
+          // #1649: the seat carries the persona's own sentence, so Your Team never shows a placeholder.
+          ...(personaCard ? { description: personaCard.card } : {}),
         });
       } catch (installErr) {
         // Same identity-continuity tolerance as the BYO path below.
@@ -398,6 +402,8 @@ const V2AgentBYO: React.FC = () => {
           scopes: DEFAULT_SCOPES,
           config: { runtime: { runtimeType: 'webhook' }, ...(personaCard ? { persona: personaCard.key } : {}) },
           displayName: personaCard?.name || cleanName,
+          // #1649: the seat carries the persona's own sentence, so Your Team never shows a placeholder.
+          ...(personaCard ? { description: personaCard.card } : {}),
         });
       } catch (installErr) {
         // "Already installed" is identity continuity (ADR-001), not a


### PR DESCRIPTION
Closes #1649.

## What

The hire flow sent `displayName` and the persona key and no description, and `agentIdentityService` filled the gap with `"<name> agent"` — so every persona hired through the normal path landed on Your Team with a placeholder, the exact class #1636/#1638 fixed by hand for the fleet's twelve seats.

- **Persona catalog**: each persona carries `card`, its Your Team sentence in the twelve seats' brief (one sentence, under 100 characters, role first, no quotes, ends with a period):
  - Scout — *Your first teammate. Answers how things work here, sets up agents, keeps what you decide.*
  - Code Reviewer — *Reviews pull requests. Findings first, each anchored to the lines that earned it.*
  - Recorder — *The room's memory. Keeps decisions, corrections and who asked for what.*
  - Planner — *Sequences the board. What runs in parallel, what blocks what, who is waiting on whom.*
- **Hire flow**: the three install sites send `description: personaCard.card` when a persona is hired.
- **Install route**: accepts `description` (trimmed, whitespace collapsed, capped at 160) and passes it to `getOrCreateAgentUser`.
- **Identity**: the three `${resolvedType} agent` fallbacks are gone. A seat with no sentence stores `''` and the card shows no line — per UX Lead's ruling on the issue: the persona sentence or an empty slot, never a fallback string.

Seats already carrying the placeholder are not rewritten here; that is the one-shot description script's job (#1636) if wanted.

## Proof

- Backend (Node 22): identity stores a supplied description and stores `''` (never `/ agent$/`) without one; the install route passes a trimmed, collapsed description through — `agentIdentityService.collisionResolver` + `registry.install-runtime-type` **18/18**; lint clean.
- Frontend: a `?persona=scout` hire sends `displayName: Scout`, `config.persona: scout` and the Scout sentence as `description`; every persona's `card` meets the brief — `V2AgentBYOHosted`, `V2AgentBYOMachine`, `personaCatalogCard`, `V2YourTeamSignal` **22/22**; eslint + tsc clean.
- The UI smoke's `KNOWN #1649` check flips to a live assertion after deploy: a fresh persona hire's card carries a sentence.

Gates: @ux-lead (the four sentences — copy is yours to rule) and @sprint-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DspLEe1mFV94dPGCqA1u5
