### PR TITLE
feat(installable): parse local MCP plugin manifests

### DIFF
--- a/backend/__tests__/unit/routes/marketplace-api.componentValidation.test.js
+++ b/backend/__tests__/unit/routes/marketplace-api.componentValidation.test.js
@@ -125,6 +125,61 @@ describe('marketplace publish validates inside the components array', () => {
     expect(Installable.create).not.toHaveBeenCalled();
   });
 
+  it('persists the parser-normalized MCP component on publish', async () => {
+    const res = await publish([{
+      name: 'Calendar',
+      type: 'mcp-server',
+      transport: 'stdio',
+      source: { spec: 'acme/calendar', subpath: './servers/calendar' },
+      command: ['node', '--port', '8080', '--port', '8080'],
+    }]);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(Installable.create).toHaveBeenCalledWith(expect.objectContaining({
+      components: [expect.objectContaining({
+        source: { spec: 'https://github.com/acme/calendar', subpath: 'servers/calendar' },
+        command: ['node', '--port', '8080', '--port', '8080'],
+      })],
+    }));
+  });
+
+  it('persists the parser-normalized MCP component on update', async () => {
+    const existing = {
+      installableId: '@nova/my-agent',
+      publisher: { userId: 'user-1' },
+      status: 'active',
+      versions: [],
+      components: [],
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    Installable.findOne.mockResolvedValue(existing);
+    const res = await publish([{
+      name: 'Calendar',
+      type: 'mcp-server',
+      transport: 'stdio',
+      source: { spec: 'acme/calendar' },
+      command: ['node', 'server.js'],
+    }]);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    expect(existing.components[0].source.spec).toBe('https://github.com/acme/calendar');
+  });
+
+  it.each([
+    'transport',
+    'source',
+    'command',
+    'url',
+    'variables',
+    'enabledTools',
+  ])('rejects MCP field %s on a non-MCP component', async (field) => {
+    const res = await publish([widget({ [field]: field === 'transport' ? 'stdio' : {} })]);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(errorOf(res)).toMatch(new RegExp(`components\\[0\\]\\.${field} is only valid for mcp-server`, 'i'));
+    expect(Installable.create).not.toHaveBeenCalled();
+  });
+
   it('rejects a components value that is not an array', async () => {
     // A string has `.length`, so the old `components.length > 50` gate passed
     // any string of 50 characters or fewer straight through.
@@ -194,7 +249,19 @@ describe('marketplace publish validates inside the components array', () => {
     ['variables'],
     ['metadata'],
   ])('caps the Mixed field %s', async (field) => {
-    const res = await publish([widget({ [field]: { blob: 'x'.repeat(20 * 1024) } })]);
+    const component = field === 'variables'
+      ? {
+        name: 'Calendar',
+        type: 'mcp-server',
+        transport: 'stdio',
+        source: { spec: 'acme/calendar' },
+        command: ['node', 'server.js'],
+        variables: Object.fromEntries(
+          Array.from({ length: 1000 }, (_, index) => [`variable${index}`, { type: 'string' }]),
+        ),
+      }
+      : widget({ [field]: { blob: 'x'.repeat(20 * 1024) } });
+    const res = await publish([component]);
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(errorOf(res)).toMatch(new RegExp(`components\\[0\\]\\.${field} must be \\d+ bytes or fewer`, 'i'));
@@ -281,6 +348,24 @@ describe('marketplace fork validates the components it copies', () => {
 
     expect(res.status).toHaveBeenCalledWith(201);
     expect(Installable.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists parser-normalized MCP components on fork', async () => {
+    const sourceComponents = [{
+      name: 'Calendar',
+      type: 'mcp-server',
+      transport: 'stdio',
+      source: { spec: 'acme/calendar' },
+      command: ['node', 'server.js'],
+    }];
+    const res = await fork(sourceComponents);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(Installable.create).toHaveBeenCalledWith(expect.objectContaining({
+      components: [expect.objectContaining({
+        source: { spec: 'https://github.com/acme/calendar' },
+      })],
+    }));
   });
 
   it('refuses to launder an unvalidated widgetUrl out of a builtin source', async () => {

--- a/backend/__tests__/unit/routes/marketplace-api.componentValidation.test.js
+++ b/backend/__tests__/unit/routes/marketplace-api.componentValidation.test.js
@@ -96,6 +96,35 @@ describe('marketplace publish validates inside the components array', () => {
     expect(Installable.create).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts the ADR-001 McpServer component and bounds its variables field', async () => {
+    const res = await publish([{
+      name: 'Calendar',
+      type: 'mcp-server',
+      transport: 'stdio',
+      source: { spec: 'acme/calendar', pin: '0123456789abcdef0123456789abcdef01234567' },
+      command: ['node', 'server.js'],
+      variables: { account: { type: 'string' } },
+      enabledTools: ['events.read'],
+    }]);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(Installable.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies parser security rules when an MCP component is published directly', async () => {
+    const res = await publish([{
+      name: 'Calendar',
+      type: 'mcp-server',
+      transport: 'stdio',
+      source: { spec: 'file:///etc/passwd' },
+      command: ['node', 'server.js'],
+    }]);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(errorOf(res)).toMatch(/components\[0\]\.source\.spec/i);
+    expect(Installable.create).not.toHaveBeenCalled();
+  });
+
   it('rejects a components value that is not an array', async () => {
     // A string has `.length`, so the old `components.length > 50` gate passed
     // any string of 50 characters or fewer straight through.
@@ -162,6 +191,7 @@ describe('marketplace publish validates inside the components array', () => {
     ['widgetConfigSchema'],
     ['schemaFields'],
     ['skillExamples'],
+    ['variables'],
     ['metadata'],
   ])('caps the Mixed field %s', async (field) => {
     const res = await publish([widget({ [field]: { blob: 'x'.repeat(20 * 1024) } })]);

--- a/backend/__tests__/unit/utils/pluginManifestParser.test.ts
+++ b/backend/__tests__/unit/utils/pluginManifestParser.test.ts
@@ -1,0 +1,241 @@
+// @ts-nocheck
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  parsePluginManifest,
+  PluginManifestValidationError,
+} from '../../../utils/pluginManifestParser';
+
+const sha = '0123456789abcdef0123456789abcdef01234567';
+
+const writeManifest = (root: string, directory: string, manifest: unknown) => {
+  const pluginDirectory = path.join(root, directory);
+  fs.mkdirSync(pluginDirectory, { recursive: true });
+  fs.writeFileSync(path.join(pluginDirectory, 'plugin.json'), JSON.stringify(manifest));
+};
+
+const validManifest = (overrides: Record<string, unknown> = {}) => ({
+  name: 'calendar-tools',
+  description: 'Calendar tools',
+  version: '1.2.3',
+  source: { spec: 'acme/calendar-tools', subpath: 'servers/calendar', pin: sha },
+  mcpServers: {
+    calendar: {
+      transport: 'stdio',
+      command: ['node', 'server.js'],
+      variables: {
+        account: { type: 'string', default: 'work' },
+        token: { type: 'string', writeOnly: true },
+      },
+      enabledTools: ['events.read', 'events.read'],
+    },
+  },
+  ...overrides,
+});
+
+const makeRoot = (manifest: unknown, directory = '.claude-plugin') => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'commonly-plugin-'));
+  writeManifest(root, directory, manifest);
+  return root;
+};
+
+describe('plugin manifest parser', () => {
+  it('maps a local Claude root to an Installable with MCP components', () => {
+    const result = parsePluginManifest(makeRoot(validManifest()));
+
+    expect(result).toMatchObject({
+      installableId: 'calendar-tools',
+      name: 'calendar-tools',
+      kind: 'app',
+      source: 'user',
+      scope: 'user',
+      components: [{
+        name: 'calendar',
+        type: 'mcp-server',
+        transport: 'stdio',
+        source: { spec: 'acme/calendar-tools', subpath: 'servers/calendar', pin: sha },
+        command: ['node', 'server.js'],
+        enabledTools: ['events.read'],
+      }],
+    });
+  });
+
+  it('accepts both plugin roots and lets Claude values win while Cursor fills gaps', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'commonly-plugin-'));
+    writeManifest(root, '.claude-plugin', {
+      name: 'dual-root',
+      description: 'Claude description',
+      version: '1.0.0',
+      source: 'acme/dual-root',
+      mcpServers: {
+        one: { transport: 'stdio', command: ['node', 'one.js'] },
+      },
+    });
+    writeManifest(root, '.cursor-plugin', {
+      name: 'cursor-name-must-not-win',
+      description: 'Cursor description',
+      version: '9.9.9',
+      source: 'acme/cursor-root',
+      mcpServers: {
+        one: { enabledTools: ['one.read'] },
+        two: { transport: 'http', url: 'https://example.com/mcp', source: 'acme/two' },
+      },
+    });
+
+    const result = parsePluginManifest(root);
+    expect(result.name).toBe('dual-root');
+    expect(result.version).toBe('1.0.0');
+    expect(result.components).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'one', command: ['node', 'one.js'], enabledTools: ['one.read'] }),
+      expect.objectContaining({ name: 'two', transport: 'http' }),
+    ]));
+  });
+
+  it.each([
+    ['file:///tmp/secret', 'Only https://github.com'],
+    ['ssh://git@github.com/acme/plugin', 'Only https://github.com'],
+    ['https://internal.example/acme/plugin', 'Only https://github.com'],
+  ])('rejects disallowed source %s before any fetch', (spec, message) => {
+    const root = makeRoot(validManifest({ source: { spec } }));
+    expect(() => parsePluginManifest(root)).toThrow(message);
+  });
+
+  it('rejects absolute and traversal subpaths', () => {
+    for (const subpath of ['/etc/passwd', '../outside', 'servers/../../outside', 'servers/%2e%2e/outside']) {
+      const root = makeRoot(validManifest({ source: { spec: 'acme/plugin', subpath } }));
+      expect(() => parsePluginManifest(root)).toThrow(PluginManifestValidationError);
+    }
+    const traversalSource = makeRoot(validManifest({ source: { spec: '../outside' } }));
+    expect(() => parsePluginManifest(traversalSource)).toThrow(PluginManifestValidationError);
+  });
+
+  it('rejects non-40-character pins and preserves a valid pin verbatim', () => {
+    const badRoot = makeRoot(validManifest({ source: { spec: 'acme/plugin', pin: 'abc' } }));
+    expect(() => parsePluginManifest(badRoot)).toThrow('40-character commit SHA');
+
+    const goodPin = 'ABCDEF0123456789ABCDEF0123456789ABCDEF01';
+    const result = parsePluginManifest(makeRoot(validManifest({ source: { spec: 'acme/plugin', pin: goodPin } })));
+    expect(result.components[0].source?.pin).toBe(goodPin);
+  });
+
+  it('canonicalizes an allowed GitHub URL and local source path', () => {
+    const github = parsePluginManifest(makeRoot(validManifest({
+      source: { spec: 'https://github.com/acme/plugin/' },
+    })));
+    expect(github.components[0].source?.spec).toBe('https://github.com/acme/plugin');
+
+    const local = parsePluginManifest(makeRoot(validManifest({
+      source: { spec: './servers//calendar' },
+    })));
+    expect(local.components[0].source?.spec).toBe('servers/calendar');
+  });
+
+  it('accepts a string source with sibling subpath and pin fields', () => {
+    const result = parsePluginManifest(makeRoot(validManifest({
+      source: 'https://github.com/acme/plugin',
+      subpath: './servers/calendar',
+      pin: sha,
+    })));
+    expect(result.components[0].source).toEqual({
+      spec: 'https://github.com/acme/plugin',
+      subpath: 'servers/calendar',
+      pin: sha,
+    });
+  });
+
+  it('infers transport for standard command/url MCP manifest entries', () => {
+    const root = makeRoot(validManifest({
+      mcpServers: {
+        calendar: {
+          command: 'npx',
+          args: ['-y', '@acme/calendar-mcp'],
+          source: 'acme/calendar',
+        },
+        remote: {
+          url: 'https://mcp.example.test/server',
+          source: 'acme/calendar',
+        },
+      },
+    }));
+    const result = parsePluginManifest(root);
+    expect(result.components).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'calendar', transport: 'stdio', command: ['npx', '-y', '@acme/calendar-mcp'] }),
+      expect.objectContaining({ name: 'remote', transport: 'http' }),
+    ]));
+  });
+
+  it('refuses a writeOnly literal default with the variable name', () => {
+    const root = makeRoot(validManifest({
+      mcpServers: {
+        calendar: {
+          transport: 'stdio',
+          command: ['node', 'server.js'],
+          variables: { token: { type: 'string', writeOnly: true, default: 'secret' } },
+        },
+      },
+    }));
+    expect(() => parsePluginManifest(root)).toThrow('manifest.mcpServers.calendar.variables.token');
+  });
+
+  it('refuses provider-specific literal fields on writeOnly variables', () => {
+    const root = makeRoot(validManifest({
+      mcpServers: {
+        calendar: {
+          transport: 'stdio',
+          command: ['node', 'server.js'],
+          variables: { token: { type: 'string', writeOnly: true, value: 'secret' } },
+        },
+      },
+    }));
+    expect(() => parsePluginManifest(root)).toThrow('literal value');
+  });
+
+  it('refuses a writeOnly literal env value but permits a secret reference', () => {
+    const literalRoot = makeRoot(validManifest({
+      mcpServers: {
+        calendar: {
+          transport: 'stdio',
+          command: ['node', 'server.js'],
+          variables: { token: { type: 'string', writeOnly: true } },
+          env: { token: 'secret' },
+        },
+      },
+    }));
+    expect(() => parsePluginManifest(literalRoot)).toThrow('writeOnly variable must use a secret reference');
+
+    const referenceRoot = makeRoot(validManifest({
+      mcpServers: {
+        calendar: {
+          transport: 'stdio',
+          command: ['node', 'server.js'],
+          variables: { token: { type: 'string', writeOnly: true } },
+          env: { token: { secretRef: 'connections/calendar/token' } },
+        },
+      },
+    }));
+    expect(() => parsePluginManifest(referenceRoot)).not.toThrow();
+  });
+
+  it('maps local skill entries and marks a skills-only plugin as kind skill', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'commonly-plugin-'));
+    fs.mkdirSync(path.join(root, 'skills', 'research'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'skills', 'research', 'SKILL.md'), '# Research\nUse primary sources.');
+    writeManifest(root, '.cursor-plugin', {
+      name: 'research-skills',
+      description: 'Research skills',
+      version: '1.0.0',
+      skills: [{ path: 'skills/research' }],
+    });
+
+    const result = parsePluginManifest(root);
+    expect(result.kind).toBe('skill');
+    expect(result.components).toEqual([expect.objectContaining({
+      type: 'skill',
+      skillId: 'research',
+      skillPrompt: '# Research\nUse primary sources.',
+    })]);
+  });
+});

