### PR TITLE
fix(v2): every non-option Activity card act is 32 tall at desktop

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -398,6 +398,9 @@ describe('v2 layout invariants (CSS rule presence)', () => {
     expect(v2).toMatch(/\.v2-activity__queue-actions,\n\.v2-activity__queue-row button,[\s\S]*?\{\n\s*display: flex;[\s\S]*?gap: 6px;/);
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-activity__queue-actions \{ grid-column: 2; \}[\s\S]*?\.v2-activity__queue-actions \{ flex-wrap: wrap; \}/);
     expect(v2).toMatch(/@media \(max-width: 640px\)[\s\S]*?\.v2-root \.v2-activity__queue-actions button \{ min-height: 44px; \}/);
+    // Every non-option card act is 32 tall at desktop, level with the options (ux-lead 67327):
+    // Approve / Deny / Mark handled / Reply / Open read 30 from the shared row-button rule.
+    expect(ruleBody(v2, '.v2-root .v2-activity__queue-actions button')).toContain('min-height: 32px');
   });
 
   test('Activity pagination keeps the Show more affordance visible and keyboard-sized', () => {

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -9092,6 +9092,7 @@ body.modern-ui.v2-canvas {
 }
 
 .v2-root .v2-activity__queue-actions button {
+  min-height: 32px;
   padding: 0 12px;
   white-space: nowrap;
   border-color: var(--v2-ink);


### PR DESCRIPTION
Owed from the 09-11 ruling, named again by ux-lead at 67327 on #1654: Approve / Deny / Mark handled / Reply / Open measured 30 at desktop while decision options sit at 32.

One line — `min-height: 32px` on `.v2-root .v2-activity__queue-actions button` (`v2.css`), which outranks the shared `.v2-activity__queue-row button { min-height: 30px }` it follows; the ≤640 rule still lifts every act to 44. Pinned in `v2-layout-invariants` (108/108). Independent of #1654 (based on main) so that PR's measured mutation set stays as gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DspLEe1mFV94dPGCqA1u5
