### PR TITLE
[frontend] Reset BYO hint paragraph margins

### DIFF
--- a/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
+++ b/frontend/src/v2/__tests__/v2-layout-invariants.test.ts
@@ -145,6 +145,10 @@ describe('v2 layout invariants (CSS rule presence)', () => {
   const appsManagement = read('../../components/AppsManagement.tsx');
   const podModel = read('../../../../backend/models/Pod.ts');
 
+  test('BYO hints do not add paragraph margins to flex gaps', () => {
+    expect(ruleBody(v2, '.v2-byo__hint')).toContain('margin: 0');
+  });
+
   test('Your Team card name owns its line so the category chip cannot crush it', () => {
     // Direction C: the name sits in its own column of the card head; the
     // crush guard is min-width 0 on the name and the head, not a flex basis.

--- a/frontend/src/v2/v2.css
+++ b/frontend/src/v2/v2.css
@@ -5694,6 +5694,7 @@ body.modern-ui.v2-canvas {
 .v2-byo__hint {
   font-size: 12px;
   color: var(--v2-text-tertiary);
+  margin: 0;
 }
 .v2-byo__error {
   padding: 10px 12px;


### PR DESCRIPTION
## Summary

Reset `.v2-byo__hint` margins so paragraph hints in BYO flex layouts use the components' explicit gaps. Add the required layout-invariant guard. This implements the one-line fix proposed and measured in the issue by lilyshen0722.

## Type

- [x] Bug fix

## Related Issues

Closes #1413

## Test Plan

- [x] Focused repository Jest suite: `v2-layout-invariants.test.ts` — 109/109 passed.
- [x] ESLint on the changed test — zero errors; six warnings on existing lines.
- [x] Real Chromium layout check using the actual stylesheet and current markup patterns.
- [x] Presence-guard mutation check and clean patch-application check.
- [x] Published files match the tested local files byte-for-byte.
- [ ] Full authoritative frontend test/lint run.
- [ ] Full stack / backend checks and `./dev.sh up` (not run).

Browser measurements, in pixels:

| Layout | Before | After |
|---|---:|---:|
| Hosted stats → hint | 30 | 18 |
| Hosted hint → CTA | 38 | 26 |
| Memory hint → textarea | 22 | 10 |
| Add-computer adjacent gaps | 18 | 6 |
| Existing span top/bottom margins | 0 / 0 | 0 / 0 |

The memory and add-computer paragraphs consequently become tighter, matching their parents' declared gaps. The hosted CTA still has its existing additional 8px top margin.

## Notes for Reviewer

Draft while full validation is unresolved. Full frontend lint reports 20 errors in existing files outside this diff. An isolated pnpm install with lifecycle scripts and lockfile writing disabled ran 60 passing suites / 531 passing tests, but other suites encountered DiceBear ESM transform and missing `prop-types` resolution problems under that installation topology. This is not a clean full-suite result; the repository's normal npm/CI run is still needed. No manifest or lockfile was changed.

The public design README and surrounding CSS were checked. The referenced external `commonly-design` skill is absent from the public archive. The change follows the existing sibling paragraph margin reset and the issue's proposed repair.

Implemented by OpenAI Codex, directed by Daniel J. Murray.