--- a/backend/__tests__/unit/utils/pluginManifestParser.test.ts
+++ b/backend/__tests__/unit/utils/pluginManifestParser.test.ts
@@ -56,7 +56,7 @@ describe('plugin manifest parser', () => {
         name: 'calendar',
         type: 'mcp-server',
         transport: 'stdio',
-        source: { spec: 'acme/calendar-tools', subpath: 'servers/calendar', pin: sha },
+        source: { spec: 'https://github.com/acme/calendar-tools', subpath: 'servers/calendar', pin: sha },
         command: ['node', 'server.js'],
         enabledTools: ['events.read'],
       }],
@@ -71,8 +71,10 @@ describe('plugin manifest parser', () => {
       version: '1.0.0',
       source: 'acme/dual-root',
       mcpServers: {
-        one: { transport: 'stdio', command: ['node', 'one.js'] },
+        one: { transport: 'stdio', command: ['node', 'one.js'], enabledTools: ['one.read'] },
+        empty: { transport: 'stdio', command: ['node', 'empty.js'], enabledTools: [] },
       },
+      skills: [{ name: 'claude-skill', prompt: 'Claude instructions' }],
     });
     writeManifest(root, '.cursor-plugin', {
       name: 'cursor-name-must-not-win',
@@ -80,9 +82,14 @@ describe('plugin manifest parser', () => {
       version: '9.9.9',
       source: 'acme/cursor-root',
       mcpServers: {
-        one: { enabledTools: ['one.read'] },
+        one: { enabledTools: ['one.write'], command: ['sh', 'evil.sh'] },
+        empty: { enabledTools: ['evil.write'] },
         two: { transport: 'http', url: 'https://example.com/mcp', source: 'acme/two' },
       },
+      skills: [
+        { name: 'claude-skill', prompt: 'Cursor instructions must not replace Claude' },
+        { name: 'cursor-skill', prompt: 'Cursor instructions' },
+      ],
     });
 
     const result = parsePluginManifest(root);
@@ -90,7 +97,10 @@ describe('plugin manifest parser', () => {
     expect(result.version).toBe('1.0.0');
     expect(result.components).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'one', command: ['node', 'one.js'], enabledTools: ['one.read'] }),
+      expect.objectContaining({ name: 'empty', enabledTools: [] }),
       expect.objectContaining({ name: 'two', transport: 'http' }),
+      expect.objectContaining({ name: 'claude-skill', skillPrompt: 'Claude instructions' }),
+      expect.objectContaining({ name: 'cursor-skill', skillPrompt: 'Cursor instructions' }),
     ]));
   });
 
@@ -130,7 +140,8 @@ describe('plugin manifest parser', () => {
     const local = parsePluginManifest(makeRoot(validManifest({
       source: { spec: './servers//calendar' },
     })));
-    expect(local.components[0].source?.spec).toBe('servers/calendar');
+    expect(local.components[0].source?.spec).toBe('./servers/calendar');
+    expect(local.components[0].source?.spec).not.toBe(github.components[0].source?.spec);
   });
 
   it('accepts a string source with sibling subpath and pin fields', () => {
@@ -167,6 +178,33 @@ describe('plugin manifest parser', () => {
     ]));
   });
 
