### PR TITLE
fix(activity): gate day-zero speech on human message

### DIFF
--- a/backend/__tests__/unit/services/activityService.recap.test.js
+++ b/backend/__tests__/unit/services/activityService.recap.test.js
@@ -1,5 +1,10 @@
 jest.mock('../../../models/Pod', () => ({ find: jest.fn(), findById: jest.fn() }));
 jest.mock('../../../models/Task', () => ({ find: jest.fn() }));
+jest.mock('../../../models/AgentRegistry', () => ({ AgentInstallation: { find: jest.fn() } }));
+const mockHasMessageByUserInPods = jest.fn();
+jest.mock('../../../models/pg/Message', () => ({
+  hasMessageByUserInPods: (...args) => mockHasMessageByUserInPods(...args),
+}));
 
 const mockGetOpenQueue = jest.fn();
 const mockHasEverHadAttention = jest.fn();
@@ -14,6 +19,7 @@ jest.mock('../../../services/attentionItemService', () => ({
 
 const Pod = require('../../../models/Pod');
 const Task = require('../../../models/Task');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
 const Activity = require('../../../models/Activity');
 const ActivityService = require('../../../services/activityService');
 
@@ -28,6 +34,9 @@ const taskQuery = (tasks) => ({
     sort: jest.fn().mockReturnValue({ limit: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(tasks) }) }),
   }),
 });
