### PR TITLE
feat(connectors): add room grant record

### DIFF
--- a/backend/__tests__/unit/services/roomGrantService.test.js
+++ b/backend/__tests__/unit/services/roomGrantService.test.js
@@ -11,7 +11,7 @@ const baseGrant = (overrides = {}) => ({
   target: { kind: 'pod', id: 'pod-1' },
   tools: ['issues.read', 'issues.comment'],
   writeMode: 'write-with-confirm',
-  budget: { calls: 10, windowMs: 60_000 },
+  budget: { calls: 10, windowMs: 60000 },
   audience: ['agent-a', 'agent-b'],
   expiresAt: new Date(Date.now() + 60 * 60 * 1000),
   brokerId: 'broker-1',
@@ -51,6 +51,30 @@ describe('RoomGrant', () => {
     expect(child.writeMode).toBe('read');
   });
 
+  it('attenuates budget by call rate, not by window length alone', async () => {
+    const parent = await service.mintGrant(baseGrant({ grantId: 'root-budget' }));
+    await expect(service.attenuateGrant({
+      parentGrantId: parent.grantId,
+      budget: { calls: 10, windowMs: 1 },
+    })).rejects.toMatchObject({ code: 'grant_not_attenuated' });
+    const child = await service.attenuateGrant({
+      parentGrantId: parent.grantId,
+      budget: { calls: 10, windowMs: 600000 },
+    });
+    expect(child.budget).toMatchObject({ calls: 10, windowMs: 600000 });
+  });
+
+  it('does not turn a lifetime calls cap into a repeating windowed cap', async () => {
+    const parent = await service.mintGrant(baseGrant({
+      grantId: 'lifetime-budget',
+      budget: { calls: 10 },
+    }));
+    await expect(service.attenuateGrant({
+      parentGrantId: parent.grantId,
+      budget: { windowMs: 1 },
+    })).rejects.toMatchObject({ code: 'grant_not_attenuated' });
+  });
+
   it('caps child expiry at parent expiry', async () => {
     const expiry = new Date(Date.now() + 5 * 60 * 1000);
     const parent = await service.mintGrant(baseGrant({ grantId: 'root-expiry', expiresAt: expiry }));
@@ -70,6 +94,32 @@ describe('RoomGrant', () => {
   it('audience is snapshot ∩ current members', () => {
     expect(service.effectiveAudience({ audience: ['agent-a', 'agent-b'] }, ['agent-b', 'agent-c']))
       .toEqual(['agent-b']);
+  });
+
+  it('refuses an audience check without current membership context', async () => {
+    const grant = await service.mintGrant(baseGrant({ grantId: 'audience-context' }));
+    await expect(service.assertGrantUsable({ grant, agentUserId: 'agent-a' }))
+      .rejects.toMatchObject({ code: 'audience_context_required' });
+  });
+
+  it('refuses grant use without an agent identity', async () => {
+    const grant = await service.mintGrant(baseGrant({ grantId: 'agent-context' }));
+    await expect(service.assertGrantUsable({ grant, currentMemberIds: ['agent-a'] }))
+      .rejects.toMatchObject({ code: 'agent_identity_required' });
+  });
+
+  it('does not mint or use descendants after an ancestor is revoked', async () => {
+    const root = await service.mintGrant(baseGrant({ grantId: 'lineage-root' }));
+    const child = await service.attenuateGrant({ parentGrantId: root.grantId });
+    await RoomGrant.updateOne({ grantId: root.grantId }, { $set: { revokedAt: new Date() } });
+    await expect(service.mintGrant({
+      ...baseGrant({ target: root.target }),
+      parentGrantId: root.grantId,
+    })).rejects.toMatchObject({ code: 'grant_revoked' });
+    await expect(service.assertGrantUsable({ grant: child, agentUserId: 'agent-a', currentMemberIds: ['agent-a'] }))
+      .rejects.toMatchObject({ code: 'grant_revoked' });
+    await expect(service.attenuateGrant({ parentGrantId: child.grantId }))
+      .rejects.toMatchObject({ code: 'grant_revoked' });
   });
 
   it('revoking the root revokes every descendant', async () => {

--- a/backend/__tests__/unit/services/roomGrantService.test.js
+++ b/backend/__tests__/unit/services/roomGrantService.test.js
@@ -1,0 +1,85 @@
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+
+let mongod;
+let RoomGrant;
+let service;
+
+const baseGrant = (overrides = {}) => ({
+  connectionId: 'connection-1',
+  installationId: 'install-1',
+  target: { kind: 'pod', id: 'pod-1' },
+  tools: ['issues.read', 'issues.comment'],
+  writeMode: 'write-with-confirm',
+  budget: { calls: 10, windowMs: 60_000 },
+  audience: ['agent-a', 'agent-b'],
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  brokerId: 'broker-1',
+  ...overrides,
+});
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  RoomGrant = require('../../../models/RoomGrant');
+  service = require('../../../services/roomGrantService');
+});
+
+afterEach(async () => {
+  await RoomGrant.deleteMany({});
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+describe('RoomGrant', () => {
+  it('mints a child only with tools ⊆ parent', async () => {
+    const parent = await service.mintGrant(baseGrant({ grantId: 'root-tools' }));
+    await expect(service.attenuateGrant({ parentGrantId: parent.grantId, tools: ['issues.delete'] }))
+      .rejects.toMatchObject({ code: 'grant_not_attenuated' });
+    const child = await service.attenuateGrant({ parentGrantId: parent.grantId, tools: ['issues.read'] });
+    expect(child.tools).toEqual(['issues.read']);
+  });
+
+  it('mints a child only with writeMode no stronger than parent', async () => {
+    const parent = await service.mintGrant(baseGrant({ grantId: 'root-mode', writeMode: 'write-with-confirm' }));
+    await expect(service.attenuateGrant({ parentGrantId: parent.grantId, writeMode: 'write' }))
+      .rejects.toMatchObject({ code: 'grant_not_attenuated' });
+    const child = await service.attenuateGrant({ parentGrantId: parent.grantId, writeMode: 'read' });
+    expect(child.writeMode).toBe('read');
+  });
+
+  it('caps child expiry at parent expiry', async () => {
+    const expiry = new Date(Date.now() + 5 * 60 * 1000);
+    const parent = await service.mintGrant(baseGrant({ grantId: 'root-expiry', expiresAt: expiry }));
+    const child = await service.attenuateGrant({
+      parentGrantId: parent.grantId,
+      expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+    });
+    expect(child.expiresAt.getTime()).toBe(expiry.getTime());
+  });
+
+  it("refuses a grant without expiresAt", async () => {
+    const input = baseGrant({ grantId: 'no-expiry' });
+    delete input.expiresAt;
+    await expect(service.mintGrant(input)).rejects.toThrow(/expiresAt/);
+  });
+
+  it('audience is snapshot ∩ current members', () => {
+    expect(service.effectiveAudience({ audience: ['agent-a', 'agent-b'] }, ['agent-b', 'agent-c']))
+      .toEqual(['agent-b']);
+  });
+
+  it('revoking the root revokes every descendant', async () => {
+    const root = await service.mintGrant(baseGrant({ grantId: 'root-revoke' }));
+    const child = await service.attenuateGrant({ parentGrantId: root.grantId, grantId: 'ignored-child' });
+    const grandchild = await service.attenuateGrant({ parentGrantId: child.grantId });
+    await service.revokeGrant(root.grantId);
+    for (const grant of [root, child, grandchild]) {
+      await expect(service.assertGrantUsable({ grantId: grant.grantId }))
+        .rejects.toMatchObject({ code: 'grant_revoked' });
+    }
+  });
+});

--- a/backend/models/RoomGrant.ts
+++ b/backend/models/RoomGrant.ts
@@ -1,0 +1,138 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+
+/**
+ * A grant of one user's connection to a pod or seat.
+ *
+ * The credential itself never lives here. `connectionId` points at the
+ * connection that owns it and `brokerId` names the proxy that is allowed to
+ * use it. Agents receive only the grant's capabilities; the broker is the
+ * only component that can resolve the connection material.
+ */
+export type RoomGrantTargetKind = 'pod' | 'seat';
+export type RoomGrantWriteMode = 'read' | 'write' | 'write-with-confirm';
+
+export interface IRoomGrantBudget {
+  calls?: number;
+  windowMs?: number;
+}
+
+export interface IRoomGrantTarget {
+  kind: RoomGrantTargetKind;
+  id: string;
+}
+
+export interface IRoomGrant extends Document {
+  grantId: string;
+  connectionId: string;
+  installationId: string;
+  target: IRoomGrantTarget;
+  tools: string[];
+  writeMode: RoomGrantWriteMode;
+  budget?: IRoomGrantBudget;
+  /** Snapshot at mint time. Effective audience is this list ∩ current members. */
+  audience: string[];
+  expiresAt: Date;
+  revokedAt?: Date | null;
+  parentGrantId?: string | null;
+  /** Required proxy identifier; an agent must never receive connection material. */
+  brokerId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface RoomGrantModel extends Model<IRoomGrant> {
+  /** Revoke a grant and all descendants with one updateMany write. */
+  revokeCascade(grantId: string): Promise<number>;
+}
+
+const GrantBudgetSchema = new Schema<IRoomGrantBudget>(
+  {
+    calls: { type: Number, min: 0 },
+    windowMs: { type: Number, min: 1 },
+  },
+  { _id: false },
+);
+
+const GrantTargetSchema = new Schema<IRoomGrantTarget>(
+  {
+    kind: { type: String, enum: ['pod', 'seat'], required: true },
+    id: { type: String, required: true, trim: true },
+  },
+  { _id: false },
+);
+
+const RoomGrantSchema = new Schema<IRoomGrant>(
+  {
+    // `grantId` is the public, opaque identifier used by the MCP endpoint;
+    // Mongo's _id remains an implementation detail.
+    grantId: { type: String, required: true, unique: true, trim: true },
+    connectionId: { type: String, required: true, trim: true },
+    installationId: { type: String, required: true, trim: true },
+    target: { type: GrantTargetSchema, required: true },
+    tools: { type: [String], required: true, default: [] },
+    writeMode: {
+      type: String,
+      enum: ['read', 'write', 'write-with-confirm'],
+      required: true,
+    },
+    budget: { type: GrantBudgetSchema },
+    audience: { type: [String], required: true, default: [] },
+    // No TTL index: expiry is a capability check and an audit fact, not a
+    // reason to delete the grant or its call trail.
+    expiresAt: { type: Date, required: true },
+    revokedAt: { type: Date, default: null },
+    parentGrantId: { type: String, default: null, trim: true },
+    brokerId: { type: String, required: true, trim: true },
+  },
+  { timestamps: true, collection: 'room_grants' },
+);
+
+RoomGrantSchema.index({ target: 1, revokedAt: 1, expiresAt: 1 });
+RoomGrantSchema.index({ parentGrantId: 1 });
+RoomGrantSchema.index({ connectionId: 1, installationId: 1 });
+
+/**
+ * Gather the grant lineage first, then perform exactly one write. This is
+ * deliberately different from the credential substrate's per-level updates:
+ * a room revoke must make the whole chain dead at one database boundary.
+ */
+RoomGrantSchema.statics.revokeCascade = async function revokeCascade(
+  grantId: string,
+): Promise<number> {
+  const ids: string[] = [grantId];
+  let frontier: string[] = [grantId];
+
+  while (frontier.length > 0) {
+    const children = await this.find({ parentGrantId: { $in: frontier } })
+      .select('grantId')
+      .lean();
+    const childIds = (children as Array<{ grantId?: string }>).map((child) => child.grantId)
+      .filter((id): id is string => Boolean(id))
+      .filter((id) => !ids.includes(id));
+    if (childIds.length === 0) break;
+    ids.push(...childIds);
+    frontier = childIds;
+  }
+
+  const revokedAt = new Date();
+  const result = await this.updateMany(
+    {
+      grantId: { $in: ids },
+      $or: [{ revokedAt: { $exists: false } }, { revokedAt: null }],
+    },
+    { $set: { revokedAt } },
+  );
+  return result.modifiedCount || 0;
+};
+
+const RoomGrant: RoomGrantModel =
+  (mongoose.models.RoomGrant as RoomGrantModel)
+  || mongoose.model<IRoomGrant, RoomGrantModel>('RoomGrant', RoomGrantSchema);
+
+export { RoomGrant, RoomGrantSchema };
+export default RoomGrant;
+
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"];
+Object.assign(module.exports, exports);

--- a/backend/models/RoomGrant.ts
+++ b/backend/models/RoomGrant.ts
@@ -34,6 +34,8 @@ export interface IRoomGrant extends Document {
   expiresAt: Date;
   revokedAt?: Date | null;
   parentGrantId?: string | null;
+  /** Denormalized root used to close revoke/mint races and check lineage. */
+  rootGrantId?: string | null;
   /** Required proxy identifier; an agent must never receive connection material. */
   brokerId: string;
   createdAt: Date;
@@ -82,6 +84,7 @@ const RoomGrantSchema = new Schema<IRoomGrant>(
     expiresAt: { type: Date, required: true },
     revokedAt: { type: Date, default: null },
     parentGrantId: { type: String, default: null, trim: true },
+    rootGrantId: { type: String, default: null, trim: true },
     brokerId: { type: String, required: true, trim: true },
   },
   { timestamps: true, collection: 'room_grants' },
@@ -89,6 +92,7 @@ const RoomGrantSchema = new Schema<IRoomGrant>(
 
 RoomGrantSchema.index({ target: 1, revokedAt: 1, expiresAt: 1 });
 RoomGrantSchema.index({ parentGrantId: 1 });
+RoomGrantSchema.index({ rootGrantId: 1 });
 RoomGrantSchema.index({ connectionId: 1, installationId: 1 });
 
 /**
@@ -100,6 +104,7 @@ RoomGrantSchema.statics.revokeCascade = async function revokeCascade(
   grantId: string,
 ): Promise<number> {
   const ids: string[] = [grantId];
+  const seen = new Set(ids);
   let frontier: string[] = [grantId];
 
   while (frontier.length > 0) {
@@ -108,9 +113,10 @@ RoomGrantSchema.statics.revokeCascade = async function revokeCascade(
       .lean();
     const childIds = (children as Array<{ grantId?: string }>).map((child) => child.grantId)
       .filter((id): id is string => Boolean(id))
-      .filter((id) => !ids.includes(id));
+      .filter((id) => !seen.has(id));
     if (childIds.length === 0) break;
     ids.push(...childIds);
+    childIds.forEach((id) => seen.add(id));
     frontier = childIds;
   }
 

--- a/backend/routes/grants.ts
+++ b/backend/routes/grants.ts
@@ -1,0 +1,194 @@
+import express from 'express';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { createHash } from 'crypto';
+import { Types } from 'mongoose';
+import Integration from '../models/Integration';
+import Pod from '../models/Pod';
+import RoomGrant from '../models/RoomGrant';
+import {
+  assertGrantUsable,
+  attenuateGrant,
+  createGrant,
+  effectiveAudience,
+  revokeGrant,
+  RoomGrantError,
+} from '../services/roomGrantService';
+import type { RoomGrantCreateInput } from '../services/roomGrantService';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const auth = require('../middleware/auth');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const agentRuntimeAuth = require('../middleware/agentRuntimeAuth');
+
+const router = express.Router();
+
+const grantRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: express.Request): string => {
+    const authHeader = req.get('Authorization') || req.get('x-auth-token');
+    if (authHeader) return `grant:${createHash('sha256').update(authHeader).digest('hex').slice(0, 16)}`;
+    return req.ip ? ipKeyGenerator(req.ip) : 'anon';
+  },
+  handler: (_req, res) => res.status(429).json({ message: 'rate limit exceeded: 60 grant operations per 60s' }),
+});
+
+interface AuthenticatedRequest extends express.Request {
+  userId?: string;
+}
+
+const callerId = (req: AuthenticatedRequest): string => {
+  const user = req.user as { id?: string; _id?: string } | undefined;
+  return String(req.userId || user?.id || user?._id || '');
+};
+
+const findConnection = async (connectionId: string): Promise<any> => {
+  if (Types.ObjectId.isValid(connectionId)) {
+    const byId = await Integration.findById(connectionId);
+    if (byId) return byId;
+  }
+  return Integration.findOne({ installationId: connectionId });
+};
+
+const connectionOwnerId = (connection: any): string => String(
+  connection?.createdBy || connection?.config?.linkedUserId || '',
+);
+
+const getTargetMembers = async (target: { kind: 'pod' | 'seat'; id: string }): Promise<string[] | undefined> => {
+  // Seat grants already identify their single target; there is no pod census
+  // to intersect for them. The broker still checks the explicit audience.
+  if (target.kind !== 'pod') return undefined;
+  if (!Types.ObjectId.isValid(target.id)) {
+    throw new RoomGrantError('invalid_target', 'target.id must be a valid pod id');
+  }
+  const pod = await Pod.findById(target.id).select('members').lean();
+  if (!pod) throw new RoomGrantError('target_not_found', 'target pod not found', 404);
+  return (pod.members || []).map((member: Types.ObjectId | string) => String(member));
+};
+
+const ensureTargetAccess = async (target: { kind: 'pod' | 'seat'; id: string }, userId: string): Promise<string[]> => {
+  const members = (await getTargetMembers(target)) || [];
+  if (target.kind === 'pod' && !members.includes(userId)) {
+    throw new RoomGrantError('access_denied', 'caller is not a member of the target pod', 403);
+  }
+  return members;
+};
+
+const handleError = (res: express.Response, error: unknown): express.Response => {
+  if (error instanceof RoomGrantError) {
+    return res.status(error.statusCode).json({ error: error.code, message: error.message, details: error.details });
+  }
+  console.error('Room grant route error:', error);
+  return res.status(500).json({ error: 'server_error', message: 'Server error' });
+};
+
+/** Mint a root grant. The connection owner is the granter; it is never taken from the body. */
+router.post('/', grantRateLimit, auth, async (req: AuthenticatedRequest, res: express.Response) => {
+  try {
+    const body = (req.body || {}) as Record<string, any>;
+    const userId = callerId(req);
+    if (!userId) return res.status(401).json({ error: 'unauthorized' });
+    const connectionId = String(body.connectionId || '').trim();
+    const connection = await findConnection(connectionId);
+    if (!connection) return res.status(404).json({ error: 'connection_not_found' });
+    if (connectionOwnerId(connection) !== userId) return res.status(403).json({ error: 'access_denied' });
+
+    const target = body.target;
+    if (!target || (target.kind !== 'pod' && target.kind !== 'seat')) {
+      return res.status(400).json({ error: 'invalid_target', message: 'target.kind must be pod or seat' });
+    }
+    const members = await ensureTargetAccess(target, userId);
+    const audience = body.audience === undefined ? members : body.audience;
+    const audienceValues = Array.isArray(audience) ? audience.map(String) : audience;
+    if (Array.isArray(audienceValues) && audienceValues.some((id: string) => !members.includes(id))) {
+      return res.status(400).json({ error: 'invalid_audience', message: 'audience must be current target members' });
+    }
+
+    const grantInput: RoomGrantCreateInput = {
+      connectionId,
+      installationId: String(body.installationId || ''),
+      target,
+      tools: body.tools,
+      writeMode: body.writeMode,
+      budget: body.budget,
+      audience: audienceValues,
+      expiresAt: body.expiresAt,
+      brokerId: String(body.brokerId || ''),
+    };
+    const grant = await createGrant(grantInput);
+    return res.status(201).json(grant);
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+/** Agent-only delegation; all parent capabilities are loaded server-side. */
+router.post(
+  '/:grantId/attenuate',
+  grantRateLimit,
+  agentRuntimeAuth,
+  async (req: AuthenticatedRequest, res: express.Response) => {
+  try {
+    const parent = await RoomGrant.findOne({ grantId: req.params.grantId });
+    if (!parent) return res.status(404).json({ error: 'grant_not_found' });
+    const agentId = String(req.agentUser?._id || '');
+    if (!agentId) return res.status(401).json({ error: 'agent_identity_required' });
+    const members = await getTargetMembers(parent.target);
+    await assertGrantUsable({
+      grant: parent,
+      agentUserId: agentId,
+      ...(members ? { currentMemberIds: members } : {}),
+    });
+    const body = (req.body || {}) as Record<string, unknown>;
+    const child = await attenuateGrant({
+      parentGrantId: parent.grantId,
+      tools: body.tools as string[] | undefined,
+      writeMode: body.writeMode as any,
+      budget: body.budget as any,
+      audience: body.audience as string[] | undefined,
+      expiresAt: body.expiresAt as string | undefined,
+    });
+    return res.status(201).json(child);
+  } catch (error) {
+    return handleError(res, error);
+  }
+  },
+);
+
+const revokeHandler = async (req: AuthenticatedRequest, res: express.Response): Promise<express.Response> => {
+  try {
+    const grant = await RoomGrant.findOne({ grantId: req.params.grantId });
+    if (!grant) return res.status(404).json({ error: 'grant_not_found' });
+    const userId = callerId(req);
+    const connection = await findConnection(grant.connectionId);
+    if (!connection || connectionOwnerId(connection) !== userId) {
+      return res.status(403).json({ error: 'access_denied' });
+    }
+    const revoked = await revokeGrant(grant.grantId);
+    return res.json({ grantId: grant.grantId, revoked });
+  } catch (error) {
+    return handleError(res, error);
+  }
+};
+
+router.post('/:grantId/revoke', grantRateLimit, auth, revokeHandler);
+router.delete('/:grantId', grantRateLimit, auth, revokeHandler);
+
+// Read is intentionally member-scoped. The route exposes the effective
+// audience, never raw connection material or the owner's secret reference.
+router.get('/:grantId', grantRateLimit, auth, async (req: AuthenticatedRequest, res: express.Response) => {
+  try {
+    const grant = await RoomGrant.findOne({ grantId: req.params.grantId }).lean();
+    if (!grant) return res.status(404).json({ error: 'grant_not_found' });
+    const members = await ensureTargetAccess(grant.target, callerId(req));
+    const currentMembers = grant.target.kind === 'seat' ? grant.audience : members;
+    return res.json({ ...grant, effectiveAudience: effectiveAudience(grant, currentMembers) });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+export default router;
+module.exports = router;

--- a/backend/routes/grants.ts
+++ b/backend/routes/grants.ts
@@ -100,9 +100,26 @@ router.post('/', grantRateLimit, auth, async (req: AuthenticatedRequest, res: ex
       return res.status(400).json({ error: 'invalid_target', message: 'target.kind must be pod or seat' });
     }
     const members = await ensureTargetAccess(target, userId);
-    const audience = body.audience === undefined ? members : body.audience;
+    // Pod grants default to the current member snapshot. A seat has no pod
+    // census, so its own seat id is the minimum audience and can be extended
+    // explicitly by the granter.
+    const audience = target.kind === 'seat'
+      ? (body.audience === undefined ? [target.id] : body.audience)
+      : (body.audience === undefined ? members : body.audience);
     const audienceValues = Array.isArray(audience) ? audience.map(String) : audience;
-    if (Array.isArray(audienceValues) && audienceValues.some((id: string) => !members.includes(id))) {
+    if (
+      target.kind === 'seat'
+      && (!Array.isArray(audienceValues)
+        || audienceValues.length !== 1
+        || audienceValues[0] !== String(target.id))
+    ) {
+      return res.status(400).json({ error: 'invalid_audience', message: 'seat audience must be the target seat' });
+    }
+    if (
+      target.kind === 'pod'
+      && Array.isArray(audienceValues)
+      && audienceValues.some((id: string) => !members.includes(id))
+    ) {
       return res.status(400).json({ error: 'invalid_audience', message: 'audience must be current target members' });
     }
 
@@ -139,7 +156,9 @@ router.post(
     await assertGrantUsable({
       grant: parent,
       agentUserId: agentId,
-      ...(members ? { currentMemberIds: members } : {}),
+      // Seat targets have no pod census; the explicit audience is the live
+      // membership context for the seat-grant check.
+      currentMemberIds: members ?? parent.audience,
     });
     const body = (req.body || {}) as Record<string, unknown>;
     const child = await attenuateGrant({

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -237,6 +237,7 @@ app.use('/api/v1', contextApiRoutes); // Context API for MCP and external agents
 app.use('/api/v1/tasks', tasksApiRoutes); // Task management for dev agents
 app.use('/api/registry', registryRoutes); // Agent Registry (package manager for agents)
 app.use('/api/credentials', require('./routes/credentials')); // ADR-026 Phase 0: credential lineage + revocation
+app.use('/api/grants', require('./routes/grants')); // ADR-001 room-grant record: server-enforced attenuation + cascade revocation
 app.use('/api/agent-binding', require('./routes/agentBinding')); // ADR-026 D3: machine adoption CAS
 app.use('/api/machines', require('./routes/machines')); // ADR-026 Phase 1: local daemon lifecycle
 app.use('/api/hosted', require('./routes/hosted')); // ADR-023 W2: hosted runtime provision surface (metered)

--- a/backend/services/roomGrantService.ts
+++ b/backend/services/roomGrantService.ts
@@ -132,8 +132,30 @@ const assertBudgetAttenuated = (
   if (!budgetFieldIsNarrower(child?.calls, parent?.calls, 'calls')) {
     throw new RoomGrantError('grant_not_attenuated', 'child budget.calls cannot exceed its parent');
   }
-  if (!budgetFieldIsNarrower(child?.windowMs, parent?.windowMs, 'windowMs')) {
-    throw new RoomGrantError('grant_not_attenuated', 'child budget.windowMs cannot exceed its parent');
+
+  // A calls-only parent is a lifetime cap. Adding a window would reset that
+  // cap repeatedly and therefore widen it, even if the child keeps the same
+  // calls value (for example, 10-ever -> 10-per-millisecond).
+  if (
+    parent?.calls !== undefined
+    && parent.windowMs === undefined
+    && child?.windowMs !== undefined
+  ) {
+    throw new RoomGrantError('grant_not_attenuated', 'child budget.windowMs cannot be added to a lifetime cap');
+  }
+
+  // A window is not independently narrower when it changes: the capability
+  // is a call rate. A shorter window at the same call count is wider, while a
+  // longer window is narrower. Compare the two rates after the per-field
+  // unbounded checks above, rather than comparing windowMs in isolation.
+  if (
+    child?.calls !== undefined
+    && child.windowMs !== undefined
+    && parent?.calls !== undefined
+    && parent.windowMs !== undefined
+    && child.calls / child.windowMs > parent.calls / parent.windowMs
+  ) {
+    throw new RoomGrantError('grant_not_attenuated', 'child budget call rate cannot exceed its parent');
   }
 };
 
@@ -164,6 +186,45 @@ const grantIsExpired = (grant: IRoomGrant | Record<string, unknown>, now = new D
   return !expiresAt || asDate(expiresAt, 'expiresAt').getTime() <= now.getTime();
 };
 
+const loadGrantLineage = async (
+  grant: IRoomGrant | Record<string, unknown>,
+): Promise<Array<IRoomGrant | Record<string, unknown>>> => {
+  const lineage: Array<IRoomGrant | Record<string, unknown>> = [grant];
+  const seen = new Set<string>();
+  let current: IRoomGrant | Record<string, unknown> = grant;
+  let parentGrantId = readGrantValue<unknown>(current, 'parentGrantId');
+  while (parentGrantId) {
+    const parentId = String(parentGrantId);
+    if (seen.has(parentId)) {
+      throw new RoomGrantError('grant_invalid_lineage', 'grant lineage contains a cycle', 403);
+    }
+    seen.add(parentId);
+    const parent = await RoomGrant.findOne({ grantId: parentId });
+    if (!parent) throw new RoomGrantError('grant_not_found', 'grant parent not found', 404);
+    lineage.push(parent);
+    current = parent;
+    parentGrantId = readGrantValue<unknown>(current, 'parentGrantId');
+  }
+  return lineage;
+};
+
+const assertGrantLineageActive = async (
+  grant: IRoomGrant | Record<string, unknown>,
+  now = new Date(),
+): Promise<Array<IRoomGrant | Record<string, unknown>>> => {
+  const lineage = await loadGrantLineage(grant);
+  for (const item of lineage) {
+    if (grantIsRevoked(item)) throw new RoomGrantError('grant_revoked', 'grant lineage is revoked', 403);
+    if (grantIsExpired(item, now)) throw new RoomGrantError('grant_expired', 'grant lineage is expired', 403);
+  }
+  return lineage;
+};
+
+const markMintedGrantRejected = async (grantId: string, error: RoomGrantError): Promise<never> => {
+  await RoomGrant.updateOne({ grantId }, { $set: { revokedAt: new Date() } });
+  throw error;
+};
+
 export const effectiveAudience = (
   grant: Pick<IRoomGrant, 'audience'> | { audience?: string[] },
   currentMemberIds: string[],
@@ -176,13 +237,23 @@ export const mintGrant = async (input: RoomGrantCreateInput): Promise<IRoomGrant
   if (input.expiresAt === undefined || input.expiresAt === null || input.expiresAt === '') {
     throw new RoomGrantError('missing_expiry', 'expiresAt is required');
   }
+  const grantId = input.grantId ? asId(input.grantId, 'grantId') : `grant_${randomUUID()}`;
+  const parentGrantId = input.parentGrantId ? asId(input.parentGrantId, 'parentGrantId') : undefined;
+  let rootGrantId = grantId;
+  if (parentGrantId) {
+    const parent = await RoomGrant.findOne({ grantId: parentGrantId });
+    if (!parent) throw new RoomGrantError('grant_not_found', 'parent grant not found', 404);
+    const lineage = await assertGrantLineageActive(parent);
+    const root = lineage[lineage.length - 1];
+    rootGrantId = String(readGrantValue<string>(root, 'rootGrantId') || readGrantValue<string>(root, 'grantId'));
+  }
   const expiresAt = asDate(input.expiresAt, 'expiresAt');
   if (expiresAt.getTime() <= Date.now()) {
     throw new RoomGrantError('invalid_expiry', 'expiresAt must be in the future');
   }
   const budget = normalizeBudget(input.budget);
   const grant = await RoomGrant.create({
-    grantId: input.grantId ? asId(input.grantId, 'grantId') : `grant_${randomUUID()}`,
+    grantId,
     connectionId: asId(input.connectionId, 'connectionId'),
     installationId: asId(input.installationId, 'installationId'),
     target: {
@@ -194,9 +265,51 @@ export const mintGrant = async (input: RoomGrantCreateInput): Promise<IRoomGrant
     budget,
     audience: uniqueStrings(input.audience, 'audience'),
     expiresAt,
-    parentGrantId: input.parentGrantId ? asId(input.parentGrantId, 'parentGrantId') : undefined,
+    parentGrantId,
+    rootGrantId,
     brokerId: asId(input.brokerId, 'brokerId'),
   });
+
+  // Re-read the root after insertion. A revoke can race the pre-insert check;
+  // in that case the cascade cannot see this child yet, so mark it revoked
+  // here and refuse to hand out a live descendant.
+  if (parentGrantId) {
+    const root = await RoomGrant.findOne({ grantId: rootGrantId }).select('revokedAt expiresAt').lean();
+    if (!root) {
+      return markMintedGrantRejected(
+        grantId,
+        new RoomGrantError('grant_not_found', 'grant root not found', 404),
+      );
+    }
+    if (grantIsRevoked(root)) {
+      return markMintedGrantRejected(
+        grantId,
+        new RoomGrantError('grant_revoked', 'grant root is revoked', 403),
+      );
+    }
+    if (grantIsExpired(root)) {
+      return markMintedGrantRejected(
+        grantId,
+        new RoomGrantError('grant_expired', 'grant root is expired', 403),
+      );
+    }
+
+    // The root check closes the common race, while this second lineage read
+    // also covers a revoked intermediate parent in a deeper delegation tree.
+    const persistedParent = await RoomGrant.findOne({ grantId: parentGrantId });
+    if (!persistedParent) {
+      return markMintedGrantRejected(
+        grantId,
+        new RoomGrantError('grant_not_found', 'grant parent not found', 404),
+      );
+    }
+    try {
+      await assertGrantLineageActive(persistedParent);
+    } catch (error) {
+      if (error instanceof RoomGrantError) return markMintedGrantRejected(grantId, error);
+      throw error;
+    }
+  }
   return grant;
 };
 
@@ -209,8 +322,7 @@ export const attenuateGrant = async (input: RoomGrantAttenuationInput): Promise<
   // from the request body, which is the critical attenuation boundary.
   const parent = await RoomGrant.findOne({ grantId: parentGrantId });
   if (!parent) throw new RoomGrantError('grant_not_found', 'parent grant not found', 404);
-  if (grantIsRevoked(parent)) throw new RoomGrantError('grant_revoked', 'parent grant is revoked', 403);
-  if (grantIsExpired(parent)) throw new RoomGrantError('grant_expired', 'parent grant is expired', 403);
+  await assertGrantLineageActive(parent);
   const parentExpiry = asDate(parent.expiresAt, 'expiresAt');
 
   const tools = input.tools === undefined ? [...parent.tools] : uniqueStrings(input.tools, 'tools');
@@ -286,12 +398,17 @@ export const assertGrantUsable = async (
   if (!grant) throw new RoomGrantError('grant_not_found', 'grant not found', 404);
   if (grantIsRevoked(grant)) throw new RoomGrantError('grant_revoked', 'grant is revoked', 403);
   if (grantIsExpired(grant)) throw new RoomGrantError('grant_expired', 'grant is expired', 403);
+  await assertGrantLineageActive(grant);
 
-  if (options.currentMemberIds && options.agentUserId) {
-    const audience = effectiveAudience(grant as Pick<IRoomGrant, 'audience'>, options.currentMemberIds);
-    if (!audience.includes(String(options.agentUserId))) {
-      throw new RoomGrantError('not_in_audience', 'agent is not in the grant audience', 403);
-    }
+  if (!options.agentUserId) {
+    throw new RoomGrantError('agent_identity_required', 'agent identity is required for grant use', 403);
+  }
+  if (!options.currentMemberIds) {
+    throw new RoomGrantError('audience_context_required', 'current member list is required for audience checks', 403);
+  }
+  const audience = effectiveAudience(grant as Pick<IRoomGrant, 'audience'>, options.currentMemberIds);
+  if (!audience.includes(String(options.agentUserId))) {
+    throw new RoomGrantError('not_in_audience', 'agent is not in the grant audience', 403);
   }
 
   if (options.tool !== undefined) {

--- a/backend/services/roomGrantService.ts
+++ b/backend/services/roomGrantService.ts
@@ -1,0 +1,328 @@
+import { randomUUID } from 'crypto';
+import RoomGrant, {
+  IRoomGrant,
+  IRoomGrantBudget,
+  RoomGrantTargetKind,
+  RoomGrantWriteMode,
+} from '../models/RoomGrant';
+
+export interface RoomGrantCreateInput {
+  grantId?: string;
+  connectionId: string;
+  installationId: string;
+  target: { kind: RoomGrantTargetKind; id: string };
+  tools: string[];
+  writeMode: RoomGrantWriteMode;
+  budget?: IRoomGrantBudget;
+  audience: string[];
+  expiresAt: Date | string | number;
+  brokerId: string;
+  parentGrantId?: string;
+}
+
+export interface RoomGrantAttenuationInput {
+  parentGrantId: string;
+  tools?: string[];
+  writeMode?: RoomGrantWriteMode;
+  budget?: IRoomGrantBudget;
+  audience?: string[];
+  expiresAt?: Date | string | number;
+  /** Accepted for API compatibility but never copied into the row. */
+  grantId?: string;
+}
+
+export interface GrantUsabilityOptions {
+  grant?: IRoomGrant | Record<string, unknown>;
+  grantId?: string;
+  agentUserId?: string;
+  currentMemberIds?: string[];
+  tool?: string;
+  requiredWriteMode?: RoomGrantWriteMode;
+}
+
+export class RoomGrantError extends Error {
+  readonly code: string;
+  readonly statusCode: number;
+  readonly details?: Record<string, unknown>;
+
+  constructor(code: string, message: string, statusCode = 400, details?: Record<string, unknown>) {
+    super(message);
+    this.name = 'RoomGrantError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+const WRITE_MODE_RANK: Record<RoomGrantWriteMode, number> = {
+  read: 0,
+  'write-with-confirm': 1,
+  write: 2,
+};
+
+const asId = (value: unknown, field: string): string => {
+  const id = String(value ?? '').trim();
+  if (!id) throw new RoomGrantError('invalid_grant', `${field} is required`);
+  return id;
+};
+
+const uniqueStrings = (values: unknown, field: string): string[] => {
+  if (!Array.isArray(values)) throw new RoomGrantError('invalid_grant', `${field} must be an array`);
+  return Array.from(new Set(values.map((value) => asId(value, field))));
+};
+
+const asDate = (value: unknown, field: string): Date => {
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value as string | number);
+  if (Number.isNaN(date.getTime())) throw new RoomGrantError('invalid_grant', `${field} must be a valid date`);
+  return date;
+};
+
+const validateWriteMode = (value: unknown): RoomGrantWriteMode => {
+  if (value !== 'read' && value !== 'write' && value !== 'write-with-confirm') {
+    throw new RoomGrantError('invalid_write_mode', 'writeMode must be read, write, or write-with-confirm');
+  }
+  return value;
+};
+
+const validateTargetKind = (value: unknown): RoomGrantTargetKind => {
+  if (value !== 'pod' && value !== 'seat') {
+    throw new RoomGrantError('invalid_target', 'target.kind must be pod or seat');
+  }
+  return value;
+};
+
+const normalizeBudget = (budget: IRoomGrantBudget | undefined): IRoomGrantBudget | undefined => {
+  if (budget === undefined || budget === null) return undefined;
+  if (typeof budget !== 'object') throw new RoomGrantError('invalid_budget', 'budget must be an object');
+  const result: IRoomGrantBudget = {};
+  if (budget.calls !== undefined) {
+    if (!Number.isInteger(budget.calls) || budget.calls < 0) {
+      throw new RoomGrantError('invalid_budget', 'budget.calls must be a non-negative integer');
+    }
+    result.calls = budget.calls;
+  }
+  if (budget.windowMs !== undefined) {
+    if (!Number.isInteger(budget.windowMs) || budget.windowMs < 1) {
+      throw new RoomGrantError('invalid_budget', 'budget.windowMs must be a positive integer');
+    }
+    result.windowMs = budget.windowMs;
+  }
+  return result;
+};
+
+const budgetFieldIsNarrower = (
+  child: number | undefined,
+  parent: number | undefined,
+  field: string,
+): boolean => {
+  // An omitted parent limit is unlimited. A child may introduce a limit, but
+  // may not turn a finite parent limit into an unlimited one.
+  if (parent === undefined) return true;
+  if (child === undefined) {
+    throw new RoomGrantError('grant_not_attenuated', `child budget.${field} cannot be wider than its parent`);
+  }
+  return child <= parent;
+};
+
+const assertBudgetAttenuated = (
+  child: IRoomGrantBudget | undefined,
+  parent: IRoomGrantBudget | undefined,
+): void => {
+  if (!parent && !child) return;
+  if (!budgetFieldIsNarrower(child?.calls, parent?.calls, 'calls')) {
+    throw new RoomGrantError('grant_not_attenuated', 'child budget.calls cannot exceed its parent');
+  }
+  if (!budgetFieldIsNarrower(child?.windowMs, parent?.windowMs, 'windowMs')) {
+    throw new RoomGrantError('grant_not_attenuated', 'child budget.windowMs cannot exceed its parent');
+  }
+};
+
+const mergeBudget = (
+  parent: IRoomGrantBudget | undefined,
+  requested: IRoomGrantBudget | undefined,
+): IRoomGrantBudget | undefined => {
+  if (requested === undefined) {
+    if (!parent) return undefined;
+    return normalizeBudget({ calls: parent.calls, windowMs: parent.windowMs });
+  }
+  return normalizeBudget({
+    calls: requested.calls === undefined ? parent?.calls : requested.calls,
+    windowMs: requested.windowMs === undefined ? parent?.windowMs : requested.windowMs,
+  });
+};
+
+const readGrantValue = <T>(grant: IRoomGrant | Record<string, unknown>, key: string): T =>
+  (grant as Record<string, unknown>)[key] as T;
+
+const grantIsRevoked = (grant: IRoomGrant | Record<string, unknown>): boolean => {
+  const revokedAt = readGrantValue<unknown>(grant, 'revokedAt');
+  return revokedAt !== undefined && revokedAt !== null;
+};
+
+const grantIsExpired = (grant: IRoomGrant | Record<string, unknown>, now = new Date()): boolean => {
+  const expiresAt = readGrantValue<unknown>(grant, 'expiresAt');
+  return !expiresAt || asDate(expiresAt, 'expiresAt').getTime() <= now.getTime();
+};
+
+export const effectiveAudience = (
+  grant: Pick<IRoomGrant, 'audience'> | { audience?: string[] },
+  currentMemberIds: string[],
+): string[] => {
+  const current = new Set(currentMemberIds.map((id) => String(id)));
+  return Array.from(new Set((grant.audience || []).map(String))).filter((id) => current.has(id));
+};
+
+export const mintGrant = async (input: RoomGrantCreateInput): Promise<IRoomGrant> => {
+  if (input.expiresAt === undefined || input.expiresAt === null || input.expiresAt === '') {
+    throw new RoomGrantError('missing_expiry', 'expiresAt is required');
+  }
+  const expiresAt = asDate(input.expiresAt, 'expiresAt');
+  if (expiresAt.getTime() <= Date.now()) {
+    throw new RoomGrantError('invalid_expiry', 'expiresAt must be in the future');
+  }
+  const budget = normalizeBudget(input.budget);
+  const grant = await RoomGrant.create({
+    grantId: input.grantId ? asId(input.grantId, 'grantId') : `grant_${randomUUID()}`,
+    connectionId: asId(input.connectionId, 'connectionId'),
+    installationId: asId(input.installationId, 'installationId'),
+    target: {
+      kind: validateTargetKind(input.target?.kind),
+      id: asId(input.target?.id, 'target.id'),
+    },
+    tools: uniqueStrings(input.tools, 'tools'),
+    writeMode: validateWriteMode(input.writeMode),
+    budget,
+    audience: uniqueStrings(input.audience, 'audience'),
+    expiresAt,
+    parentGrantId: input.parentGrantId ? asId(input.parentGrantId, 'parentGrantId') : undefined,
+    brokerId: asId(input.brokerId, 'brokerId'),
+  });
+  return grant;
+};
+
+// The public name mirrors the ADR and makes the route's intent explicit.
+export const createGrant = mintGrant;
+
+export const attenuateGrant = async (input: RoomGrantAttenuationInput): Promise<IRoomGrant> => {
+  const parentGrantId = asId(input.parentGrantId, 'parentGrantId');
+  // Load the parent by its server-side id. No parent capabilities are accepted
+  // from the request body, which is the critical attenuation boundary.
+  const parent = await RoomGrant.findOne({ grantId: parentGrantId });
+  if (!parent) throw new RoomGrantError('grant_not_found', 'parent grant not found', 404);
+  if (grantIsRevoked(parent)) throw new RoomGrantError('grant_revoked', 'parent grant is revoked', 403);
+  if (grantIsExpired(parent)) throw new RoomGrantError('grant_expired', 'parent grant is expired', 403);
+  const parentExpiry = asDate(parent.expiresAt, 'expiresAt');
+
+  const tools = input.tools === undefined ? [...parent.tools] : uniqueStrings(input.tools, 'tools');
+  const parentTools = new Set(parent.tools.map(String));
+  const outsideTools = tools.filter((tool) => !parentTools.has(tool));
+  if (outsideTools.length) {
+    throw new RoomGrantError(
+      'grant_not_attenuated',
+      `child tools must be a subset of parent tools: ${outsideTools.join(', ')}`,
+      400,
+      { tools: outsideTools },
+    );
+  }
+
+  const writeMode = input.writeMode === undefined ? parent.writeMode : validateWriteMode(input.writeMode);
+  if (WRITE_MODE_RANK[writeMode] > WRITE_MODE_RANK[parent.writeMode]) {
+    throw new RoomGrantError('grant_not_attenuated', 'child writeMode cannot be stronger than its parent');
+  }
+
+  const requestedBudget = normalizeBudget(input.budget);
+  const budget = mergeBudget(parent.budget, requestedBudget);
+  assertBudgetAttenuated(budget, parent.budget);
+
+  const audience = input.audience === undefined
+    ? [...parent.audience]
+    : uniqueStrings(input.audience, 'audience');
+  const parentAudience = new Set(parent.audience.map(String));
+  const outsideAudience = audience.filter((id) => !parentAudience.has(id));
+  if (outsideAudience.length) {
+    throw new RoomGrantError('grant_not_attenuated', 'child audience must be a subset of parent audience', 400, {
+      audience: outsideAudience,
+    });
+  }
+
+  const requestedExpiry = input.expiresAt === undefined
+    ? new Date(parentExpiry)
+    : asDate(input.expiresAt, 'expiresAt');
+  // The plan deliberately clamps a later child expiry rather than rejecting it.
+  const expiresAt = requestedExpiry.getTime() > parentExpiry.getTime()
+    ? new Date(parentExpiry)
+    : requestedExpiry;
+  if (expiresAt.getTime() <= Date.now()) {
+    throw new RoomGrantError('invalid_expiry', 'expiresAt must be in the future');
+  }
+
+  return mintGrant({
+    connectionId: parent.connectionId,
+    installationId: parent.installationId,
+    target: { kind: parent.target.kind, id: parent.target.id },
+    tools,
+    writeMode,
+    budget,
+    audience,
+    expiresAt,
+    parentGrantId,
+    brokerId: parent.brokerId,
+  });
+};
+
+export const revokeGrant = async (grantId: string): Promise<number> => {
+  const id = asId(grantId, 'grantId');
+  const root = await RoomGrant.findOne({ grantId: id }).select('grantId').lean();
+  if (!root) throw new RoomGrantError('grant_not_found', 'grant not found', 404);
+  return RoomGrant.revokeCascade(id);
+};
+
+export const assertGrantUsable = async (
+  options: GrantUsabilityOptions,
+): Promise<IRoomGrant | Record<string, unknown>> => {
+  const grant = options.grant || (options.grantId
+    ? await RoomGrant.findOne({ grantId: asId(options.grantId, 'grantId') })
+    : null);
+  if (!grant) throw new RoomGrantError('grant_not_found', 'grant not found', 404);
+  if (grantIsRevoked(grant)) throw new RoomGrantError('grant_revoked', 'grant is revoked', 403);
+  if (grantIsExpired(grant)) throw new RoomGrantError('grant_expired', 'grant is expired', 403);
+
+  if (options.currentMemberIds && options.agentUserId) {
+    const audience = effectiveAudience(grant as Pick<IRoomGrant, 'audience'>, options.currentMemberIds);
+    if (!audience.includes(String(options.agentUserId))) {
+      throw new RoomGrantError('not_in_audience', 'agent is not in the grant audience', 403);
+    }
+  }
+
+  if (options.tool !== undefined) {
+    const tools = (readGrantValue<string[]>(grant, 'tools') || []).map(String);
+    if (!tools.includes(options.tool)) {
+      throw new RoomGrantError('tool_not_allowed', `tool is not allowed by this grant: ${options.tool}`, 403);
+    }
+  }
+  if (options.requiredWriteMode !== undefined) {
+    const actualMode = readGrantValue<RoomGrantWriteMode>(grant, 'writeMode');
+    if (WRITE_MODE_RANK[options.requiredWriteMode] > WRITE_MODE_RANK[actualMode]) {
+      throw new RoomGrantError('write_mode_not_allowed', 'tool requires a stronger write mode than this grant', 403);
+    }
+  }
+  return grant;
+};
+
+export const getEffectiveAudience = effectiveAudience;
+
+export default {
+  mintGrant,
+  createGrant,
+  attenuateGrant,
+  revokeGrant,
+  assertGrantUsable,
+  effectiveAudience,
+  getEffectiveAudience,
+  RoomGrantError,
+};
+
+// CJS compat: let require() return the default export directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"];
+Object.assign(module.exports, exports);


### PR DESCRIPTION
Implements connector plan piece 1 from ADR-001 / #1659.

- Adds RoomGrant model with required expiry, broker reference, audience snapshot, target, capabilities, budget, and lineage.
- Adds server-computed attenuation (tools, write mode, budget, audience, expiry cap).
- Adds one-write descendant revocation and effective audience checks.
- Adds authenticated grant mint/revoke/agent attenuation routes.
- Adds named acceptance tests for attenuation, expiry, audience intersection, and three-level cascade revocation.

Tests: `npm test -- --runInBand __tests__/unit/services/roomGrantService.test.js`; `npm run tsc:check`.