+  it('preserves argv order and duplicate values for command and args', () => {
+    const result = parsePluginManifest(makeRoot(validManifest({
+      mcpServers: {
+        array: {
+          transport: 'stdio',
+          command: ['srv', '--port', '8080', '--admin-port', '8080'],
+          source: 'acme/argv',
+        },
+        split: {
+          command: 'npx',
+          args: ['-y', 'pkg', '--port', '8080', '--admin-port', '8080'],
+          source: 'acme/args',
+        },
+      },
+    })));
+    expect(result.components).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'array',
+        command: ['srv', '--port', '8080', '--admin-port', '8080'],
+      }),
+      expect.objectContaining({
+        name: 'split',
+        command: ['npx', '-y', 'pkg', '--port', '8080', '--admin-port', '8080'],
+      }),
+    ]));
+  });
+
   it('refuses a writeOnly literal default with the variable name', () => {
     const root = makeRoot(validManifest({
       mcpServers: {
@@ -193,6 +231,25 @@ describe('plugin manifest parser', () => {
     expect(() => parsePluginManifest(root)).toThrow('literal value');
   });
 
+  it.each(['enum', 'const', 'examples'])('refuses writeOnly variable %s', (field) => {
+    const root = makeRoot(validManifest({
+      mcpServers: {
+        calendar: {
+          transport: 'stdio',
+          command: ['node', 'server.js'],
+          variables: {
+            token: {
+              type: 'string',
+              writeOnly: true,
+              [field]: field === 'enum' ? ['sk-live-LEAK'] : ['example'],
+            },
+          },
+        },
+      },
+    }));
+    expect(() => parsePluginManifest(root)).toThrow(/writeOnly variables cannot contain literal/);
+  });
+
   it('refuses a writeOnly literal env value but permits a secret reference', () => {
     const literalRoot = makeRoot(validManifest({
       mcpServers: {
@@ -217,6 +274,43 @@ describe('plugin manifest parser', () => {
       },
     }));
     expect(() => parsePluginManifest(referenceRoot)).not.toThrow();
+  });
+
+  it.each([
+    'http://example.com/mcp',
+    'https://169.254.169.254/latest/meta-data',
+    'https://169.254.169.254./latest/meta-data',
+    'https://2852039166/latest/meta-data',
+    'https://0251.0376.0251.0376/latest/meta-data',
+    'https://[::ffff:a9fe:a9fe]/latest/meta-data',
+    'https://user:secret@mcp.example.com/mcp',
+    'https://localhost./mcp',
+    'https://dev.localhost/mcp',
+    'https://metadata.google.internal./mcp',
+    '${COMMONLY_API_URL}@evil.com/mcp',
+  ])('rejects unsafe MCP HTTP URL %s', (url) => {
+    const root = makeRoot(validManifest({
+      mcpServers: {
+        remote: { transport: 'http', url, source: 'acme/remote' },
+      },
+    }));
+    expect(() => parsePluginManifest(root)).toThrow(PluginManifestValidationError);
+  });
+
+  it('accepts a complete Commonly API origin placeholder for an MCP HTTP URL', () => {
+    const root = makeRoot(validManifest({
+      mcpServers: {
+        remote: { transport: 'http', url: '${COMMONLY_API_URL}/mcp', source: 'acme/remote' },
+      },
+    }));
+    expect(parsePluginManifest(root).components[0].url).toBe('${COMMONLY_API_URL}/mcp');
+  });
+
+  it('refuses percent-encoded MCP source subpaths', () => {
+    const root = makeRoot(validManifest({
+      source: { spec: 'acme/plugin', subpath: 'servers/%252e%252e/outside' },
+    }));
+    expect(() => parsePluginManifest(root)).toThrow(PluginManifestValidationError);
   });
 
   it('maps local skill entries and marks a skills-only plugin as kind skill', () => {

--- a/backend/models/Installable.ts
+++ b/backend/models/Installable.ts
@@ -6,7 +6,7 @@ import mongoose, { Document, Model, Schema, Types } from 'mongoose';
  *
  * Replaces the pre-v2 `App` + `AgentRegistry` split. A single Installable carries
  * one or more polymorphic `components` (agent, slash-command, event-handler,
- * scheduled-job, widget, webhook, data-schema), so a single marketplace entry
+ * scheduled-job, widget, webhook, data-schema, skill, mcp-server), so a single marketplace entry
  * can ship a bundle (e.g. an agent + its companion slash command + a widget)
  * while preserving component-level addressing and scoping.
  *
@@ -70,7 +70,8 @@ export type ComponentType =
   | 'widget'
   | 'webhook'
   | 'data-schema'
-  | 'skill';
+  | 'skill'
+  | 'mcp-server';
 
 export type AddressMode =
   | '@mention'
@@ -125,6 +126,22 @@ export interface IComponentPersona {
   avatar?: string;
   systemPrompt?: string;
   memoryStrategy?: ComponentMemoryStrategy;
+}
+
+export interface IMcpSource {
+  spec: string;
+  subpath?: string;
+  pin?: string;
+}
+
+export type McpVariableType = 'string' | 'number' | 'boolean';
+
+export interface IMcpVariable {
+  type: McpVariableType;
+  description?: string;
+  default?: string | number | boolean;
+  enum?: Array<string | number>;
+  writeOnly?: boolean;
 }
 
 export interface ISlashCommandParameter {
@@ -191,6 +208,14 @@ export interface IComponent {
   skillPrompt?: string;
   skillTools?: string[];
   skillExamples?: unknown;
+
+  // MCP-server-specific (agent-only — no addresses)
+  transport?: 'stdio' | 'http';
+  source?: IMcpSource;
+  command?: string[];
+  url?: string;
+  variables?: Record<string, IMcpVariable>;
+  enabledTools?: string[];
 
   // Component-level free-form metadata.
   metadata?: Record<string, unknown>;
@@ -356,6 +381,7 @@ const ComponentSchema = new Schema<IComponent>(
         'webhook',
         'data-schema',
         'skill',
+        'mcp-server',
       ],
       required: true,
     },
@@ -414,6 +440,20 @@ const ComponentSchema = new Schema<IComponent>(
     skillPrompt: { type: String },
     skillTools: { type: [String], default: undefined },
     skillExamples: { type: Schema.Types.Mixed },
+
+    // MCP server (agent-only — no addresses)
+    transport: { type: String, enum: ['stdio', 'http'] },
+    source: {
+      type: new Schema({
+        spec: { type: String, required: true },
+        subpath: { type: String },
+        pin: { type: String },
+      }, { _id: false }),
+    },
+    command: { type: [String], default: undefined },
+    url: { type: String },
+    variables: { type: Schema.Types.Mixed },
+    enabledTools: { type: [String], default: undefined },
 
     // Free-form component metadata
     metadata: { type: Schema.Types.Mixed },

--- a/backend/routes/marketplace-api.ts
+++ b/backend/routes/marketplace-api.ts
@@ -28,12 +28,11 @@ const validateNamespace = (installableId: string, username: string) => {
   return null;
 };
 
-// Validation stops at the components array (PR #215/#230): every scalar above
-// is length- or enum-checked, and then `components` is taken from the body and
-// persisted with one length test. Everything nested inside it — including
-// `widgetUrl`, whose immediate sibling `widgetLocation` HAS an enum — reaches
-// Mongo unchecked. Nested validation was not overlooked as a category; it was
-// applied one field over and stopped at the array boundary.
+// Component validation is a persistence boundary (PR #215/#230): every
+// component is checked before it reaches Mongo, and MCP components are passed
+// through the parser's normalizer so publish, update and fork share one row
+// shape. The generic checks below cover component types and widget fields;
+// parser-owned MCP rules cover source, transport, argv and variables.
 //
 // This matters more than "an unused field is sloppy". Nothing renders a widget
 // today, so stored rows are inert — but they are inert only until a renderer
@@ -67,6 +66,7 @@ const MAX_MIXED_FIELD_BYTES = 16 * 1024;
 
 const MAX_COMPONENTS = 50;
 const MAX_WIDGET_URL_LENGTH = 2048;
+const MCP_COMPONENT_FIELDS = ['transport', 'source', 'command', 'url', 'variables', 'enabledTools'];
 
 // Scheme allowlist rather than a denylist: `javascript:` and `data:` are the
 // two that turn a stored string into script execution the moment something
@@ -74,61 +74,68 @@ const MAX_WIDGET_URL_LENGTH = 2048;
 // argument. http/https are what a widget host can legitimately be.
 const WIDGET_URL_SCHEMES = ['http:', 'https:'];
 
-const validateComponents = (components: any) => {
-  if (components === undefined || components === null) return null;
-  if (!Array.isArray(components)) return 'components must be an array';
+const normalizeComponents = (components: any) => {
+  if (components === undefined || components === null) return { components, error: null };
+  if (!Array.isArray(components)) return { components, error: 'components must be an array' };
   if (components.length > MAX_COMPONENTS) {
-    return `Maximum ${MAX_COMPONENTS} components per manifest`;
+    return { components, error: `Maximum ${MAX_COMPONENTS} components per manifest` };
   }
 
-  for (let i = 0; i < components.length; i += 1) {
-    const component = components[i];
+  const normalizedComponents = components.slice();
+  for (let i = 0; i < normalizedComponents.length; i += 1) {
+    const component = normalizedComponents[i];
     const at = `components[${i}]`;
 
     if (!component || typeof component !== 'object' || Array.isArray(component)) {
-      return `${at} must be an object`;
+      return { components, error: `${at} must be an object` };
     }
     if (typeof component.name !== 'string' || !component.name.trim()) {
-      return `${at}.name is required`;
+      return { components, error: `${at}.name is required` };
     }
     if (component.name.length > 100) {
-      return `${at}.name must be 100 characters or fewer`;
+      return { components, error: `${at}.name must be 100 characters or fewer` };
     }
     if (!COMPONENT_TYPES.includes(component.type)) {
-      return `${at}.type must be one of: ${COMPONENT_TYPES.join(', ')}`;
+      return { components, error: `${at}.type must be one of: ${COMPONENT_TYPES.join(', ')}` };
     }
     if (component.description !== undefined) {
       if (typeof component.description !== 'string') {
-        return `${at}.description must be a string`;
+        return { components, error: `${at}.description must be a string` };
       }
       if (component.description.length > 500) {
-        return `${at}.description must be 500 characters or fewer`;
+        return { components, error: `${at}.description must be 500 characters or fewer` };
       }
     }
 
     if (component.type === 'mcp-server') {
-      const mcpErrors = validateMcpComponent(component, at);
-      if (mcpErrors.length) {
-        const firstError = mcpErrors[0];
-        return `${firstError.field}: ${firstError.message}`;
+      const validation = validateMcpComponent(component, at);
+      if (validation.errors.length) {
+        const firstError = validation.errors[0];
+        return { components, error: `${firstError.field}: ${firstError.message}` };
+      }
+      normalizedComponents[i] = validation.component;
+    } else {
+      const mcpField = MCP_COMPONENT_FIELDS.find((field) => component[field] !== undefined);
+      if (mcpField) {
+        return { components, error: `${at}.${mcpField} is only valid for mcp-server components` };
       }
     }
 
     if (component.widgetUrl !== undefined) {
       if (typeof component.widgetUrl !== 'string') {
-        return `${at}.widgetUrl must be a string`;
+        return { components, error: `${at}.widgetUrl must be a string` };
       }
       if (component.widgetUrl.length > MAX_WIDGET_URL_LENGTH) {
-        return `${at}.widgetUrl must be ${MAX_WIDGET_URL_LENGTH} characters or fewer`;
+        return { components, error: `${at}.widgetUrl must be ${MAX_WIDGET_URL_LENGTH} characters or fewer` };
       }
       let parsed;
       try {
         parsed = new URL(component.widgetUrl);
       } catch {
-        return `${at}.widgetUrl must be an absolute URL`;
+        return { components, error: `${at}.widgetUrl must be an absolute URL` };
       }
       if (!WIDGET_URL_SCHEMES.includes(parsed.protocol)) {
-        return `${at}.widgetUrl must use one of: ${WIDGET_URL_SCHEMES.join(', ')}`;
+        return { components, error: `${at}.widgetUrl must use one of: ${WIDGET_URL_SCHEMES.join(', ')}` };
       }
     }
 
@@ -141,15 +148,15 @@ const validateComponents = (components: any) => {
         // A body that survived JSON.parse cannot be cyclic, so reaching here
         // means something else (a getter, a BigInt) — reject rather than store
         // a value we could not measure.
-        return `${at}.${field} could not be serialized`;
+        return { components, error: `${at}.${field} could not be serialized` };
       }
       if (serialized !== undefined && Buffer.byteLength(serialized, 'utf8') > MAX_MIXED_FIELD_BYTES) {
-        return `${at}.${field} must be ${MAX_MIXED_FIELD_BYTES} bytes or fewer when serialized`;
+        return { components, error: `${at}.${field} must be ${MAX_MIXED_FIELD_BYTES} bytes or fewer when serialized` };
       }
     }
   }
 
-  return null;
+  return { components: normalizedComponents, error: null };
 };
 
 const RUNTIME_MAP: Record<string, string> = {
@@ -255,10 +262,11 @@ router.post('/publish', auth, async (req: any, res: any) => {
     if (!['agent', 'app', 'skill', 'bundle'].includes(kind)) {
       return res.status(400).json({ error: 'kind must be one of: agent, app, skill, bundle' });
     }
-    const componentsError = validateComponents(components);
-    if (componentsError) {
-      return res.status(400).json({ error: componentsError });
+    const componentsValidation = normalizeComponents(components);
+    if (componentsValidation.error) {
+      return res.status(400).json({ error: componentsValidation.error });
     }
+    const normalizedComponents = componentsValidation.components;
 
     const nsError = validateNamespace(installableId.toLowerCase(), username);
     if (nsError) {
@@ -298,7 +306,7 @@ router.post('/publish', auth, async (req: any, res: any) => {
       existing.version = version;
       existing.name = name;
       existing.description = description || existing.description;
-      if (components) existing.components = components;
+      if (components) existing.components = normalizedComponents;
       if (requires) existing.requires = requires;
       if (readme !== undefined) existing.readme = readme;
       if (categories || tags) {
@@ -373,7 +381,7 @@ router.post('/publish', auth, async (req: any, res: any) => {
       source: 'marketplace' as const,
       scope: scope || 'pod',
       requires: requires || [],
-      components: components || [],
+      components: normalizedComponents || [],
       readme,
       marketplace: {
         published: true,
@@ -406,7 +414,9 @@ router.post('/publish', auth, async (req: any, res: any) => {
       console.warn('[marketplace] Installable write failed (AR succeeded):', (installableError as any).message);
       return res.status(201).json({
         success: true,
-        warnings: ['Installable catalog write failed; manifest is installable but not yet browsable. Retry publish to sync.'],
+        warnings: [
+          'Installable catalog write failed; manifest is installable but not yet browsable. Retry publish to sync.',
+        ],
         manifest: {
           installableId: installableDoc.installableId,
           version,
@@ -542,10 +552,10 @@ router.post('/fork', auth, async (req: any, res: any) => {
     // /publish. Any row predating this validation is forkable too. Without
     // this check, fork is the path that launders an unvalidated component into
     // the published catalog. (@sprint-review, 58602.)
-    const sourceComponentsError = validateComponents(source.components);
-    if (sourceComponentsError) {
+    const sourceComponentsValidation = normalizeComponents(source.components);
+    if (sourceComponentsValidation.error) {
       return res.status(400).json({
-        error: `Source manifest cannot be forked: ${sourceComponentsError}`,
+        error: `Source manifest cannot be forked: ${sourceComponentsValidation.error}`,
       });
     }
 
@@ -563,7 +573,7 @@ router.post('/fork', auth, async (req: any, res: any) => {
       source: 'marketplace' as const,
       scope: source.scope,
       requires: source.requires || [],
-      components: source.components || [],
+      components: sourceComponentsValidation.components || [],
       readme: source.readme,
       marketplace: {
         published: true,

--- a/backend/routes/marketplace-api.ts
+++ b/backend/routes/marketplace-api.ts
@@ -3,6 +3,7 @@ const auth = require('../middleware/auth');
 const User = require('../models/User');
 const Installable = require('../models/Installable');
 const { AgentRegistry, AgentInstallation } = require('../models/AgentRegistry');
+const { validateMcpComponent } = require('../utils/pluginManifestParser');
 
 const router = express.Router();
 
@@ -48,13 +49,20 @@ const COMPONENT_TYPES = [
   'webhook',
   'data-schema',
   'skill',
+  'mcp-server',
 ];
 
-// The four `Schema.Types.Mixed` fields on ComponentSchema. Mixed accepts any
+// The five `Schema.Types.Mixed` fields on ComponentSchema. Mixed accepts any
 // JSON of any size, and at 50 components per manifest that is an unbounded
 // write reachable by anyone who can publish — a larger surface than the URL
 // and independent of it, so a widgetUrl allowlist alone would not touch it.
-const MIXED_COMPONENT_FIELDS = ['widgetConfigSchema', 'schemaFields', 'skillExamples', 'metadata'];
+const MIXED_COMPONENT_FIELDS = [
+  'widgetConfigSchema',
+  'schemaFields',
+  'skillExamples',
+  'variables',
+  'metadata',
+];
 const MAX_MIXED_FIELD_BYTES = 16 * 1024;
 
 const MAX_COMPONENTS = 50;
@@ -95,6 +103,14 @@ const validateComponents = (components: any) => {
       }
       if (component.description.length > 500) {
         return `${at}.description must be 500 characters or fewer`;
+      }
+    }
+
+    if (component.type === 'mcp-server') {
+      const mcpErrors = validateMcpComponent(component, at);
+      if (mcpErrors.length) {
+        const firstError = mcpErrors[0];
+        return `${firstError.field}: ${firstError.message}`;
       }
     }
 

--- a/backend/utils/agentManifestRegistry.ts
+++ b/backend/utils/agentManifestRegistry.ts
@@ -398,6 +398,10 @@ const normalizePublishPayload = (payload: any = {}) => {
 module.exports = {
   ManifestValidationError,
   normalizePublishPayload,
+  // The plugin parser lives separately so the legacy agent-manifest contract
+  // stays stable, while keeping the registry utility as the discoverable
+  // import for callers that already consume manifest helpers.
+  ...require('./pluginManifestParser'),
 };
 
 export {};

--- a/backend/utils/pluginManifestParser.ts
+++ b/backend/utils/pluginManifestParser.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { isIP } from 'net';
 import path from 'path';
 
 import type {
@@ -58,6 +59,7 @@ const VARIABLE_TYPES = new Set(['string', 'number', 'boolean']);
 const MAX_STRING_LENGTH = 2_000;
 // Keep the parser aligned with the marketplace persistence boundary.
 const MAX_COMPONENTS = 50;
+const COMMONLY_API_URL_PLACEHOLDER = '${COMMONLY_API_URL}';
 
 const isRecord = (value: unknown): value is AnyRecord => (
   value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -144,6 +146,10 @@ const normalizeRelativeSubpath = (
     return undefined;
   }
   const raw = value.trim();
+  if (raw.includes('%')) {
+    addError(details, field, 'Must not contain percent-encoded path segments');
+    return undefined;
+  }
   let decoded: string;
   try {
     decoded = decodeURIComponent(raw);
@@ -245,8 +251,11 @@ const normalizeSource = (
     // scheme-free value is a local path and must remain relative to the root.
     addError(details, `${field}.spec`, 'Local source must be a relative path inside the checkout');
     return undefined;
-  } else if (!isOwnerRepoShorthand(normalizedSpec)) {
-    canonicalSpec = path.posix.normalize(normalizedSpec).replace(/^\.\//, '');
+  } else if (isOwnerRepoShorthand(normalizedSpec)) {
+    canonicalSpec = `https://github.com/${normalizedSpec}`;
+  } else {
+    const normalizedPath = path.posix.normalize(normalizedSpec).replace(/^\.\//, '');
+    canonicalSpec = `./${normalizedPath}`;
   }
 
   const normalizedSubpath = normalizeRelativeSubpath(subpath, `${field}.subpath`, details);
@@ -288,6 +297,34 @@ const normalizeStringList = (
       seen.add(normalized);
       result.push(normalized);
     }
+  });
+  if (value.length > maxItems) addError(details, field, `Must not contain more than ${maxItems} entries`);
+  return result;
+};
+
+const normalizeArgvList = (
+  value: unknown,
+  field: string,
+  details: PluginManifestValidationDetail[],
+  maxItems = 100,
+): string[] | undefined => {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    addError(details, field, 'Must be an array of strings');
+    return undefined;
+  }
+  const result: string[] = [];
+  value.forEach((entry, index) => {
+    if (typeof entry !== 'string' || !entry.trim()) {
+      addError(details, `${field}[${index}]`, 'Must be a non-empty string');
+      return;
+    }
+    const normalized = entry.trim();
+    if (normalized.length > MAX_STRING_LENGTH) {
+      addError(details, `${field}[${index}]`, `Must not exceed ${MAX_STRING_LENGTH} characters`);
+      return;
+    }
+    result.push(normalized);
   });
   if (value.length > maxItems) addError(details, field, `Must not contain more than ${maxItems} entries`);
   return result;
@@ -355,7 +392,7 @@ const normalizeVariables = (
       addError(details, variableField, 'writeOnly variables cannot contain a literal default');
     }
     if (writeOnly === true) {
-      ['value', 'literal', 'secret', 'example'].forEach((literalKey) => {
+      ['value', 'literal', 'secret', 'example', 'examples', 'enum', 'const'].forEach((literalKey) => {
         if (own(definition, literalKey)) {
           addError(details, variableField, `writeOnly variables cannot contain literal ${literalKey}`);
         }
@@ -418,6 +455,60 @@ const rejectLiteralSecretValues = (
   });
 };
 
+const normalizeHttpUrl = (
+  value: unknown,
+  field: string,
+  details: PluginManifestValidationDetail[],
+): string | undefined => {
+  if (typeof value !== 'string' || !value.trim()) {
+    addError(details, field, 'http server url is required');
+    return undefined;
+  }
+  const url = value.trim();
+  if (url.includes('${')) {
+    // The runtime may substitute its own origin, but only when the complete
+    // origin is the placeholder. `${COMMONLY_API_URL}@evil.com` must never
+    // become an authority-bearing URL after substitution.
+    if (url.startsWith(COMMONLY_API_URL_PLACEHOLDER)
+      && (url.length === COMMONLY_API_URL_PLACEHOLDER.length
+        || url[COMMONLY_API_URL_PLACEHOLDER.length] === '/')) {
+      return url;
+    }
+    addError(details, field, 'URL placeholders must stand for the complete origin');
+    return undefined;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    addError(details, field, 'Must be a valid https URL');
+    return undefined;
+  }
+  if (parsed.protocol !== 'https:') {
+    addError(details, field, 'MCP server URL must use https');
+    return undefined;
+  }
+  if (parsed.username || parsed.password) {
+    addError(details, field, 'MCP server URL must not contain credentials');
+    return undefined;
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  const hostnameWithoutTrailingDot = hostname.replace(/\.+$/, '');
+  const ipCandidate = hostnameWithoutTrailingDot.replace(/^\[|\]$/g, '');
+  if (
+    hostname.startsWith('[')
+    || isIP(ipCandidate) !== 0
+    || hostnameWithoutTrailingDot === 'localhost'
+    || hostnameWithoutTrailingDot.endsWith('.localhost')
+    || hostnameWithoutTrailingDot.endsWith('.local')
+    || hostnameWithoutTrailingDot.endsWith('.internal')
+  ) {
+    addError(details, field, 'MCP server URL host must be a public DNS name');
+    return undefined;
+  }
+  return url;
+};
+
 const mergeMissing = (primary: unknown, secondary: unknown): unknown => {
   if (primary === undefined) return secondary;
   if (isRecord(primary) && isRecord(secondary)) {
@@ -428,19 +519,30 @@ const mergeMissing = (primary: unknown, secondary: unknown): unknown => {
     return result;
   }
   if (Array.isArray(primary) && Array.isArray(secondary)) {
-    // Claude is authoritative for duplicate entries. Cursor may fill in a
-    // server/skill omitted by Claude, but cannot replace one it defines.
-    const byName = new Map<string, AnyRecord>();
-    const unnamed: unknown[] = [];
-    [...primary, ...secondary].forEach((entry) => {
-      if (isRecord(entry) && typeof entry.name === 'string') {
-        const existing = byName.get(entry.name);
-        byName.set(entry.name, existing ? mergeMissing(existing, entry) as AnyRecord : entry);
-      } else {
-        unnamed.push(entry);
-      }
-    });
-    return [...byName.values(), ...unnamed];
+    // Arrays of named records are the one mergeable list shape: Claude keeps
+    // authority for duplicate names while Cursor can add a named entry that
+    // Claude omitted. Primitive arrays (enabledTools, argv, etc.) are kept
+    // wholesale so a secondary provider cannot widen or alter them.
+    const isNamedRecord = (entry: unknown): entry is AnyRecord => (
+      isRecord(entry) && typeof entry.name === 'string' && Boolean(entry.name.trim())
+    );
+    const canMergeByName = (entries: unknown[]) => entries.every(isNamedRecord);
+    if (canMergeByName(primary) && canMergeByName(secondary)) {
+      const result = primary.map((entry) => ({ ...entry }));
+      const indexes = new Map(result.map((entry, index) => [entry.name, index]));
+      secondary.forEach((entry) => {
+        const existingIndex = indexes.get(entry.name);
+        if (existingIndex === undefined) {
+          indexes.set(entry.name, result.length);
+          result.push({ ...entry });
+        } else {
+          result[existingIndex] = mergeMissing(result[existingIndex], entry) as AnyRecord;
+        }
+      });
+      return result;
+    }
+    // A defined Claude array is authoritative for every other array shape.
+    return primary;
   }
   return primary;
 };
@@ -557,7 +659,7 @@ const normalizeCommand = (
   details: PluginManifestValidationDetail[],
 ): string[] | undefined => {
   if (Array.isArray(value)) {
-    const command = normalizeStringList(value, field, details, 100);
+    const command = normalizeArgvList(value, field, details, 100);
     if (command && command.length === 0) addError(details, field, 'Must contain at least one argv entry');
     if (args !== undefined) {
       addError(details, `${field}.args`, 'args is not valid when command is already an argv array');
@@ -570,7 +672,7 @@ const normalizeCommand = (
   if (typeof value === 'string' && value.trim()) {
     const normalizedCommand = requiredString(value, field, details, 2_000);
     if (args === undefined) return [normalizedCommand];
-    const normalizedArgs = normalizeStringList(args, `${field}.args`, details, 99);
+    const normalizedArgs = normalizeArgvList(args, `${field}.args`, details, 99);
     return normalizedArgs ? [normalizedCommand, ...normalizedArgs] : [normalizedCommand];
   }
   addError(details, field, 'stdio server command must be an argv array');
@@ -631,16 +733,7 @@ const normalizeMcpServer = (
     if (server.command !== undefined || server.args !== undefined) {
       addError(details, `${field}.command`, 'http servers must not define command');
     }
-    if (typeof server.url !== 'string' || !server.url.trim()) {
-      addError(details, `${field}.url`, 'http server url is required');
-    } else {
-      try {
-        const parsedUrl = new URL(server.url.trim());
-        if (!['http:', 'https:'].includes(parsedUrl.protocol)) throw new Error('protocol');
-      } catch {
-        addError(details, `${field}.url`, 'Must be a valid http or https URL');
-      }
-    }
+    normalizeHttpUrl(server.url, `${field}.url`, details);
   }
 
   return {
@@ -684,10 +777,10 @@ const normalizeMcpServers = (
 export const validateMcpComponent = (
   component: unknown,
   fieldPrefix = 'component',
-): PluginManifestValidationDetail[] => {
+): { component?: IComponent; errors: PluginManifestValidationDetail[] } => {
   const details: PluginManifestValidationDetail[] = [];
-  normalizeMcpServer('', component, {}, 0, details, fieldPrefix);
-  return details;
+  const normalized = normalizeMcpServer('', component, {}, 0, details, fieldPrefix);
+  return { component: normalized, errors: details };
 };
 
 const readPluginManifests = (

--- a/backend/utils/pluginManifestParser.ts
+++ b/backend/utils/pluginManifestParser.ts
@@ -1,0 +1,792 @@
+import fs from 'fs';
+import path from 'path';
+
+import type {
+  IComponent,
+  IInstallable,
+  IMcpSource,
+  IMcpVariable,
+  InstallableKind,
+} from '../models/Installable';
+
+/** A field-level error returned when a plugin cannot be made installable. */
+export interface PluginManifestValidationDetail {
+  field: string;
+  message: string;
+}
+
+/**
+ * Parsing is deliberately a refusal boundary. In particular, malformed
+ * source targets and literal write-only values must fail before a resolver or
+ * an adapter gets a chance to read them.
+ */
+export class PluginManifestValidationError extends Error {
+  details: PluginManifestValidationDetail[];
+
+  constructor(details: PluginManifestValidationDetail[]) {
+    super(`Invalid plugin manifest: ${details.map(({ field, message }) => `${field}: ${message}`).join('; ')}`);
+    this.name = 'PluginManifestValidationError';
+    this.details = details;
+  }
+}
+
+type AnyRecord = Record<string, any>;
+type PluginRootKind = 'claude' | 'cursor';
+
+export interface ParsedPluginInstallable {
+  installableId: string;
+  name: string;
+  description: string;
+  version: string;
+  kind: InstallableKind;
+  source: 'marketplace' | 'user';
+  scope: IInstallable['scope'];
+  requires: string[];
+  components: IComponent[];
+}
+
+const PLUGIN_DIRS: Array<{ kind: PluginRootKind; directory: string }> = [
+  { kind: 'claude', directory: '.claude-plugin' },
+  { kind: 'cursor', directory: '.cursor-plugin' },
+];
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const URI_SCHEME_PATTERN = /^[a-z][a-z\d+.-]*:/i;
+const OWNER_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const INSTALLABLE_ID_PATTERN = /^(@[a-z0-9-]+\/)?[a-z0-9-]+$/;
+const VARIABLE_TYPES = new Set(['string', 'number', 'boolean']);
+const MAX_STRING_LENGTH = 2_000;
+// Keep the parser aligned with the marketplace persistence boundary.
+const MAX_COMPONENTS = 50;
+
+const isRecord = (value: unknown): value is AnyRecord => (
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+);
+
+const isOwnerRepoShorthand = (value: string): boolean => {
+  if (!OWNER_REPO_PATTERN.test(value)) return false;
+  const [owner, repository] = value.split('/');
+  return owner !== '.' && owner !== '..' && repository !== '.' && repository !== '..';
+};
+
+const hasTraversalSegment = (value: string): boolean => {
+  try {
+    return decodeURIComponent(value).split('/').includes('..');
+  } catch {
+    return true;
+  }
+};
+
+const own = (value: AnyRecord, key: string): boolean => (
+  Object.prototype.hasOwnProperty.call(value, key)
+);
+
+const addError = (
+  details: PluginManifestValidationDetail[],
+  field: string,
+  message: string,
+) => details.push({ field, message });
+
+const requiredString = (
+  value: unknown,
+  field: string,
+  details: PluginManifestValidationDetail[],
+  maxLength = MAX_STRING_LENGTH,
+): string => {
+  if (typeof value !== 'string' || !value.trim()) {
+    addError(details, field, 'Must be a non-empty string');
+    return '';
+  }
+  const normalized = value.trim();
+  if (normalized.length > maxLength) {
+    addError(details, field, `Must not exceed ${maxLength} characters`);
+    return normalized.slice(0, maxLength);
+  }
+  return normalized;
+};
+
+const optionalString = (
+  value: unknown,
+  field: string,
+  details: PluginManifestValidationDetail[],
+  maxLength = MAX_STRING_LENGTH,
+): string | undefined => {
+  if (value === undefined) return undefined;
+  return requiredString(value, field, details, maxLength);
+};
+
+const normalizeId = (
+  name: string,
+  details: PluginManifestValidationDetail[],
+): string => {
+  const trimmed = name.trim();
+  const candidate = trimmed
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9@/_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .toLowerCase();
+  if (!candidate || !INSTALLABLE_ID_PATTERN.test(candidate)) {
+    addError(details, 'manifest.name', 'Must produce a valid installable id');
+    return '';
+  }
+  return candidate;
+};
+
+const normalizeRelativeSubpath = (
+  value: unknown,
+  field: string,
+  details: PluginManifestValidationDetail[],
+): string | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !value.trim()) {
+    addError(details, field, 'Must be a relative checkout path');
+    return undefined;
+  }
+  const raw = value.trim();
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    addError(details, field, 'Must be valid URL/path encoding');
+    return undefined;
+  }
+  // Treat backslashes as separators for validation even on POSIX. Otherwise
+  // a manifest authored on Windows could smuggle a traversal into a Linux
+  // install or vice versa.
+  if (
+    decoded.includes('\\')
+    || decoded.includes('\0')
+    || path.posix.isAbsolute(decoded)
+    || path.win32.isAbsolute(decoded)
+  ) {
+    addError(details, field, 'Must be a relative path inside the checkout');
+    return undefined;
+  }
+  const segments = decoded.split('/');
+  if (segments.includes('..')) {
+    addError(details, field, 'Must not contain .. path segments');
+    return undefined;
+  }
+  const normalized = path.posix.normalize(decoded).replace(/^\.\//, '');
+  if (normalized === '.' || normalized === '') return undefined;
+  if (normalized === '..' || normalized.startsWith('../')) {
+    addError(details, field, 'Must stay inside the checkout');
+    return undefined;
+  }
+  return normalized;
+};
+
+const normalizeSource = (
+  value: unknown,
+  field: string,
+  details: PluginManifestValidationDetail[],
+): IMcpSource | undefined => {
+  let spec: unknown = value;
+  let subpath: unknown;
+  let pin: unknown;
+
+  if (isRecord(value)) {
+    spec = value.spec;
+    subpath = value.subpath;
+    pin = value.pin;
+  }
+
+  if (typeof spec !== 'string' || !spec.trim()) {
+    addError(details, `${field}.spec`, 'Must be a non-empty source specification');
+    return undefined;
+  }
+  const normalizedSpec = spec.trim();
+  let canonicalSpec = normalizedSpec;
+
+  if (URI_SCHEME_PATTERN.test(normalizedSpec)) {
+    let parsed: URL;
+    try {
+      parsed = new URL(normalizedSpec);
+    } catch {
+      addError(details, `${field}.spec`, 'Must be a valid source URL');
+      return undefined;
+    }
+    if (
+      parsed.protocol !== 'https:'
+      || parsed.hostname.toLowerCase() !== 'github.com'
+      || parsed.username
+      || parsed.password
+      || parsed.port
+      || parsed.search
+      || parsed.hash
+    ) {
+      addError(details, `${field}.spec`, 'Only https://github.com source URLs are allowed');
+      return undefined;
+    }
+    const repositoryPath = parsed.pathname.replace(/^\//, '').replace(/\/$/, '');
+    if (!/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)(?:\.git)?$/.test(repositoryPath)) {
+      addError(details, `${field}.spec`, 'GitHub source URL must identify exactly one repository');
+      return undefined;
+    }
+    canonicalSpec = `https://github.com/${repositoryPath}`;
+  } else if (normalizedSpec.includes(':')) {
+    // A colon that was not parsed as an allowed URL is generally a URI scheme
+    // (file:, ssh:, git:, etc.), not a local path we should interpret.
+    addError(details, `${field}.spec`, 'Only https://github.com source URLs or local paths are allowed');
+    return undefined;
+  } else if (
+    !isOwnerRepoShorthand(normalizedSpec)
+    && (
+      path.posix.isAbsolute(normalizedSpec)
+      || path.win32.isAbsolute(normalizedSpec)
+      || normalizedSpec.includes('\\')
+      || normalizedSpec.split('/').includes('..')
+      || hasTraversalSegment(normalizedSpec)
+      || normalizedSpec.includes('\0')
+    )
+  ) {
+    // GitHub owner/repo shorthand is already a valid source. Every other
+    // scheme-free value is a local path and must remain relative to the root.
+    addError(details, `${field}.spec`, 'Local source must be a relative path inside the checkout');
+    return undefined;
+  } else if (!isOwnerRepoShorthand(normalizedSpec)) {
+    canonicalSpec = path.posix.normalize(normalizedSpec).replace(/^\.\//, '');
+  }
+
+  const normalizedSubpath = normalizeRelativeSubpath(subpath, `${field}.subpath`, details);
+  if (pin !== undefined && (typeof pin !== 'string' || !SHA_PATTERN.test(pin))) {
+    addError(details, `${field}.pin`, 'Must be a 40-character commit SHA');
+  }
+
+  return {
+    spec: canonicalSpec,
+    ...(normalizedSubpath ? { subpath: normalizedSubpath } : {}),
+    ...(pin !== undefined && typeof pin === 'string' && SHA_PATTERN.test(pin) ? { pin } : {}),
+  };
+};
+
+const normalizeStringList = (
+  value: unknown,
+  field: string,
+  details: PluginManifestValidationDetail[],
+  maxItems = 100,
+): string[] | undefined => {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    addError(details, field, 'Must be an array of strings');
+    return undefined;
+  }
+  const result: string[] = [];
+  const seen = new Set<string>();
+  value.forEach((entry, index) => {
+    if (typeof entry !== 'string' || !entry.trim()) {
+      addError(details, `${field}[${index}]`, 'Must be a non-empty string');
+      return;
+    }
+    const normalized = entry.trim();
+    if (normalized.length > MAX_STRING_LENGTH) {
+      addError(details, `${field}[${index}]`, `Must not exceed ${MAX_STRING_LENGTH} characters`);
+      return;
+    }
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  });
+  if (value.length > maxItems) addError(details, field, `Must not contain more than ${maxItems} entries`);
+  return result;
+};
+
+const normalizeDefault = (
+  value: unknown,
+  field: string,
+  type: string,
+  details: PluginManifestValidationDetail[],
+): string | number | boolean | undefined => {
+  if (type === 'string') {
+    if (typeof value !== 'string') {
+      addError(details, field, 'Must match variable type string');
+      return undefined;
+    }
+    return value;
+  }
+  if (type === 'number') {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      addError(details, field, 'Must match variable type number');
+      return undefined;
+    }
+    return value;
+  }
+  if (typeof value !== 'boolean') {
+    addError(details, field, 'Must match variable type boolean');
+    return undefined;
+  }
+  return value;
+};
+
+const normalizeVariables = (
+  value: unknown,
+  field: string,
+  details: PluginManifestValidationDetail[],
+): Record<string, IMcpVariable> | undefined => {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    addError(details, field, 'Must be an object keyed by variable name');
+    return undefined;
+  }
+
+  const variables: Record<string, IMcpVariable> = {};
+  Object.entries(value).forEach(([name, definition]) => {
+    const variableField = `${field}.${name}`;
+    if (!/^[A-Za-z][A-Za-z0-9_.-]{0,127}$/.test(name)) {
+      addError(details, variableField, 'Variable name is invalid');
+      return;
+    }
+    if (!isRecord(definition)) {
+      addError(details, variableField, 'Must be a JSON Schema variable object');
+      return;
+    }
+    const type = requiredString(definition.type, `${variableField}.type`, details, 20);
+    if (!VARIABLE_TYPES.has(type)) {
+      addError(details, `${variableField}.type`, 'Must be string, number, or boolean');
+      return;
+    }
+    const writeOnly = definition.writeOnly;
+    if (writeOnly !== undefined && typeof writeOnly !== 'boolean') {
+      addError(details, `${variableField}.writeOnly`, 'Must be a boolean');
+    }
+    if (writeOnly === true && own(definition, 'default')) {
+      addError(details, variableField, 'writeOnly variables cannot contain a literal default');
+    }
+    if (writeOnly === true) {
+      ['value', 'literal', 'secret', 'example'].forEach((literalKey) => {
+        if (own(definition, literalKey)) {
+          addError(details, variableField, `writeOnly variables cannot contain literal ${literalKey}`);
+        }
+      });
+    }
+    const description = optionalString(definition.description, `${variableField}.description`, details);
+    let defaultValue: string | number | boolean | undefined;
+    if (own(definition, 'default') && writeOnly !== true) {
+      defaultValue = normalizeDefault(definition.default, `${variableField}.default`, type, details);
+    }
+
+    let enumValues: Array<string | number> | undefined;
+    if (definition.enum !== undefined) {
+      if (!Array.isArray(definition.enum)) {
+        addError(details, `${variableField}.enum`, 'Must be an array of strings or numbers');
+      } else {
+        enumValues = [];
+        definition.enum.forEach((entry: unknown, index: number) => {
+          const invalidType = typeof entry !== 'string' && typeof entry !== 'number';
+          const invalidNumber = typeof entry === 'number' && !Number.isFinite(entry);
+          if (invalidType || invalidNumber) {
+            addError(details, `${variableField}.enum[${index}]`, 'Must be a string or number');
+          } else if (!enumValues!.includes(entry)) {
+            enumValues!.push(entry);
+          }
+        });
+      }
+    }
+
+    variables[name] = {
+      type: type as IMcpVariable['type'],
+      ...(description ? { description } : {}),
+      ...(defaultValue !== undefined ? { default: defaultValue } : {}),
+      ...(enumValues ? { enum: enumValues } : {}),
+      ...(writeOnly === true ? { writeOnly: true } : {}),
+    };
+  });
+  return variables;
+};
+
+const rejectLiteralSecretValues = (
+  server: AnyRecord,
+  variables: Record<string, IMcpVariable> | undefined,
+  field: string,
+  details: PluginManifestValidationDetail[],
+) => {
+  if (!variables) return;
+  const env = server.env ?? server.values ?? server.config;
+  if (!isRecord(env)) return;
+  Object.entries(variables).forEach(([name, definition]) => {
+    if (!definition.writeOnly || !own(env, name)) return;
+    const value = env[name];
+    const isSecretReference = isRecord(value)
+      && typeof value.secretRef === 'string'
+      && value.secretRef.trim().length > 0;
+    const isPlaceholder = typeof value === 'string' && /^\$\{COMMONLY_[A-Z0-9_.-]+\}$/.test(value);
+    if (!isSecretReference && !isPlaceholder) {
+      addError(details, `${field}.${name}`, 'writeOnly variable must use a secret reference, not a literal');
+    }
+  });
+};
+
+const mergeMissing = (primary: unknown, secondary: unknown): unknown => {
+  if (primary === undefined) return secondary;
+  if (isRecord(primary) && isRecord(secondary)) {
+    const result: AnyRecord = { ...primary };
+    Object.entries(secondary).forEach(([key, value]) => {
+      result[key] = mergeMissing(result[key], value);
+    });
+    return result;
+  }
+  if (Array.isArray(primary) && Array.isArray(secondary)) {
+    // Claude is authoritative for duplicate entries. Cursor may fill in a
+    // server/skill omitted by Claude, but cannot replace one it defines.
+    const byName = new Map<string, AnyRecord>();
+    const unnamed: unknown[] = [];
+    [...primary, ...secondary].forEach((entry) => {
+      if (isRecord(entry) && typeof entry.name === 'string') {
+        const existing = byName.get(entry.name);
+        byName.set(entry.name, existing ? mergeMissing(existing, entry) as AnyRecord : entry);
+      } else {
+        unnamed.push(entry);
+      }
+    });
+    return [...byName.values(), ...unnamed];
+  }
+  return primary;
+};
+
+const readJson = (
+  filePath: string,
+  field: string,
+  details: PluginManifestValidationDetail[],
+): AnyRecord | undefined => {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) {
+      addError(details, field, 'Must contain a JSON object');
+      return undefined;
+    }
+    return parsed;
+  } catch {
+    addError(details, field, 'Must be valid JSON');
+    return undefined;
+  }
+};
+
+const safeRelativePath = (
+  rootPath: string,
+  candidate: string,
+  field: string,
+  details: PluginManifestValidationDetail[],
+): string | undefined => {
+  const rootReal = fs.realpathSync(rootPath);
+  const target = path.resolve(rootPath, candidate);
+  const targetRelative = path.relative(rootPath, target);
+  if (targetRelative.startsWith('..') || path.isAbsolute(targetRelative)) {
+    addError(details, field, 'Path must stay inside the plugin root');
+    return undefined;
+  }
+  try {
+    const targetReal = fs.realpathSync(target);
+    const relativeReal = path.relative(rootReal, targetReal);
+    if (relativeReal.startsWith('..') || path.isAbsolute(relativeReal)) {
+      addError(details, field, 'Path must stay inside the plugin root');
+      return undefined;
+    }
+  } catch {
+    addError(details, field, 'Path does not exist inside the plugin root');
+    return undefined;
+  }
+  return target;
+};
+
+const normalizeSkill = (
+  rootPath: string,
+  rawSkill: unknown,
+  index: number,
+  details: PluginManifestValidationDetail[],
+): IComponent | undefined => {
+  const field = `manifest.skills[${index}]`;
+  const definition = typeof rawSkill === 'string' ? { path: rawSkill } : rawSkill;
+  if (!isRecord(definition)) {
+    addError(details, field, 'Must be a skill path or object');
+    return undefined;
+  }
+  const skillPath = typeof definition.path === 'string' ? definition.path : undefined;
+  const safePath = skillPath ? normalizeRelativeSubpath(skillPath, `${field}.path`, details) : undefined;
+  let prompt = optionalString(
+    definition.prompt ?? definition.skillPrompt ?? definition.content,
+    `${field}.prompt`,
+    details,
+    100_000,
+  );
+  if (safePath) {
+    const skillDirectory = safeRelativePath(rootPath, safePath, `${field}.path`, details);
+    if (skillDirectory && fs.statSync(skillDirectory).isDirectory()) {
+      const skillFile = path.join(skillDirectory, 'SKILL.md');
+      if (fs.existsSync(skillFile) && prompt === undefined) {
+        const safeSkillFile = safeRelativePath(
+          rootPath,
+          path.join(safePath, 'SKILL.md'),
+          `${field}.path`,
+          details,
+        );
+        if (safeSkillFile) prompt = fs.readFileSync(safeSkillFile, 'utf8');
+      }
+    } else if (skillDirectory && fs.statSync(skillDirectory).isFile() && prompt === undefined) {
+      prompt = fs.readFileSync(skillDirectory, 'utf8');
+    }
+  }
+  const name = requiredString(
+    definition.name ?? (safePath ? path.basename(safePath) : undefined),
+    `${field}.name`,
+    details,
+    200,
+  );
+  const skillId = normalizeId(name, details);
+  const tools = normalizeStringList(definition.tools ?? definition.skillTools, `${field}.tools`, details);
+  const description = optionalString(definition.description, `${field}.description`, details, 2_000);
+  const skillPrompt = requiredString(prompt, `${field}.prompt`, details, 100_000);
+  const examples = definition.examples ?? definition.skillExamples;
+  return {
+    name: skillId || name,
+    type: 'skill',
+    ...(description ? { description } : {}),
+    skillId: skillId || name,
+    skillPrompt,
+    ...(tools ? { skillTools: tools } : {}),
+    ...(examples !== undefined ? { skillExamples: examples } : {}),
+  };
+};
+
+const normalizeCommand = (
+  value: unknown,
+  args: unknown,
+  field: string,
+  details: PluginManifestValidationDetail[],
+): string[] | undefined => {
+  if (Array.isArray(value)) {
+    const command = normalizeStringList(value, field, details, 100);
+    if (command && command.length === 0) addError(details, field, 'Must contain at least one argv entry');
+    if (args !== undefined) {
+      addError(details, `${field}.args`, 'args is not valid when command is already an argv array');
+    }
+    return command;
+  }
+  // The public component shape is argv[], but accepting the common manifest
+  // `{ command: "npx", args: [...] }` form makes the parser interoperable
+  // without leaking that provider-specific shape into Installable.
+  if (typeof value === 'string' && value.trim()) {
+    const normalizedCommand = requiredString(value, field, details, 2_000);
+    if (args === undefined) return [normalizedCommand];
+    const normalizedArgs = normalizeStringList(args, `${field}.args`, details, 99);
+    return normalizedArgs ? [normalizedCommand, ...normalizedArgs] : [normalizedCommand];
+  }
+  addError(details, field, 'stdio server command must be an argv array');
+  return undefined;
+};
+
+const normalizeMcpServer = (
+  serverName: string,
+  server: unknown,
+  manifest: AnyRecord,
+  index: number,
+  details: PluginManifestValidationDetail[],
+  fieldPrefix = 'manifest.mcpServers',
+): IComponent | undefined => {
+  const field = fieldPrefix === 'manifest.mcpServers'
+    ? `${fieldPrefix}.${serverName || index}`
+    : fieldPrefix;
+  if (!isRecord(server)) {
+    addError(details, field, 'Must be an object');
+    return undefined;
+  }
+  const name = requiredString(server.name ?? serverName, `${field}.name`, details, 200);
+  const transport = server.transport
+    ?? (server.command !== undefined ? 'stdio' : server.url !== undefined ? 'http' : undefined);
+  if (transport !== 'stdio' && transport !== 'http') {
+    addError(details, `${field}.transport`, 'Must be stdio or http');
+  }
+  const sourceValue = server.source !== undefined ? server.source : manifest.source;
+  const sourceInput = isRecord(sourceValue)
+    ? {
+      ...sourceValue,
+      subpath: sourceValue.subpath ?? server.subpath ?? manifest.subpath,
+      pin: sourceValue.pin ?? server.pin ?? manifest.pin,
+    }
+    : {
+      spec: sourceValue,
+      subpath: server.subpath ?? manifest.subpath,
+      pin: server.pin ?? manifest.pin,
+    };
+  const source = normalizeSource(sourceInput, `${field}.source`, details);
+  const variables = normalizeVariables(
+    server.variables !== undefined ? server.variables : manifest.variables,
+    `${field}.variables`,
+    details,
+  );
+  rejectLiteralSecretValues(server, variables, `${field}.env`, details);
+  const enabledTools = normalizeStringList(
+    server.enabledTools !== undefined ? server.enabledTools : manifest.enabledTools,
+    `${field}.enabledTools`,
+    details,
+  );
+
+  let command: string[] | undefined;
+  if (transport === 'stdio') {
+    command = normalizeCommand(server.command, server.args, `${field}.command`, details);
+    if (server.url !== undefined) addError(details, `${field}.url`, 'stdio servers must not define url');
+  } else if (transport === 'http') {
+    if (server.command !== undefined || server.args !== undefined) {
+      addError(details, `${field}.command`, 'http servers must not define command');
+    }
+    if (typeof server.url !== 'string' || !server.url.trim()) {
+      addError(details, `${field}.url`, 'http server url is required');
+    } else {
+      try {
+        const parsedUrl = new URL(server.url.trim());
+        if (!['http:', 'https:'].includes(parsedUrl.protocol)) throw new Error('protocol');
+      } catch {
+        addError(details, `${field}.url`, 'Must be a valid http or https URL');
+      }
+    }
+  }
+
+  return {
+    name,
+    type: 'mcp-server',
+    transport: transport as 'stdio' | 'http',
+    ...(source ? { source } : {}),
+    ...(command ? { command } : {}),
+    ...(transport === 'http' && typeof server.url === 'string' ? { url: server.url.trim() } : {}),
+    ...(variables ? { variables } : {}),
+    ...(enabledTools ? { enabledTools } : {}),
+    ...(typeof server.description === 'string' && server.description.trim()
+      ? { description: server.description.trim() }
+      : {}),
+  };
+};
+
+const normalizeMcpServers = (
+  value: unknown,
+  manifest: AnyRecord,
+  details: PluginManifestValidationDetail[],
+): IComponent[] => {
+  if (value === undefined) return [];
+  const entries: Array<[string, unknown]> = Array.isArray(value)
+    ? value.map((entry) => [isRecord(entry) && typeof entry.name === 'string' ? entry.name : '', entry])
+    : isRecord(value) ? Object.entries(value) : [];
+  if (!Array.isArray(value) && !isRecord(value)) {
+    addError(details, 'manifest.mcpServers', 'Must be an object or array');
+    return [];
+  }
+  if (entries.length > MAX_COMPONENTS) {
+    addError(details, 'manifest.mcpServers', `Must not contain more than ${MAX_COMPONENTS} entries`);
+  }
+  return entries
+    .slice(0, MAX_COMPONENTS)
+    .map(([name, server], index) => normalizeMcpServer(name, server, manifest, index, details))
+    .filter((component): component is IComponent => component !== undefined);
+};
+
+/** Validate one already-decoded MCP component at an API persistence boundary. */
+export const validateMcpComponent = (
+  component: unknown,
+  fieldPrefix = 'component',
+): PluginManifestValidationDetail[] => {
+  const details: PluginManifestValidationDetail[] = [];
+  normalizeMcpServer('', component, {}, 0, details, fieldPrefix);
+  return details;
+};
+
+const readPluginManifests = (
+  rootPath: string,
+  details: PluginManifestValidationDetail[],
+): { manifest: AnyRecord; kinds: PluginRootKind[] } => {
+  const manifests: Array<{ kind: PluginRootKind; manifest: AnyRecord }> = [];
+  PLUGIN_DIRS.forEach(({ kind, directory }) => {
+    const relativeManifestPath = path.join(directory, 'plugin.json');
+    const manifestPath = path.join(rootPath, relativeManifestPath);
+    if (!fs.existsSync(manifestPath)) return;
+    const safeManifestPath = safeRelativePath(
+      rootPath,
+      relativeManifestPath,
+      `${directory}/plugin.json`,
+      details,
+    );
+    if (!safeManifestPath) return;
+    const parsed = readJson(safeManifestPath, `${directory}/plugin.json`, details);
+    if (parsed) manifests.push({ kind, manifest: parsed });
+  });
+  if (!manifests.length) {
+    addError(details, 'root', 'Expected .claude-plugin/plugin.json or .cursor-plugin/plugin.json');
+    return { manifest: {}, kinds: [] };
+  }
+  const primary = manifests.find(({ kind }) => kind === 'claude') ?? manifests[0];
+  const secondary = manifests.find(({ kind }) => kind !== primary.kind);
+  return {
+    manifest: secondary ? mergeMissing(primary.manifest, secondary.manifest) as AnyRecord : primary.manifest,
+    kinds: manifests.map(({ kind }) => kind),
+  };
+};
+
+/**
+ * Parse a local Claude/Cursor plugin root into an Installable-shaped object.
+ * This first cut never fetches a source; it only validates source metadata and
+ * reads files below the supplied local root.
+ */
+export const parsePluginManifest = (
+  root: string,
+  options: { source?: 'marketplace' | 'user'; scope?: IInstallable['scope'] } = {},
+): ParsedPluginInstallable => {
+  const details: PluginManifestValidationDetail[] = [];
+  if (typeof root !== 'string' || !root.trim()) {
+    throw new PluginManifestValidationError([{ field: 'root', message: 'Plugin root is required' }]);
+  }
+  let rootPath: string;
+  try {
+    rootPath = fs.realpathSync(path.resolve(root));
+    if (!fs.statSync(rootPath).isDirectory()) throw new Error('not directory');
+  } catch {
+    throw new PluginManifestValidationError([{ field: 'root', message: 'Plugin root must be an existing directory' }]);
+  }
+
+  const loaded = readPluginManifests(rootPath, details);
+  const manifest = loaded.manifest;
+  const name = requiredString(manifest.name, 'manifest.name', details, 200);
+  const installableId = normalizeId(name, details);
+  const description = typeof manifest.description === 'string' ? manifest.description.trim() : '';
+  const version = requiredString(manifest.version, 'manifest.version', details, 100);
+
+  const components = normalizeMcpServers(manifest.mcpServers, manifest, details);
+  const rawSkills = manifest.skills;
+  if (rawSkills !== undefined) {
+    if (!Array.isArray(rawSkills)) {
+      addError(details, 'manifest.skills', 'Must be an array');
+    } else {
+      rawSkills.slice(0, MAX_COMPONENTS - components.length).forEach((skill, index) => {
+        const component = normalizeSkill(rootPath, skill, index, details);
+        if (component) components.push(component);
+      });
+      if (rawSkills.length > MAX_COMPONENTS) {
+        addError(details, 'manifest.skills', `Must not contain more than ${MAX_COMPONENTS} entries`);
+      }
+    }
+  }
+  if (components.length > MAX_COMPONENTS) {
+    addError(details, 'manifest.components', `Must not contain more than ${MAX_COMPONENTS} entries`);
+  }
+  if (details.length) throw new PluginManifestValidationError(details);
+
+  const kind: InstallableKind = components.length > 0 && components.every(({ type }) => type === 'skill')
+    ? 'skill'
+    : 'app';
+  return {
+    installableId,
+    name,
+    description,
+    version,
+    kind,
+    source: options.source ?? 'user',
+    scope: options.scope ?? 'user',
+    requires: [],
+    components,
+  };
+};
+
+// Names used by callers that describe the input as a root rather than a file.
+export const parsePluginRoot = parsePluginManifest;
+export const parsePluginInstallable = parsePluginManifest;
+
+export default parsePluginManifest;


### PR DESCRIPTION
Implements the parser cut sequenced in ADR-001 amendment PR #1658.

- Adds `mcp-server` component fields/schema to Installable.
- Parses `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` (Claude wins, Cursor fills missing fields).
- Projects MCP servers and local skills into an Installable.
- Validates source scheme/host, traversal-safe subpaths, and 40-character pins before any fetch path.
- Rejects literal writeOnly defaults/env values and retains only schema/secret references.
- Adds focused fixtures/tests for the named contract.

Tests: `npm test -- --runInBand __tests__/unit/utils/pluginManifestParser.test.ts`
Typecheck: `npm run tsc:check`

Builds against #1658 §1/§2; fetch/SHA resolution remains the second cut.