+const installationQuery = (installations) => ({
+  select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(installations) }),
+});
 
 describe('ActivityService recap and legacy approval authorization', () => {
   let feedSpy;
@@ -38,6 +47,8 @@ describe('ActivityService recap and legacy approval authorization', () => {
     Pod.find.mockReturnValue(podQuery([pod]));
     Pod.findById.mockReturnValue({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(pod) })) });
     Task.find.mockReturnValue(taskQuery([]));
+    AgentInstallation.find.mockReturnValue(installationQuery([]));
+    mockHasMessageByUserInPods.mockResolvedValue(false);
     mockGetOpenQueue.mockResolvedValue({ items: [], count: 0, composePodId: null });
     mockHasEverHadAttention.mockResolvedValue(false);
     mockAcknowledgeAttention.mockResolvedValue({ success: true });
@@ -90,6 +101,54 @@ describe('ActivityService recap and legacy approval authorization', () => {
     try {
       const result = await ActivityService.getRecap(ownerId, { window: 'today' });
       expect(result.hasEverHadAttention).toBeNull();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('closes the speak step from the account holder message, not the agent last-message field', async () => {
+    AgentInstallation.find.mockReturnValue(installationQuery([
+      { podId: 'pod-1', agentName: 'scout', config: {} },
+    ]));
+    mockHasMessageByUserInPods.mockResolvedValue(true);
+
+    const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+
+    expect(result.hasSpokenToAgent).toBe(true);
+    expect(mockHasMessageByUserInPods).toHaveBeenCalledWith(ownerId, ['pod-1']);
+  });
+
+  test('does not count an internal seat as an agent pod for the speak step', async () => {
+    AgentInstallation.find.mockReturnValue(installationQuery([
+      { podId: 'pod-1', agentName: 'hosted-smoke', config: {} },
+    ]));
+    mockHasMessageByUserInPods.mockResolvedValue(true);
+
+    const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+
+    expect(result.hasSpokenToAgent).toBe(false);
+    expect(mockHasMessageByUserInPods).not.toHaveBeenCalled();
+  });
+
+  test('does not count a human message in a pod with no agent seat', async () => {
+    mockHasMessageByUserInPods.mockResolvedValue(true);
+
+    const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+
+    expect(result.hasSpokenToAgent).toBe(false);
+    expect(mockHasMessageByUserInPods).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when the human-message fact is unavailable', async () => {
+    AgentInstallation.find.mockReturnValue(installationQuery([
+      { podId: 'pod-1', agentName: 'scout', config: {} },
+    ]));
+    mockHasMessageByUserInPods.mockRejectedValue(new Error('message store unavailable'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const result = await ActivityService.getRecap(ownerId, { window: 'today' });
+      expect(result.hasSpokenToAgent).toBeNull();
     } finally {
       warnSpy.mockRestore();
     }

--- a/backend/models/pg/Message.ts
+++ b/backend/models/pg/Message.ts
@@ -618,6 +618,30 @@ class Message {
       return [];
     }
   }
+
+  /**
+   * Whether a user has posted any non-system message in one of the supplied
+   * pods. This is intentionally an existence query: callers use it for
+   * onboarding facts, not for rendering history or counting activity.
+   */
+  static async hasMessageByUserInPods(userId: unknown, podIds: unknown[]): Promise<boolean> {
+    if (!userId || !podIds || !podIds.length) return false;
+    const uid = (userId as { toString(): string }).toString();
+    const podIdStrs = podIds
+      .map((id) => (id as { toString(): string } | undefined)?.toString())
+      .filter(Boolean);
+    if (!podIdStrs.length) return false;
+    const result = await (pool as PgPool).query(
+      `SELECT 1
+         FROM messages
+        WHERE user_id = $1
+          AND pod_id = ANY($2)
+          AND message_type != 'system'
+        LIMIT 1`,
+      [uid, podIdStrs],
+    );
+    return result.rows.length > 0;
+  }
 }
 
 export default Message;

--- a/backend/services/activityService.ts
+++ b/backend/services/activityService.ts
@@ -12,6 +12,10 @@ const Post = require('../models/Post');
 const Task = require('../models/Task');
 // eslint-disable-next-line global-require
 const isPodMember = require('../utils/isPodMember');
+// Keep day-zero seat classification identical to the registry roster. The
+// roster helper is the single source of truth for internal smoke/demo seats.
+const { AgentInstallation } = require('../models/AgentRegistry');
+const { isInternalSeat, normalizeConfigMap } = require('../routes/registry/helpers');
 
 let PGMessage: unknown = null;
 try {
@@ -113,6 +117,55 @@ interface ComputeFlagsOptions {
 const SYSTEM_BOT_NAMES = new Set(['commonly-bot', 'commonly-ai-agent']);
 
 class ActivityService {
+  /**
+   * A day-zero "speak" step closes only after the account holder has posted
+   * in a pod that currently has a non-internal agent seat. Agent intros,
+   * heartbeats, teammate posts, and messages in ordinary human-only pods do
+   * not satisfy that contract. A null result is reserved for an unavailable
+   * read so the frontend can fail closed rather than inventing completion.
+   */
+  static async hasHumanMessageWithAgent(userId: unknown, podIds: unknown[]): Promise<boolean> {
+    if (!userId || !podIds.length) return false;
+    const installQuery = AgentInstallation.find({
+      podId: { $in: podIds },
+      status: 'active',
+    });
+    const selected = typeof installQuery.select === 'function'
+      ? installQuery.select('podId agentName config')
+      : installQuery;
+    const installations = typeof selected.lean === 'function' ? await selected.lean() : await selected;
+    const agentPodIds = Array.from(new Set(
+      (installations as Array<{ podId?: unknown; agentName?: string; config?: unknown }>)
+        .filter((installation) => !isInternalSeat(
+          installation.agentName,
+          normalizeConfigMap(installation.config),
+        ))
+        .map((installation) => String(installation.podId || ''))
+        .filter(Boolean),
+    ));
+    if (!agentPodIds.length) return false;
+
+    // PostgreSQL is the normal chat store. If it is unavailable, inspect the
+    // Mongo fallback only for a positive hit; an empty fallback cannot prove
+    // that the PG store was empty, so preserve the unknown state by throwing.
+    if (PGMessage && typeof (PGMessage as any).hasMessageByUserInPods === 'function') {
+      try {
+        return await (PGMessage as any).hasMessageByUserInPods(userId, agentPodIds);
+      } catch (pgError) {
+        if (Message && typeof (Message as any).exists === 'function') {
+          const fallback = await (Message as any).exists({
+            podId: { $in: agentPodIds },
+            userId,
+            messageType: { $ne: 'system' },
+          });
+          if (fallback) return true;
+        }
+        throw pgError;
+      }
+    }
+    throw new Error('Message store unavailable');
+  }
+
   /**
    * Read-side projection for the v2 Activity surface. The source events stay
    * in their owning stores: messages remain in Postgres and board transitions
@@ -233,6 +286,7 @@ class ActivityService {
     // every item is handled. AttentionItem rows are durable, so this remains
     // true across queue resolution and does not depend on the recap window.
     let hasEverHadAttention: boolean | null = requestedPodId ? false : null;
+    let hasSpokenToAgent: boolean | null = null;
     if (!requestedPodId) {
       try {
         hasEverHadAttention = await AttentionItemService.hasEverHadAttention(userId);
@@ -240,6 +294,16 @@ class ActivityService {
         // Keep the recap readable if the advisory onboarding check is
         // unavailable; the queue itself remains authoritative below.
         console.warn('[activity] day-zero attention check failed:', (error as Error).message);
+      }
+      try {
+        hasSpokenToAgent = await ActivityService.hasHumanMessageWithAgent(
+          userId,
+          scopedPods.map((pod) => pod._id),
+        );
+      } catch (error) {
+        // Keep onboarding fail-closed when the message/roster read is
+        // unavailable. `null` is distinct from a measured `false`.
+        console.warn('[activity] day-zero human-message check failed:', (error as Error).message);
       }
     }
     const needsYou = attention.items
@@ -291,6 +355,7 @@ class ActivityService {
       scope: requestedPodId || 'all',
       pods: pods.map((pod) => ({ id: String(pod._id), name: pod.name })),
       hasEverHadAttention,
+      hasSpokenToAgent,
       needsYou,
       agents: agentRecaps,
       board,

--- a/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
+++ b/frontend/src/v2/__tests__/V2ActivityPage.test.tsx
@@ -45,6 +45,7 @@ const decisionQueue = {
 
 const recap = {
   pods: [{ id: 'pod-1', name: 'Launch pod' }],
+  hasSpokenToAgent: false,
   needsYou: [{
     id: 'mention-1', kind: 'mention', title: 'Review requested', detail: 'A direct mention.',
     podId: 'pod-1', podName: 'Launch pod', timestamp: '2026-08-26T11:00:00.000Z',
@@ -239,11 +240,11 @@ describe('V2ActivityPage', () => {
     const empty = { ...recap, hasEverHadAttention: false, needsYou: [], agents: [], board: [] };
     // Facts come from the registry's per-pod agent list (what Your Team reads), never from the
     // 24h recap window (sprint-review 66671): a hired seat that has not acted is absent from recap.
-    const mockFor = (seats, connectors) => (url: string) => {
+    const mockFor = (seats, connectors, hasSpokenToAgent = false) => (url: string) => {
       if (url === '/api/activity/decision-queue') return Promise.resolve({ data: { items: [], count: 0, countsByPod: {} } });
       if (url === '/api/integrations/user/all') return Promise.resolve({ data: connectors });
       if (url.startsWith('/api/registry/pods/')) return Promise.resolve({ data: { agents: seats } });
-      return Promise.resolve({ data: empty });
+      return Promise.resolve({ data: { ...empty, hasSpokenToAgent } });
     };
     mockGet.mockImplementation(mockFor([], []));
     const first = renderPage();
@@ -263,8 +264,9 @@ describe('V2ActivityPage', () => {
     expect(screen.getByTestId('current-path')).toHaveTextContent('/v2/agents');
     first.unmount();
 
-    // An agent exists but has not answered, no connector: steps 2 and 3, composer back, step 2 is the ink act.
-    // A provisioned seat has lastActiveAt (runtime-token use) but lastMessage null: it has never spoken.
+    // An agent exists but has not received a human ask, no connector: steps 2
+    // and 3, composer back, step 2 is the ink act. A provisioned seat's
+    // runtime activity or own intro must not close the human-message step.
     mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z', lastMessage: null }, { name: 'hosted-smoke', lastMessage: { content: 'x' }, internal: true }], []));
     const second = renderPage();
     expect(await screen.findByText('2 steps · until your first ask arrives')).toBeInTheDocument();
@@ -273,8 +275,9 @@ describe('V2ActivityPage', () => {
     expect(screen.getByRole('heading', { name: /tell your agents/i })).toBeInTheDocument();
     second.unmount();
 
-    // Everything done: no card at all — the 0-state board already gated.
-    mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z', lastMessage: { content: 'Hi there', createdAt: '2026-09-08T10:00:03.000Z' } }], [{ status: 'active' }]));
+    // A human message in that agent pod is the fact that closes step 2,
+    // regardless of whether the agent has answered yet.
+    mockGet.mockImplementation(mockFor([{ name: 'scout', displayName: 'Scout', lastActiveAt: '2026-09-08T10:00:00.000Z', lastMessage: null }], [{ status: 'active' }], true));
     renderPage();
     expect(await screen.findByText('Nothing needs you.')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Get started' })).not.toBeInTheDocument();

--- a/frontend/src/v2/components/V2ActivityPage.tsx
+++ b/frontend/src/v2/components/V2ActivityPage.tsx
@@ -76,6 +76,9 @@ interface ActivityRecap {
   // Account-level durable fact: once any attention item has existed, the
   // first-ask onboarding card should not return after the queue is resolved.
   hasEverHadAttention?: boolean | null;
+  // Account holder's own message in a pod with a non-internal agent seat.
+  // Null means the read was unavailable; the day-zero card fails closed.
+  hasSpokenToAgent?: boolean | null;
   needsYou: NeedsYouItem[];
   agents: AgentRecap[];
   board: BoardItem[];
@@ -201,15 +204,15 @@ const V2ActivityPage: React.FC = () => {
   const [queueAutoPending, setQueueAutoPending] = useState(false);
   // Day zero (ux-lead 66658/66666): Get started is its own card above Needs you and a step is
   // not an ask — no actor, no ring, no count, no badge; a step leaves when the account does
-  // something. hire ← an agent exists; speak ← an agent has answered; connect ← a connector row.
+  // something. hire ← an agent exists; speak ← the account holder has posted in an agent pod;
+  // connect ← a connector row.
   const [connectorCount, setConnectorCount] = useState<number | null>(null);
-  // "Hired" and "has answered" are facts about the account's seats, not about the last 24h
+  // "Hired" is a fact about the account's seats, not about the last 24h
   // (sprint-review 66671: recap.agents only carries agents that acted inside the recap window).
-  // The registry's per-pod agent list is what Your Team reads. `lastMessage` is proof of speech
-  // (null when the seat has never spoken in that pod); `lastActiveAt` is only proof of life —
-  // provisioning uses a runtime token and sets it (sprint-review 66678) — so it must not close
-  // the step whose job is to notice a seat that never answered.
-  const [hiredAgents, setHiredAgents] = useState<Array<{ name: string; lastMessage?: unknown; internal?: boolean }> | null>(null);
+  // The registry's per-pod agent list is what Your Team reads. Speech itself
+  // comes from recap.hasSpokenToAgent: a registry last-message field is agent
+  // speech, not the account holder's first human ask.
+  const [hiredAgents, setHiredAgents] = useState<Array<{ name: string; internal?: boolean }> | null>(null);
   const [queueLoadingMore, setQueueLoadingMore] = useState(false);
   const [queueMoreError, setQueueMoreError] = useState(false);
   const [historyRemaining, setHistoryRemaining] = useState(0);
@@ -564,7 +567,7 @@ const V2ActivityPage: React.FC = () => {
     const token = localStorage.getItem('token');
     const headers = { 'x-auth-token': token ?? '' };
     Promise.all(recap.pods.slice(0, 20).map((pod) => axios
-      .get<{ agents?: Array<{ name: string; lastMessage?: unknown; internal?: boolean }> }>(`/api/registry/pods/${pod.id}/agents`, { headers })
+      .get<{ agents?: Array<{ name: string; internal?: boolean }> }>(`/api/registry/pods/${pod.id}/agents`, { headers })
       .then((res) => (Array.isArray(res.data?.agents) ? res.data.agents : []))
       .catch(() => [])))
       .then((lists) => { if (active) setHiredAgents(lists.flat().filter((agent) => !agent.internal)); });
@@ -574,7 +577,7 @@ const V2ActivityPage: React.FC = () => {
     if (!recap || podId !== 'all' || hiredAgents === null) return [] as Array<'hire' | 'speak' | 'connect'>;
     const open: Array<'hire' | 'speak' | 'connect'> = [];
     if (hiredAgents.length === 0) open.push('hire');
-    if (!hiredAgents.some((agent) => agent.lastMessage != null)) open.push('speak');
+    if (recap.hasSpokenToAgent === false) open.push('speak');
     if (connectorCount !== null && connectorCount === 0) open.push('connect');
     return open;
   }, [recap, podId, hiredAgents, connectorCount]);


### PR DESCRIPTION
## Summary
- gate the day-zero speak step on the account holder's own non-system message in a pod with an active non-internal seat
- expose the account-level fact from the activity recap and fail closed when the roster/message read is unavailable
- add regression coverage for agent intros, internal/no-seat pods, and the human-message contract

## Verification
- `backend`: 12 focused recap tests
- `frontend`: 52 focused V2ActivityPage tests
- `frontend`: `npm run typecheck`, `npm run build`
- `backend`: `npm run build`
