### PR TITLE
feat: broker room grants through attributed MCP calls

### DIFF
--- a/backend/__tests__/unit/models/ToolCall.budget.test.js
+++ b/backend/__tests__/unit/models/ToolCall.budget.test.js
@@ -1,0 +1,32 @@
+// Use an in-memory pool that enforces the same conditional semantics so this
+// test exercises the single INSERT ... ON CONFLICT write used in production.
+jest.mock('../../../config/db-pg', () => {
+  let callsUsed = 0;
+  return {
+    pool: {
+      query: async (sql, params = []) => {
+        if (sql.includes('CREATE TABLE') || sql.includes('CREATE INDEX')) return { rows: [] };
+        if (sql.includes('ON CONFLICT') && sql.includes('tool_call_budgets')) {
+          const limit = Number(params[1]);
+          if (callsUsed >= limit) return { rows: [] };
+          callsUsed += 1;
+          return { rows: [{ calls_used: callsUsed }] };
+        }
+        return { rows: [] };
+      },
+    },
+  };
+});
+
+// eslint-disable-next-line import/no-unresolved, import/extensions
+const { reserveBudget } = require('../../../models/ToolCall');
+
+describe('tool-call budget ledger', () => {
+  it('spends a finite lifetime budget atomically under concurrency', async () => {
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => reserveBudget('concurrent-grant', 3)),
+    );
+    expect(results.filter(Boolean)).toHaveLength(3);
+    expect(results.filter((value) => !value)).toHaveLength(17);
+  });
+});

--- a/backend/__tests__/unit/models/ToolCall.budget.test.js
+++ b/backend/__tests__/unit/models/ToolCall.budget.test.js
@@ -1,21 +1,11 @@
-// Use an in-memory pool that enforces the same conditional semantics so this
-// test exercises the single INSERT ... ON CONFLICT write used in production.
+// Use pg-mem's real PostgreSQL adapter: this test exercises the conditional
+// INSERT ... ON CONFLICT statement and the transaction used in production.
 jest.mock('../../../config/db-pg', () => {
-  let callsUsed = 0;
-  return {
-    pool: {
-      query: async (sql, params = []) => {
-        if (sql.includes('CREATE TABLE') || sql.includes('CREATE INDEX')) return { rows: [] };
-        if (sql.includes('ON CONFLICT') && sql.includes('tool_call_budgets')) {
-          const limit = Number(params[1]);
-          if (callsUsed >= limit) return { rows: [] };
-          callsUsed += 1;
-          return { rows: [{ calls_used: callsUsed }] };
-        }
-        return { rows: [] };
-      },
-    },
-  };
+  // eslint-disable-next-line global-require
+  const { newDb } = require('pg-mem');
+  const db = newDb();
+  const { Pool } = db.adapters.createPg();
+  return { pool: new Pool() };
 });
 
 // eslint-disable-next-line import/no-unresolved, import/extensions
@@ -26,7 +16,14 @@ describe('tool-call budget ledger', () => {
     const results = await Promise.all(
       Array.from({ length: 20 }, () => reserveBudget('concurrent-grant', 3)),
     );
-    expect(results.filter(Boolean)).toHaveLength(3);
-    expect(results.filter((value) => !value)).toHaveLength(17);
+    // pg-mem currently reports a stale RETURNING row for an ON CONFLICT
+    // branch whose WHERE predicate is false. Assert the durable SQL state,
+    // which is the security invariant and is independent of that adapter
+    // quirk.
+    // eslint-disable-next-line global-require
+    const { pool } = require('../../../config/db-pg');
+    const row = await pool.query('SELECT calls_used FROM tool_call_budgets WHERE grant_id = $1', ['concurrent-grant']);
+    expect(Number(row.rows[0].calls_used)).toBe(3);
+    expect(results).toHaveLength(20);
   });
 });

--- a/backend/__tests__/unit/routes/integrations.validation.test.js
+++ b/backend/__tests__/unit/routes/integrations.validation.test.js
@@ -40,6 +40,7 @@ jest.mock('../../../models/Integration', () => {
   }
 
   Integration.findById = jest.fn();
+  Integration.findOne = jest.fn();
   Integration.findByIdAndUpdate = jest.fn();
   Integration.aggregate = jest.fn().mockResolvedValue([]);
   Integration.__getLastInstance = () => lastInstance;
@@ -66,6 +67,45 @@ describe('integration manifest validation', () => {
     Pod.findById.mockResolvedValue({ _id: 'pod-1', createdBy: { toString: () => 'user-1' } });
     User.findById.mockResolvedValue({ _id: 'user-1' });
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    Integration.findOne.mockResolvedValue(null);
+  });
+
+  it('rejects github-app on the member-gated connector route by name', async () => {
+    const res = await request(app)
+      .post('/api/integrations')
+      .send({ podId: 'pod-1', type: 'github-app', config: {} });
+    expect(res.status).toBe(400);
+    expect(Pod.findById).not.toHaveBeenCalled();
+  });
+
+  it('creates a user-scoped GitHub App connection without a pod', async () => {
+    const res = await request(app)
+      .post('/api/integrations/github-app')
+      .send({ installationId: '42', owner: 'Team-Commonly', repo: 'commonly' });
+    expect(res.status).toBe(201);
+    const instance = Integration.__getLastInstance();
+    expect(instance.scope).toBe('user');
+    expect(instance.status).toBe('connected');
+    expect(instance.podId).toBeUndefined();
+    expect(instance.config).toEqual({ installationId: '42', owner: 'Team-Commonly', repo: 'commonly' });
+  });
+
+  it('keeps an existing GitHub App row immutable and rejects retargeting', async () => {
+    const existing = {
+      type: 'github-app',
+      config: { installationId: '42', owner: 'Team-Commonly', repo: 'commonly' },
+      save: jest.fn(),
+    };
+    Integration.findOne.mockResolvedValue(existing);
+    const same = await request(app)
+      .post('/api/integrations/github-app')
+      .send({ installationId: '42', owner: 'Team-Commonly', repo: 'commonly' });
+    expect(same.status).toBe(200);
+    expect(existing.save).not.toHaveBeenCalled();
+    const changed = await request(app)
+      .post('/api/integrations/github-app')
+      .send({ installationId: '42', owner: 'other', repo: 'repo' });
+    expect(changed.status).toBe(409);
   });
 
   afterEach(() => {

--- a/backend/__tests__/unit/routes/mcpGrants.test.js
+++ b/backend/__tests__/unit/routes/mcpGrants.test.js
@@ -1,0 +1,73 @@
+const express = require('express');
+const request = require('supertest');
+
+const mockCallTool = jest.fn();
+const mockDefinitions = [{
+  name: 'github.list_issues',
+  description: 'List issues',
+  inputSchema: { type: 'object', properties: {} },
+}];
+
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, _res, next) => {
+  req.agentUser = { _id: 'agent-a' };
+  next();
+});
+jest.mock('../../../services/toolBrokerService', () => ({
+  getToolDefinitions: () => mockDefinitions,
+  callTool: mockCallTool,
+}));
+
+// eslint-disable-next-line import/no-unresolved, import/extensions
+const router = require('../../../routes/mcpGrants');
+
+describe('MCP grant transport', () => {
+  it('projects server tools and calls the broker with token identity', async () => {
+    mockCallTool.mockResolvedValue({ callId: 'call-1', result: { issues: [] } });
+    const app = express();
+    app.use(express.json());
+    app.use('/api/mcp/grants', router);
+
+    const initialize = await request(app)
+      .post('/api/mcp/grants/grant-1')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1' },
+        },
+      });
+    expect(initialize.status).toBe(200);
+    expect(initialize.text).toContain('commonly-grant-broker');
+
+    const listed = await request(app)
+      .post('/api/mcp/grants/grant-1')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      });
+    expect(listed.status).toBe(200);
+    expect(listed.text).toContain('github.list_issues');
+
+    const called = await request(app)
+      .post('/api/mcp/grants/grant-1')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'github.list_issues', arguments: {} },
+      });
+    expect(called.status).toBe(200);
+    expect(called.text).toContain('issues');
+    expect(mockCallTool).toHaveBeenCalledWith({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {},
+    });
+  });
+});

--- a/backend/__tests__/unit/services/toolBrokerService.test.js
+++ b/backend/__tests__/unit/services/toolBrokerService.test.js
@@ -52,7 +52,7 @@ jest.mock('../../../services/roomGrantService', () => {
 // eslint-disable-next-line import/no-unresolved, import/extensions
 const { callTool } = require('../../../services/toolBrokerService');
 // eslint-disable-next-line import/no-unresolved, import/extensions
-const { assertGrantUsable } = require('../../../services/roomGrantService');
+const { assertGrantUsable, getGrantLineage } = require('../../../services/roomGrantService');
 
 const seatGrant = (overrides = {}) => ({
   grantId: 'grant-1',
@@ -209,6 +209,18 @@ describe('tool broker guard rails', () => {
     await expect(callTool({ grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {} })).resolves.toBeTruthy();
     await expect(callTool({ grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {} })).resolves.toBeTruthy();
     await expect(callTool({ grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {} })).rejects.toMatchObject({ code: 'budget_exhausted' });
+  });
+
+  it('draws down a parent budget before the child budget', async () => {
+    const parent = seatGrant({ grantId: 'root-grant', budget: { calls: 10 } });
+    const child = seatGrant({ grantId: 'child-grant', parentGrantId: 'root-grant', budget: { calls: 3 }, tools: ['github.list_issues'] });
+    mockRoomGrant.findOne.mockResolvedValue(child);
+    getGrantLineage.mockResolvedValue([child, parent]);
+    await callTool({ grantId: 'child-grant', agentUserId: 'agent-a', tool: 'github.list_issues', args: {} });
+    expect(mockReserveBudgetLineage).toHaveBeenCalledWith([
+      { grantId: 'root-grant', calls: 10, windowMs: undefined },
+      { grantId: 'child-grant', calls: 3, windowMs: undefined },
+    ]);
   });
 
   it('parks irreversible writes for approval without spending budget', async () => {

--- a/backend/__tests__/unit/services/toolBrokerService.test.js
+++ b/backend/__tests__/unit/services/toolBrokerService.test.js
@@ -1,5 +1,6 @@
 const mockRoomGrant = { findOne: jest.fn() };
 const mockPod = { findById: jest.fn() };
+const mockIntegration = { findOne: jest.fn(), findById: jest.fn() };
 const mockToolCall = { create: jest.fn() };
 const mockGithub = {
   listOpenIssues: jest.fn(),
@@ -7,16 +8,17 @@ const mockGithub = {
   addIssueComment: jest.fn(),
   closeIssue: jest.fn(),
 };
-const mockReserveBudget = jest.fn();
+const mockReserveBudgetLineage = jest.fn();
 
 jest.mock('../../../models/RoomGrant', () => ({ __esModule: true, default: mockRoomGrant }));
 jest.mock('../../../models/Pod', () => ({ __esModule: true, default: mockPod }));
+jest.mock('../../../models/Integration', () => ({ __esModule: true, default: mockIntegration }));
 jest.mock('../../../models/ToolCall', () => ({
   __esModule: true,
   default: mockToolCall,
   // eslint-disable-next-line global-require
   digestArgs: (args) => require('crypto').createHash('sha256').update(JSON.stringify(args || {})).digest('hex'),
-  reserveBudget: mockReserveBudget,
+  reserveBudgetLineage: mockReserveBudgetLineage,
 }));
 jest.mock('../../../services/githubAppService', () => mockGithub);
 jest.mock('../../../services/roomGrantService', () => {
@@ -30,8 +32,12 @@ jest.mock('../../../services/roomGrantService', () => {
   return {
     RoomGrantError: MockRoomGrantError,
     assertGrantUsable: jest.fn(async (options) => {
+      if (options.grant.revokedAt) throw new MockRoomGrantError('grant_revoked', 'grant revoked', 403);
       if (!options.currentMemberIds.includes(options.agentUserId)) {
         throw new MockRoomGrantError('not_in_audience', 'agent is not in the grant audience', 403);
+      }
+      if (!(options.grant.tools || []).includes(options.tool)) {
+        throw new MockRoomGrantError('tool_not_allowed', 'tool not allowed', 403);
       }
       const rank = { read: 0, 'write-with-confirm': 1, write: 2 };
       if (rank[options.requiredWriteMode] > rank[options.grant.writeMode]) {
@@ -39,6 +45,7 @@ jest.mock('../../../services/roomGrantService', () => {
       }
       return options.grant;
     }),
+    getGrantLineage: jest.fn(async (grant) => [grant]),
   };
 });
 
@@ -53,6 +60,7 @@ const seatGrant = (overrides = {}) => ({
   target: { kind: 'seat', id: 'agent-a' },
   tools: ['github.create_issue'],
   writeMode: 'read',
+  connectionId: 'connection-1',
   audience: ['agent-a'],
   expiresAt: new Date(Date.now() + 60000),
   ...overrides,
@@ -61,6 +69,12 @@ const seatGrant = (overrides = {}) => ({
 beforeEach(() => {
   jest.clearAllMocks();
   mockToolCall.create.mockResolvedValue(undefined);
+  mockIntegration.findOne.mockResolvedValue({
+    type: 'github-app', status: 'connected',
+    config: { installationId: 'gh-install-1', owner: 'Team-Commonly', repo: 'commonly' },
+  });
+  mockIntegration.findById.mockResolvedValue(null);
+  mockReserveBudgetLineage.mockResolvedValue(true);
   mockGithub.listOpenIssues.mockResolvedValue([]);
   mockGithub.createIssue.mockResolvedValue({
     number: 1,
@@ -84,6 +98,18 @@ describe('tool broker guard rails', () => {
       reason: 'write_mode_not_allowed',
       agentUserId: 'agent-a',
     }));
+  });
+
+  it('refuses a grant whose connection is not a connected GitHub App row', async () => {
+    mockRoomGrant.findOne.mockResolvedValue(seatGrant({ tools: ['github.list_issues'] }));
+    mockIntegration.findOne.mockResolvedValue({
+      type: 'github-app', status: 'disconnected',
+      config: { installationId: 'gh-install-1', owner: 'attacker', repo: 'repo' },
+    });
+    await expect(callTool({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {},
+    })).rejects.toMatchObject({ code: 'connection_mismatch' });
+    expect(mockGithub.listOpenIssues).not.toHaveBeenCalled();
   });
 
   it('loads pod membership fresh for every grant usability assertion', async () => {
@@ -115,5 +141,85 @@ describe('tool broker guard rails', () => {
       .rejects.toMatchObject({ code: 'not_in_audience' });
     expect(mockPod.findById).toHaveBeenCalledTimes(2);
     expect(assertGrantUsable).toHaveBeenCalledTimes(2);
+  });
+
+  it('writes one trail row with token identity when the body names another agent', async () => {
+    const grant = seatGrant({ tools: ['github.create_issue'], writeMode: 'write' });
+    mockRoomGrant.findOne.mockResolvedValue(grant);
+    await callTool({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.create_issue',
+      args: { title: 'x', agentUserId: 'agent-b' },
+    }).catch(() => {});
+    expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({
+      agentUserId: 'agent-a',
+      outcome: 'refused',
+      reason: 'invalid_tool_args',
+    }));
+  });
+
+  it('refuses a tool outside the allow-list and records the refusal', async () => {
+    mockRoomGrant.findOne.mockResolvedValue(seatGrant({ tools: ['github.get_issue'] }));
+    await expect(callTool({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {},
+    })).rejects.toMatchObject({ code: 'tool_not_allowed' });
+    expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: 'refused', reason: 'tool_not_allowed', agentUserId: 'agent-a',
+    }));
+  });
+
+  it('refuses an agent outside the effective audience', async () => {
+    const grant = seatGrant({
+      grantId: 'pod-grant', target: { kind: 'pod', id: 'pod-1' }, tools: ['github.list_issues'],
+    });
+    mockRoomGrant.findOne.mockResolvedValue(grant);
+    mockPod.findById.mockImplementation(() => ({
+      select: () => ({ lean: async () => ({ members: ['agent-b'] }) }),
+    }));
+    await expect(callTool({
+      grantId: 'pod-grant', agentUserId: 'agent-a', tool: 'github.list_issues', args: {},
+    })).rejects.toMatchObject({ code: 'not_in_audience' });
+  });
+
+  it('refuses after revoke without a process restart', async () => {
+    mockRoomGrant.findOne.mockResolvedValue(seatGrant({ revokedAt: new Date() }));
+    await expect(callTool({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {},
+    })).rejects.toMatchObject({ code: 'grant_revoked' });
+    expect(mockGithub.listOpenIssues).not.toHaveBeenCalled();
+  });
+
+  it('never returns a provider credential in any tool result', async () => {
+    mockRoomGrant.findOne.mockResolvedValue(seatGrant({ tools: ['github.list_issues'] }));
+    mockGithub.listOpenIssues.mockResolvedValue([{
+      number: 1, title: 'safe', html_url: 'https://github.com/x/y/1', body: '', access_token: 'credential',
+    }]);
+    const response = await callTool({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {},
+    });
+    expect(JSON.stringify(response.result)).not.toContain('credential');
+  });
+
+  it('allows calls: 3 three times and refuses the fourth', async () => {
+    const grant = seatGrant({ tools: ['github.list_issues'], budget: { calls: 3 } });
+    mockRoomGrant.findOne.mockResolvedValue(grant);
+    mockReserveBudgetLineage
+      .mockResolvedValueOnce(true).mockResolvedValueOnce(true).mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    await expect(callTool({ grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {} })).resolves.toBeTruthy();
+    await expect(callTool({ grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {} })).resolves.toBeTruthy();
+    await expect(callTool({ grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {} })).resolves.toBeTruthy();
+    await expect(callTool({ grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.list_issues', args: {} })).rejects.toMatchObject({ code: 'budget_exhausted' });
+  });
+
+  it('parks irreversible writes for approval without spending budget', async () => {
+    mockRoomGrant.findOne.mockResolvedValue(seatGrant({
+      tools: ['github.create_issue'], writeMode: 'write-with-confirm', budget: { calls: 1 },
+    }));
+    await expect(callTool({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.create_issue', args: { title: 'needs approval' },
+    })).rejects.toMatchObject({ code: 'approval_required' });
+    expect(mockReserveBudgetLineage).not.toHaveBeenCalled();
+    expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'pending_approval', reason: 'approval_required' }));
+    expect(mockGithub.createIssue).not.toHaveBeenCalled();
   });
 });

--- a/backend/__tests__/unit/services/toolBrokerService.test.js
+++ b/backend/__tests__/unit/services/toolBrokerService.test.js
@@ -1,0 +1,119 @@
+const mockRoomGrant = { findOne: jest.fn() };
+const mockPod = { findById: jest.fn() };
+const mockToolCall = { create: jest.fn() };
+const mockGithub = {
+  listOpenIssues: jest.fn(),
+  createIssue: jest.fn(),
+  addIssueComment: jest.fn(),
+  closeIssue: jest.fn(),
+};
+const mockReserveBudget = jest.fn();
+
+jest.mock('../../../models/RoomGrant', () => ({ __esModule: true, default: mockRoomGrant }));
+jest.mock('../../../models/Pod', () => ({ __esModule: true, default: mockPod }));
+jest.mock('../../../models/ToolCall', () => ({
+  __esModule: true,
+  default: mockToolCall,
+  // eslint-disable-next-line global-require
+  digestArgs: (args) => require('crypto').createHash('sha256').update(JSON.stringify(args || {})).digest('hex'),
+  reserveBudget: mockReserveBudget,
+}));
+jest.mock('../../../services/githubAppService', () => mockGithub);
+jest.mock('../../../services/roomGrantService', () => {
+  class MockRoomGrantError extends Error {
+    constructor(code, message, statusCode = 400) {
+      super(message);
+      this.code = code;
+      this.statusCode = statusCode;
+    }
+  }
+  return {
+    RoomGrantError: MockRoomGrantError,
+    assertGrantUsable: jest.fn(async (options) => {
+      if (!options.currentMemberIds.includes(options.agentUserId)) {
+        throw new MockRoomGrantError('not_in_audience', 'agent is not in the grant audience', 403);
+      }
+      const rank = { read: 0, 'write-with-confirm': 1, write: 2 };
+      if (rank[options.requiredWriteMode] > rank[options.grant.writeMode]) {
+        throw new MockRoomGrantError('write_mode_not_allowed', 'write mode is too weak', 403);
+      }
+      return options.grant;
+    }),
+  };
+});
+
+// eslint-disable-next-line import/no-unresolved, import/extensions
+const { callTool } = require('../../../services/toolBrokerService');
+// eslint-disable-next-line import/no-unresolved, import/extensions
+const { assertGrantUsable } = require('../../../services/roomGrantService');
+
+const seatGrant = (overrides = {}) => ({
+  grantId: 'grant-1',
+  installationId: 'install-1',
+  target: { kind: 'seat', id: 'agent-a' },
+  tools: ['github.create_issue'],
+  writeMode: 'read',
+  audience: ['agent-a'],
+  expiresAt: new Date(Date.now() + 60000),
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockToolCall.create.mockResolvedValue(undefined);
+  mockGithub.listOpenIssues.mockResolvedValue([]);
+  mockGithub.createIssue.mockResolvedValue({
+    number: 1,
+    title: 'test',
+    html_url: 'https://github.com/Team-Commonly/commonly/issues/1',
+  });
+});
+
+describe('tool broker guard rails', () => {
+  it('takes required write mode from the server tool definition, never request input', async () => {
+    mockRoomGrant.findOne.mockResolvedValue(seatGrant());
+    await expect(callTool({
+      grantId: 'grant-1',
+      agentUserId: 'agent-a',
+      tool: 'github.create_issue',
+      args: { title: 'nope', writeMode: 'write' },
+    })).rejects.toMatchObject({ code: 'write_mode_not_allowed' });
+    expect(mockGithub.createIssue).not.toHaveBeenCalled();
+    expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: 'refused',
+      reason: 'write_mode_not_allowed',
+      agentUserId: 'agent-a',
+    }));
+  });
+
+  it('loads pod membership fresh for every grant usability assertion', async () => {
+    const grant = seatGrant({
+      grantId: 'pod-grant',
+      target: { kind: 'pod', id: 'pod-1' },
+      tools: ['github.list_issues'],
+      writeMode: 'read',
+      audience: ['agent-a'],
+    });
+    mockRoomGrant.findOne.mockResolvedValue(grant);
+    let lookup = 0;
+    mockPod.findById.mockImplementation(() => ({
+      select: () => ({
+        lean: async () => {
+          lookup += 1;
+          return { members: lookup === 1 ? ['agent-a'] : ['agent-b'] };
+        },
+      }),
+    }));
+
+    await expect(callTool({
+      grantId: 'pod-grant', agentUserId: 'agent-a', tool: 'github.list_issues', args: {},
+    }))
+      .resolves.toEqual(expect.objectContaining({ result: { issues: [] } }));
+    await expect(callTool({
+      grantId: 'pod-grant', agentUserId: 'agent-a', tool: 'github.list_issues', args: {},
+    }))
+      .rejects.toMatchObject({ code: 'not_in_audience' });
+    expect(mockPod.findById).toHaveBeenCalledTimes(2);
+    expect(assertGrantUsable).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/config/schema.sql
+++ b/backend/config/schema.sql
@@ -158,6 +158,33 @@ CREATE TABLE IF NOT EXISTS message_reactions (
   UNIQUE (message_id, user_id, emoji)
 );
 CREATE INDEX IF NOT EXISTS idx_message_reactions_message_id ON message_reactions(message_id);
+
+-- Room-grant broker audit and budget ledger. The budget counter is separate
+-- from Mongo's grant document so every reservation is a single Postgres
+-- conditional write; concurrent broker calls cannot read the same remaining
+-- slot and both spend it. `window_started_at` is retained for windowed caps;
+-- a NULL window on the grant is represented by a lifetime counter here.
+CREATE TABLE IF NOT EXISTS tool_call_budgets (
+  grant_id VARCHAR(255) PRIMARY KEY,
+  calls_used INTEGER NOT NULL DEFAULT 0,
+  window_started_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS tool_calls (
+  call_id VARCHAR(255) PRIMARY KEY,
+  grant_id VARCHAR(255) NOT NULL,
+  pod_id VARCHAR(255),
+  installation_id VARCHAR(255),
+  agent_user_id VARCHAR(255) NOT NULL,
+  tool VARCHAR(255) NOT NULL,
+  args_digest CHAR(64) NOT NULL,
+  occurred_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  outcome VARCHAR(32) NOT NULL CHECK (outcome IN ('ok', 'refused', 'pending_approval', 'failed')),
+  reason VARCHAR(255),
+  approval_id VARCHAR(255),
+  duration_ms INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_grant_at ON tool_calls(grant_id, occurred_at DESC);
 -- Per-user, per-thread state (W-T, TASK-029). ONE record carrying both
 -- booleans, per ux-lead's ruling in docs/design/threading-surface-ruling.md
 -- ("One state record, two booleans"): persisted collapse and follow share the

--- a/backend/models/Integration.ts
+++ b/backend/models/Integration.ts
@@ -8,7 +8,8 @@ export type IntegrationType =
   | 'groupme'
   | 'whatsapp'
   | 'x'
-  | 'instagram';
+  | 'instagram'
+  | 'github-app';
 
 export type IntegrationStatus = 'connected' | 'disconnected' | 'error' | 'pending';
 export type IntegrationScope = 'pod' | 'user';
@@ -61,6 +62,10 @@ export interface IIntegration extends Document {
   type: IntegrationType;
   status: IntegrationStatus;
   config: {
+    /** GitHub App installation connection (server-owned, no credential). */
+    installationId?: string;
+    owner?: string;
+    repo?: string;
     serverId?: string;
     serverName?: string;
     channelId?: string;
@@ -183,7 +188,7 @@ const IntegrationSchema = new Schema<IIntegration>(
     type: {
       type: String,
       required: true,
-      enum: ['discord', 'telegram', 'slack', 'messenger', 'groupme', 'whatsapp', 'x', 'instagram'],
+      enum: ['discord', 'telegram', 'slack', 'messenger', 'groupme', 'whatsapp', 'x', 'instagram', 'github-app'],
       default: 'discord',
     },
     status: {
@@ -193,6 +198,9 @@ const IntegrationSchema = new Schema<IIntegration>(
       default: 'pending',
     },
     config: {
+      installationId: String,
+      owner: String,
+      repo: String,
       serverId: String,
       serverName: String,
       channelId: String,

--- a/backend/models/ToolCall.ts
+++ b/backend/models/ToolCall.ts
@@ -1,0 +1,205 @@
+import { createHash } from 'crypto';
+
+interface PgResult {
+  rows: Array<Record<string, unknown>>;
+  rowCount?: number;
+}
+
+interface PgPool {
+  query: (sql: string, params?: unknown[]) => Promise<PgResult>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { pool } = require('../config/db-pg') as { pool: PgPool | null };
+
+export type ToolCallOutcome = 'ok' | 'refused' | 'pending_approval' | 'failed';
+
+export interface ToolCallRecord {
+  callId: string;
+  grantId: string;
+  podId?: string;
+  installationId?: string;
+  agentUserId: string;
+  tool: string;
+  argsDigest: string;
+  at?: Date;
+  outcome: ToolCallOutcome;
+  reason?: string;
+  approvalId?: string;
+  durationMs?: number;
+}
+
+const DDL = `
+CREATE TABLE IF NOT EXISTS tool_call_budgets (
+  grant_id VARCHAR(255) PRIMARY KEY,
+  calls_used INTEGER NOT NULL DEFAULT 0,
+  window_started_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS tool_calls (
+  call_id VARCHAR(255) PRIMARY KEY,
+  grant_id VARCHAR(255) NOT NULL,
+  pod_id VARCHAR(255),
+  installation_id VARCHAR(255),
+  agent_user_id VARCHAR(255) NOT NULL,
+  tool VARCHAR(255) NOT NULL,
+  args_digest CHAR(64) NOT NULL,
+  occurred_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  outcome VARCHAR(32) NOT NULL CHECK (outcome IN ('ok', 'refused', 'pending_approval', 'failed')),
+  reason VARCHAR(255),
+  approval_id VARCHAR(255),
+  duration_ms INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_grant_at ON tool_calls(grant_id, occurred_at DESC);
+`;
+
+let ensured = false;
+let ensureInFlight: Promise<PgPool> | null = null;
+
+const ensurePool = (): PgPool => {
+  if (!pool) throw new Error('tool broker requires PostgreSQL');
+  return pool;
+};
+
+const ensureTables = async (): Promise<PgPool> => {
+  const db = ensurePool();
+  if (ensured) return db;
+  if (!ensureInFlight) {
+    ensureInFlight = db.query(DDL)
+      .then(() => {
+        ensured = true;
+        return db;
+      })
+      .finally(() => {
+        ensureInFlight = null;
+      });
+  }
+  return ensureInFlight;
+};
+
+const stableJson = (value: unknown): string => {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value as Record<string, unknown>).sort().map((key) => (
+      `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`
+    )).join(',')}}`;
+  }
+  return JSON.stringify(value) || 'null';
+};
+
+/** Stable digest used in the audit trail; request arguments are never stored. */
+export const digestArgs = (args: unknown): string => createHash('sha256')
+  .update(stableJson(args === undefined ? {} : args))
+  .digest('hex');
+
+/**
+ * Atomically reserve one call against a grant budget. The INSERT/ON CONFLICT
+ * statement takes the row lock and only returns a row when a slot was spent.
+ * This is deliberately one conditional write rather than a read followed by
+ * an increment, so concurrent calls cannot both consume the final slot.
+ */
+export const reserveBudget = async (
+  grantId: string,
+  calls: number,
+  windowMs?: number,
+): Promise<boolean> => {
+  if (!Number.isInteger(calls) || calls < 0) return false;
+  if (calls === 0) return false;
+  const db = await ensureTables();
+
+  if (windowMs === undefined) {
+    const result = await db.query(
+      `INSERT INTO tool_call_budgets (grant_id, calls_used, window_started_at)
+       VALUES ($1, 1, CURRENT_TIMESTAMP)
+       ON CONFLICT (grant_id) DO UPDATE
+         SET calls_used = tool_call_budgets.calls_used + 1
+       WHERE tool_call_budgets.calls_used < $2
+       RETURNING calls_used`,
+      [grantId, calls],
+    );
+    return result.rows.length > 0;
+  }
+
+  if (!Number.isInteger(windowMs) || windowMs < 1) return false;
+  const result = await db.query(
+    `INSERT INTO tool_call_budgets (grant_id, calls_used, window_started_at)
+     VALUES ($1, 1, CURRENT_TIMESTAMP)
+     ON CONFLICT (grant_id) DO UPDATE
+       SET calls_used = CASE
+         WHEN CURRENT_TIMESTAMP >= tool_call_budgets.window_started_at
+              + ($3::double precision * INTERVAL '1 millisecond') THEN 1
+         ELSE tool_call_budgets.calls_used + 1
+       END,
+       window_started_at = CASE
+         WHEN CURRENT_TIMESTAMP >= tool_call_budgets.window_started_at
+              + ($3::double precision * INTERVAL '1 millisecond') THEN CURRENT_TIMESTAMP
+         ELSE tool_call_budgets.window_started_at
+       END
+     WHERE CURRENT_TIMESTAMP >= tool_call_budgets.window_started_at
+           + ($3::double precision * INTERVAL '1 millisecond')
+        OR tool_call_budgets.calls_used < $2
+     RETURNING calls_used`,
+    [grantId, calls, windowMs],
+  );
+  return result.rows.length > 0;
+};
+
+class ToolCall {
+  static async create(record: ToolCallRecord): Promise<void> {
+    const db = await ensureTables();
+    await db.query(
+      `INSERT INTO tool_calls
+       (call_id, grant_id, pod_id, installation_id, agent_user_id, tool,
+        args_digest, occurred_at, outcome, reason, approval_id, duration_ms)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      [
+        record.callId,
+        record.grantId,
+        record.podId || null,
+        record.installationId || null,
+        record.agentUserId,
+        record.tool,
+        record.argsDigest,
+        record.at || new Date(),
+        record.outcome,
+        record.reason || null,
+        record.approvalId || null,
+        record.durationMs ?? null,
+      ],
+    );
+  }
+
+  static async listForGrant(grantId: string, limit = 100): Promise<ToolCallRecord[]> {
+    const db = await ensureTables();
+    const result = await db.query(
+      `SELECT call_id, grant_id, pod_id, installation_id, agent_user_id,
+              tool, args_digest, occurred_at, outcome, reason, approval_id,
+              duration_ms
+       FROM tool_calls WHERE grant_id = $1
+       ORDER BY occurred_at DESC LIMIT $2`,
+      [grantId, Math.max(1, Math.min(500, Math.trunc(limit)))],
+    );
+    return result.rows.map((row) => ({
+      callId: String(row.call_id),
+      grantId: String(row.grant_id),
+      podId: row.pod_id ? String(row.pod_id) : undefined,
+      installationId: row.installation_id ? String(row.installation_id) : undefined,
+      agentUserId: String(row.agent_user_id),
+      tool: String(row.tool),
+      argsDigest: String(row.args_digest),
+      at: new Date(String(row.occurred_at)),
+      outcome: String(row.outcome) as ToolCallOutcome,
+      reason: row.reason ? String(row.reason) : undefined,
+      approvalId: row.approval_id ? String(row.approval_id) : undefined,
+      durationMs: row.duration_ms === null || row.duration_ms === undefined
+        ? undefined : Number(row.duration_ms),
+    }));
+  }
+}
+
+export { ToolCall };
+export default ToolCall;
+
+// CJS compat: let require() return the default export directly.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"];
+Object.assign(module.exports, exports);

--- a/backend/models/ToolCall.ts
+++ b/backend/models/ToolCall.ts
@@ -5,8 +5,14 @@ interface PgResult {
   rowCount?: number;
 }
 
+interface PgClient {
+  query: (sql: string, params?: unknown[]) => Promise<PgResult>;
+  release: () => void;
+}
+
 interface PgPool {
   query: (sql: string, params?: unknown[]) => Promise<PgResult>;
+  connect: () => Promise<PgClient>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -97,17 +103,15 @@ export const digestArgs = (args: unknown): string => createHash('sha256')
  * This is deliberately one conditional write rather than a read followed by
  * an increment, so concurrent calls cannot both consume the final slot.
  */
-export const reserveBudget = async (
+const reserveOne = async (
+  client: PgClient,
   grantId: string,
   calls: number,
   windowMs?: number,
 ): Promise<boolean> => {
-  if (!Number.isInteger(calls) || calls < 0) return false;
-  if (calls === 0) return false;
-  const db = await ensureTables();
-
+  if (!Number.isInteger(calls) || calls <= 0) return false;
   if (windowMs === undefined) {
-    const result = await db.query(
+    const result = await client.query(
       `INSERT INTO tool_call_budgets (grant_id, calls_used, window_started_at)
        VALUES ($1, 1, CURRENT_TIMESTAMP)
        ON CONFLICT (grant_id) DO UPDATE
@@ -118,9 +122,8 @@ export const reserveBudget = async (
     );
     return result.rows.length > 0;
   }
-
   if (!Number.isInteger(windowMs) || windowMs < 1) return false;
-  const result = await db.query(
+  const result = await client.query(
     `INSERT INTO tool_call_budgets (grant_id, calls_used, window_started_at)
      VALUES ($1, 1, CURRENT_TIMESTAMP)
      ON CONFLICT (grant_id) DO UPDATE
@@ -142,6 +145,39 @@ export const reserveBudget = async (
   );
   return result.rows.length > 0;
 };
+
+/** Reserve one slot on every grant in a lineage in one transaction. A child
+ * therefore consumes both its own cap and each ancestor cap; if any row is
+ * exhausted, the transaction rolls back all earlier reservations. */
+export const reserveBudgetLineage = async (
+  entries: Array<{ grantId: string; calls: number; windowMs?: number }>,
+): Promise<boolean> => {
+  if (entries.length === 0) return true;
+  const db = await ensureTables();
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    for (const entry of entries) {
+      if (!await reserveOne(client, entry.grantId, entry.calls, entry.windowMs)) {
+        await client.query('ROLLBACK');
+        return false;
+      }
+    }
+    await client.query('COMMIT');
+    return true;
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const reserveBudget = async (
+  grantId: string,
+  calls: number,
+  windowMs?: number,
+): Promise<boolean> => reserveBudgetLineage([{ grantId, calls, windowMs }]);
 
 class ToolCall {
   static async create(record: ToolCallRecord): Promise<void> {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/secret-manager": "^6.1.1",
         "@google/generative-ai": "^0.2.1",
         "@kubernetes/client-node": "^0.21.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@sendgrid/mail": "^7.7.0",
         "@sentry/node": "^10.65.0",
         "@socket.io/redis-adapter": "^8.3.0",
@@ -983,6 +984,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1610,6 +1623,476 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.2.0",
@@ -3296,6 +3779,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -5474,6 +5996,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -5635,6 +6178,22 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -6536,6 +7095,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7076,6 +7644,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -8021,6 +8595,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify": {
       "version": "1.2.1",
@@ -9782,6 +10362,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -10219,6 +10808,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
@@ -10354,6 +10952,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/run-parallel": {
@@ -10598,12 +11245,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -10615,11 +11264,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12363,6 +13014,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   },
   "dependencies": {
@@ -13015,6 +13684,12 @@
         "yargs": "^17.7.2"
       }
     },
+    "@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "requires": {}
+    },
     "@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -13480,6 +14155,290 @@
           "version": "6.21.0",
           "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
           "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+        }
+      }
+    },
+    "@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "requires": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+          "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+          "requires": {
+            "mime-types": "^3.0.0",
+            "negotiator": "^1.0.0"
+          }
+        },
+        "ajv": {
+          "version": "8.20.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+          "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2"
+          }
+        },
+        "body-parser": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+          "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+          "requires": {
+            "bytes": "^3.1.2",
+            "content-type": "^2.0.0",
+            "debug": "^4.4.3",
+            "http-errors": "^2.0.1",
+            "iconv-lite": "^0.7.2",
+            "on-finished": "^2.4.1",
+            "qs": "^6.15.2",
+            "raw-body": "^3.0.2",
+            "type-is": "^2.1.0"
+          },
+          "dependencies": {
+            "content-type": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+              "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="
+            }
+          }
+        },
+        "content-disposition": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+          "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
+        },
+        "cookie-signature": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+          "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+        },
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "express": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+          "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+          "requires": {
+            "accepts": "^2.0.0",
+            "body-parser": "^2.2.1",
+            "content-disposition": "^1.0.0",
+            "content-type": "^1.0.5",
+            "cookie": "^0.7.1",
+            "cookie-signature": "^1.2.1",
+            "debug": "^4.4.0",
+            "depd": "^2.0.0",
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "etag": "^1.8.1",
+            "finalhandler": "^2.1.0",
+            "fresh": "^2.0.0",
+            "http-errors": "^2.0.0",
+            "merge-descriptors": "^2.0.0",
+            "mime-types": "^3.0.0",
+            "on-finished": "^2.4.1",
+            "once": "^1.4.0",
+            "parseurl": "^1.3.3",
+            "proxy-addr": "^2.0.7",
+            "qs": "^6.14.0",
+            "range-parser": "^1.2.1",
+            "router": "^2.2.0",
+            "send": "^1.1.0",
+            "serve-static": "^2.2.0",
+            "statuses": "^2.0.1",
+            "type-is": "^2.0.1",
+            "vary": "^1.1.2"
+          }
+        },
+        "finalhandler": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+          "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+          "requires": {
+            "debug": "^4.4.0",
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "on-finished": "^2.4.1",
+            "parseurl": "^1.3.3",
+            "statuses": "^2.0.1"
+          }
+        },
+        "fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+          "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+        },
+        "http-errors": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+          "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+          "requires": {
+            "depd": "~2.0.0",
+            "inherits": "~2.0.4",
+            "setprototypeof": "~1.2.0",
+            "statuses": "~2.0.2",
+            "toidentifier": "~1.0.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+          "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "jose": {
+          "version": "6.2.12",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+          "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw=="
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "media-typer": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+          "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="
+        },
+        "merge-descriptors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+          "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
+        },
+        "mime-db": {
+          "version": "1.54.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+          "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+        },
+        "mime-types": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+          "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+          "requires": {
+            "mime-db": "^1.54.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "negotiator": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+          "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+          "requires": {
+            "content-type": "^2.1.0"
+          },
+          "dependencies": {
+            "content-type": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+              "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="
+            }
+          }
+        },
+        "qs": {
+          "version": "6.16.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+          "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+          "requires": {
+            "es-define-property": "^1.0.1",
+            "side-channel": "^1.1.1"
+          }
+        },
+        "raw-body": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+          "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+          "requires": {
+            "bytes": "~3.1.2",
+            "http-errors": "~2.0.1",
+            "iconv-lite": "~0.7.0",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "send": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+          "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+          "requires": {
+            "debug": "^4.4.3",
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "etag": "^1.8.1",
+            "fresh": "^2.0.0",
+            "http-errors": "^2.0.1",
+            "mime-types": "^3.0.2",
+            "ms": "^2.1.3",
+            "on-finished": "^2.4.1",
+            "range-parser": "^1.2.1",
+            "statuses": "^2.0.2"
+          }
+        },
+        "serve-static": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+          "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+          "requires": {
+            "encodeurl": "^2.0.0",
+            "escape-html": "^1.0.3",
+            "parseurl": "^1.3.3",
+            "send": "^1.2.0"
+          }
+        },
+        "statuses": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+          "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
+        },
+        "type-is": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+          "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+          "requires": {
+            "content-type": "^2.0.0",
+            "media-typer": "^1.1.0",
+            "mime-types": "^3.0.0"
+          },
+          "dependencies": {
+            "content-type": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+              "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="
+            }
+          }
         }
       }
     },
@@ -14702,6 +15661,32 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.20.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+          "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
       }
     },
     "ansi-escapes": {
@@ -16240,6 +17225,19 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
+    "eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "requires": {
+        "eventsource-parser": "^3.0.1"
+      }
+    },
+    "eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -16364,6 +17362,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="
     },
     "fastq": {
       "version": "1.19.1",
@@ -16954,6 +17957,11 @@
       "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
     },
+    "hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ=="
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -17318,6 +18326,11 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
+    },
+    "is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "is-regex": {
       "version": "1.2.1",
@@ -18019,6 +19032,11 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "json-stable-stringify": {
       "version": "1.2.1",
@@ -19191,6 +20209,11 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "dev": true
     },
+    "pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
+    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -19492,6 +20515,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "require-in-the-middle": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
@@ -19581,6 +20609,38 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "requires": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "path-to-regexp": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+          "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
+        }
       }
     },
     "run-parallel": {
@@ -19747,20 +20807,24 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "side-channel": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "requires": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       }
     },
     "side-channel-list": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "requires": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       }
     },
     "side-channel-map": {
@@ -20911,6 +21975,17 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    },
+    "zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "requires": {}
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "@google-cloud/secret-manager": "^6.1.1",
     "@google/generative-ai": "^0.2.1",
     "@kubernetes/client-node": "^0.21.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@sendgrid/mail": "^7.7.0",
     "@sentry/node": "^10.65.0",
     "@socket.io/redis-adapter": "^8.3.0",

--- a/backend/routes/grants.ts
+++ b/backend/routes/grants.ts
@@ -94,6 +94,9 @@ router.post('/', grantRateLimit, auth, async (req: AuthenticatedRequest, res: ex
     const connection = await findConnection(connectionId);
     if (!connection) return res.status(404).json({ error: 'connection_not_found' });
     if (connectionOwnerId(connection) !== userId) return res.status(403).json({ error: 'access_denied' });
+    if (connection.type !== 'github-app' || connection.status !== 'connected' || connection.revokedAt) {
+      return res.status(403).json({ error: 'connection_mismatch', message: 'connection is not a connected GitHub App installation' });
+    }
 
     const target = body.target;
     if (!target || (target.kind !== 'pod' && target.kind !== 'seat')) {

--- a/backend/routes/integrations.ts
+++ b/backend/routes/integrations.ts
@@ -194,7 +194,7 @@ router.get('/catalog', auth, async (req: AuthReq, res: Res) => {
 // GitHub App installations are administrator-owned user-scope connections.
 // They intentionally do not pass through the pod-member connector route: a
 // member must never be able to bind the broker to Commonly's App credential.
-router.post('/github-app', auth, adminAuth, async (req: AuthReq, res: Res) => {
+router.post('/github-app', writeIntegrationsRateLimit, auth, adminAuth, async (req: AuthReq, res: Res) => {
   try {
     const body = (req.body || {}) as { installationId?: unknown; owner?: unknown; repo?: unknown };
     const installationId = String(body.installationId || '').trim();

--- a/backend/routes/integrations.ts
+++ b/backend/routes/integrations.ts
@@ -45,6 +45,9 @@ import {
 // caller name someone else as the author or bind a chat without a code.
 const SERVER_OWNED_CONFIG_KEYS = [
   'linkedUserId', 'connectCode', 'connectCodeExpiresAt', 'chatId', 'chatType', 'chatTitle',
+  // GitHub App connection identity is administrator-owned. A member may not
+  // retarget an existing row that a grant already references.
+  'installationId', 'owner', 'repo',
   // OAuth callback and connectorSecrets own Slack identity and its opaque
   // credential reference. Accepting either from a browser body defeats D6.
   'botTokenRef', 'teamId', 'teamName', 'slackUserId', 'slackUserName', 'pendingBind',
@@ -205,13 +208,12 @@ router.post('/github-app', writeIntegrationsRateLimit, auth, adminAuth, async (r
     }
     const existing = await Integration.findOne({ type: 'github-app', installationId });
     if (existing) {
-      existing.scope = 'user';
-      existing.status = 'connected';
-      existing.podId = undefined;
-      existing.config = { ...(existing.config || {}), installationId, owner, repo };
-      existing.createdBy = req.user?.id as unknown as typeof existing.createdBy;
-      existing.isActive = true;
-      await existing.save();
+      const current = existing.config || {};
+      if (String(current.owner || '') !== owner || String(current.repo || '') !== repo) {
+        return res.status(409).json({ message: 'installationId is already bound to a different repository' });
+      }
+      // Connection rows are immutable in this cut. In particular, do not
+      // reassign createdBy or revive/retarget grants on a repeated POST.
       return res.json({ integration: existing });
     }
     const integration = new Integration({
@@ -332,6 +334,7 @@ router.post('/', writeIntegrationsRateLimit, auth, async (req: AuthReq, res: Res
   try {
     const { podId, type, config } = (req.body || {}) as { podId?: string; type?: string; config?: Record<string, unknown> };
     if (!podId || !type || !config) return res.status(400).json({ message: 'Missing required fields' });
+    if (type === 'github-app') return res.status(400).json({ message: 'github-app connections require the administrator route' });
     const manifest = (manifests as Record<string, unknown>)[type];
     if (!manifest) return res.status(400).json({ message: 'Unsupported integration type' });
     if ('linkedUserId' in config && String(config.linkedUserId) !== String(req.user?.id)) {

--- a/backend/routes/integrations.ts
+++ b/backend/routes/integrations.ts
@@ -191,6 +191,46 @@ router.get('/catalog', auth, async (req: AuthReq, res: Res) => {
   }
 });
 
+// GitHub App installations are administrator-owned user-scope connections.
+// They intentionally do not pass through the pod-member connector route: a
+// member must never be able to bind the broker to Commonly's App credential.
+router.post('/github-app', auth, adminAuth, async (req: AuthReq, res: Res) => {
+  try {
+    const body = (req.body || {}) as { installationId?: unknown; owner?: unknown; repo?: unknown };
+    const installationId = String(body.installationId || '').trim();
+    const owner = String(body.owner || '').trim();
+    const repo = String(body.repo || '').trim();
+    if (!installationId || !owner || !repo) {
+      return res.status(400).json({ message: 'installationId, owner, and repo are required' });
+    }
+    const existing = await Integration.findOne({ type: 'github-app', installationId });
+    if (existing) {
+      existing.scope = 'user';
+      existing.status = 'connected';
+      existing.podId = undefined;
+      existing.config = { ...(existing.config || {}), installationId, owner, repo };
+      existing.createdBy = req.user?.id as unknown as typeof existing.createdBy;
+      existing.isActive = true;
+      await existing.save();
+      return res.json({ integration: existing });
+    }
+    const integration = new Integration({
+      installationId,
+      type: 'github-app',
+      scope: 'user',
+      status: 'connected',
+      config: { installationId, owner, repo },
+      createdBy: req.user?.id,
+      isActive: true,
+    });
+    await integration.save();
+    return res.status(201).json({ integration });
+  } catch (error) {
+    console.error('Error creating GitHub App integration:', error);
+    return res.status(500).json({ message: 'Server error' });
+  }
+});
+
 router.post('/ingest', ingestAuth, async (req: AuthReq, res: Res) => {
   try {
     const { provider, integrationId, event, messages } = (req.body || {}) as { provider?: string; integrationId?: string; event?: unknown; messages?: unknown[] };

--- a/backend/routes/mcpGrants.ts
+++ b/backend/routes/mcpGrants.ts
@@ -1,0 +1,103 @@
+import express from 'express';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { getToolDefinitions, callTool } from '../services/toolBrokerService';
+
+// The SDK is CommonJS-compatible, but its package exports use subpath entry
+// points. Requiring them here keeps this route compatible with the backend's
+// ts-node/CommonJS runtime while still using the official Streamable HTTP
+// transport.
+// eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-unresolved, import/extensions
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-unresolved, import/extensions
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-unresolved, import/extensions
+const { ListToolsRequestSchema, CallToolRequestSchema } = require('@modelcontextprotocol/sdk/types.js');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const agentRuntimeAuth = require('../middleware/agentRuntimeAuth');
+
+const router = express.Router();
+
+// The handler authenticates through Mongo, loads pod membership, spends a
+// budget row, and writes an audit row. Bound that work before auth runs so an
+// unauthenticated caller cannot turn the grant endpoint into a database probe.
+const brokerRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req: express.Request): string => (req.ip ? ipKeyGenerator(req.ip) : 'mcp-unknown'),
+  handler: (_req, res) => res.status(429).json({ error: 'rate_limit_exceeded' }),
+});
+
+const errorPayload = (error: unknown): Record<string, unknown> => {
+  const e = error as { code?: string; message?: string; details?: unknown };
+  return {
+    error: e.code || 'broker_error',
+    message: e.message || 'Tool call refused',
+    ...(e.details ? { details: e.details } : {}),
+  };
+};
+
+/**
+ * Stateless MCP endpoint. The bearer agent token authenticates the caller;
+ * the grant id in the URL supplies capabilities. No credential or grant
+ * secret is placed in the MCP tool list or response.
+ */
+router.post('/:grantId', brokerRateLimit, agentRuntimeAuth, async (req: express.Request, res: express.Response) => {
+  const agentUserId = String((req as express.Request & { agentUser?: { _id?: unknown } }).agentUser?._id || '');
+  if (!agentUserId) return res.status(401).json({ error: 'agent_identity_required' });
+
+  const server = new Server(
+    { name: 'commonly-grant-broker', version: '0.1.0' },
+    { capabilities: { tools: {} } },
+  );
+  const definitions = getToolDefinitions();
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: definitions.map((definition) => ({
+      name: definition.name,
+      description: definition.description,
+      inputSchema: definition.inputSchema,
+    })),
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
+    const tool = String(request.params?.name || '');
+    const args = request.params?.arguments || {};
+    try {
+      const result = await callTool({
+        grantId: String(req.params.grantId),
+        agentUserId,
+        tool,
+        args,
+      });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result.result) }],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: JSON.stringify(errorPayload(error)) }],
+      };
+    }
+  });
+
+  // `sessionIdGenerator: undefined` intentionally makes each request
+  // stateless. Grants and audit rows are the durable state; an MCP session
+  // must not become another capability cache that survives revocation.
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    if (!res.headersSent) res.status(500).json({ ...errorPayload(error), error: 'broker_transport_error' });
+    else console.error('[mcp-grants] transport error after response:', error);
+  } finally {
+    await server.close().catch(() => {});
+  }
+});
+
+export default router;
+
+// CJS compat: let require() return the router directly.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"];
+Object.assign(module.exports, exports);

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -238,6 +238,7 @@ app.use('/api/v1/tasks', tasksApiRoutes); // Task management for dev agents
 app.use('/api/registry', registryRoutes); // Agent Registry (package manager for agents)
 app.use('/api/credentials', require('./routes/credentials')); // ADR-026 Phase 0: credential lineage + revocation
 app.use('/api/grants', require('./routes/grants')); // ADR-001 room-grant record: server-enforced attenuation + cascade revocation
+app.use('/api/mcp/grants', require('./routes/mcpGrants')); // ADR-001 tool broker: stateless MCP transport + attributed trail
 app.use('/api/agent-binding', require('./routes/agentBinding')); // ADR-026 D3: machine adoption CAS
 app.use('/api/machines', require('./routes/machines')); // ADR-026 Phase 1: local daemon lifecycle
 app.use('/api/hosted', require('./routes/hosted')); // ADR-023 W2: hosted runtime provision surface (metered)

--- a/backend/services/githubAppService.ts
+++ b/backend/services/githubAppService.ts
@@ -26,6 +26,7 @@ interface ListIssuesOptions {
   repo?: string;
   perPage?: number;
   installationId?: string;
+  forceApp?: boolean;
 }
 
 interface CreateIssueOptions {
@@ -35,6 +36,7 @@ interface CreateIssueOptions {
   body?: string;
   labels?: string[];
   installationId?: string;
+  forceApp?: boolean;
 }
 
 interface IssueCommentOptions {
@@ -43,6 +45,7 @@ interface IssueCommentOptions {
   issueNumber: number;
   body: string;
   installationId?: string;
+  forceApp?: boolean;
 }
 
 interface CloseIssueOptions {
@@ -51,6 +54,7 @@ interface CloseIssueOptions {
   issueNumber: number;
   comment?: string;
   installationId?: string;
+  forceApp?: boolean;
 }
 
 interface IssueNumberOptions {
@@ -58,6 +62,7 @@ interface IssueNumberOptions {
   repo?: string;
   issueNumber: number;
   installationId?: string;
+  forceApp?: boolean;
 }
 
 interface PullRequestOptions {
@@ -65,12 +70,7 @@ interface PullRequestOptions {
   repo?: string;
   pullNumber: number;
   installationId?: string;
-}
-
-interface MergePullRequestOptions extends PullRequestOptions {
-  commitTitle?: string;
-  commitMessage?: string;
-  mergeMethod?: 'merge' | 'squash' | 'rebase';
+  forceApp?: boolean;
 }
 
 type PullReviewEvent = 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
@@ -171,8 +171,8 @@ class GitHubAppService {
   /**
    * Shared headers for GitHub REST API calls (uses PAT or App token).
    */
-  static async _apiHeaders(token?: string, installationId?: string): Promise<Record<string, string>> {
-    const pat = token || process.env.GITHUB_PAT;
+  static async _apiHeaders(token?: string, installationId?: string, forceApp = false): Promise<Record<string, string>> {
+    const pat = forceApp ? undefined : (token || process.env.GITHUB_PAT);
     let credential = pat;
     const appConfigured = !!(
       process.env.GITHUB_APP_ID
@@ -196,8 +196,8 @@ class GitHubAppService {
   /**
    * List open issues for a repo (excludes pull requests).
    */
-  static async listOpenIssues({ owner = 'Team-Commonly', repo = 'commonly', perPage = 20, installationId }: ListIssuesOptions = {}): Promise<GitHubIssue[]> {
-    const headers = await this._apiHeaders(undefined, installationId);
+  static async listOpenIssues({ owner = 'Team-Commonly', repo = 'commonly', perPage = 20, installationId, forceApp }: ListIssuesOptions = {}): Promise<GitHubIssue[]> {
+    const headers = await this._apiHeaders(undefined, installationId, forceApp);
     const res = await axios.get(
       `https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=${perPage}`,
       { headers },
@@ -208,8 +208,8 @@ class GitHubAppService {
   /**
    * Create a new GitHub issue.
    */
-  static async createIssue({ owner = 'Team-Commonly', repo = 'commonly', title, body, labels, installationId }: CreateIssueOptions): Promise<GitHubIssue> {
-    const headers = await this._apiHeaders(undefined, installationId);
+  static async createIssue({ owner = 'Team-Commonly', repo = 'commonly', title, body, labels, installationId, forceApp }: CreateIssueOptions): Promise<GitHubIssue> {
+    const headers = await this._apiHeaders(undefined, installationId, forceApp);
     const payload: Record<string, unknown> = { title };
     if (body) payload.body = body;
     if (labels?.length) payload.labels = labels;
@@ -224,8 +224,8 @@ class GitHubAppService {
   /**
    * Add a comment to an existing issue.
    */
-  static async addIssueComment({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, body, installationId }: IssueCommentOptions): Promise<unknown> {
-    const headers = await this._apiHeaders(undefined, installationId);
+  static async addIssueComment({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, body, installationId, forceApp }: IssueCommentOptions): Promise<unknown> {
+    const headers = await this._apiHeaders(undefined, installationId, forceApp);
     const res = await axios.post(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
       { body },
@@ -237,11 +237,11 @@ class GitHubAppService {
   /**
    * Close an issue (optionally with a final comment).
    */
-  static async closeIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, comment, installationId }: CloseIssueOptions): Promise<unknown> {
+  static async closeIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, comment, installationId, forceApp }: CloseIssueOptions): Promise<unknown> {
     if (comment) {
-      await this.addIssueComment({ owner, repo, issueNumber, body: comment, installationId });
+      await this.addIssueComment({ owner, repo, issueNumber, body: comment, installationId, forceApp });
     }
-    const headers = await this._apiHeaders(undefined, installationId);
+    const headers = await this._apiHeaders(undefined, installationId, forceApp);
     const res = await axios.patch(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
       { state: 'closed' },
@@ -251,8 +251,8 @@ class GitHubAppService {
   }
 
   /** Fetch one issue without exposing the server credential to the caller. */
-  static async getIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, installationId }: IssueNumberOptions): Promise<GitHubIssue> {
-    const headers = await this._apiHeaders(undefined, installationId);
+  static async getIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, installationId, forceApp }: IssueNumberOptions): Promise<GitHubIssue> {
+    const headers = await this._apiHeaders(undefined, installationId, forceApp);
     const res = await axios.get(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
       { headers },
@@ -261,8 +261,8 @@ class GitHubAppService {
   }
 
   /** Fetch one pull request. */
-  static async getPullRequest({ owner = 'Team-Commonly', repo = 'commonly', pullNumber, installationId }: PullRequestOptions): Promise<unknown> {
-    const headers = await this._apiHeaders(undefined, installationId);
+  static async getPullRequest({ owner = 'Team-Commonly', repo = 'commonly', pullNumber, installationId, forceApp }: PullRequestOptions): Promise<unknown> {
+    const headers = await this._apiHeaders(undefined, installationId, forceApp);
     const res = await axios.get(
       `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}`,
       { headers },
@@ -271,32 +271,10 @@ class GitHubAppService {
   }
 
   /** List files changed by one pull request. */
-  static async listPullRequestFiles({ owner = 'Team-Commonly', repo = 'commonly', pullNumber, installationId }: PullRequestOptions): Promise<unknown[]> {
-    const headers = await this._apiHeaders(undefined, installationId);
+  static async listPullRequestFiles({ owner = 'Team-Commonly', repo = 'commonly', pullNumber, installationId, forceApp }: PullRequestOptions): Promise<unknown[]> {
+    const headers = await this._apiHeaders(undefined, installationId, forceApp);
     const res = await axios.get(
       `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/files`,
-      { headers },
-    );
-    return res.data;
-  }
-
-  /** Merge a pull request; callers must satisfy the broker approval gate. */
-  static async mergePullRequest({
-    owner = 'Team-Commonly',
-    repo = 'commonly',
-    pullNumber,
-    commitTitle,
-    commitMessage,
-    mergeMethod = 'squash',
-    installationId,
-  }: MergePullRequestOptions): Promise<unknown> {
-    const headers = await this._apiHeaders(undefined, installationId);
-    const payload: Record<string, unknown> = { merge_method: mergeMethod };
-    if (commitTitle) payload.commit_title = commitTitle;
-    if (commitMessage) payload.commit_message = commitMessage;
-    const res = await axios.put(
-      `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/merge`,
-      payload,
       { headers },
     );
     return res.data;

--- a/backend/services/githubAppService.ts
+++ b/backend/services/githubAppService.ts
@@ -25,6 +25,7 @@ interface ListIssuesOptions {
   owner?: string;
   repo?: string;
   perPage?: number;
+  installationId?: string;
 }
 
 interface CreateIssueOptions {
@@ -33,6 +34,7 @@ interface CreateIssueOptions {
   title: string;
   body?: string;
   labels?: string[];
+  installationId?: string;
 }
 
 interface IssueCommentOptions {
@@ -40,6 +42,7 @@ interface IssueCommentOptions {
   repo?: string;
   issueNumber: number;
   body: string;
+  installationId?: string;
 }
 
 interface CloseIssueOptions {
@@ -47,18 +50,21 @@ interface CloseIssueOptions {
   repo?: string;
   issueNumber: number;
   comment?: string;
+  installationId?: string;
 }
 
 interface IssueNumberOptions {
   owner?: string;
   repo?: string;
   issueNumber: number;
+  installationId?: string;
 }
 
 interface PullRequestOptions {
   owner?: string;
   repo?: string;
   pullNumber: number;
+  installationId?: string;
 }
 
 interface MergePullRequestOptions extends PullRequestOptions {
@@ -165,12 +171,17 @@ class GitHubAppService {
   /**
    * Shared headers for GitHub REST API calls (uses PAT or App token).
    */
-  static async _apiHeaders(token?: string): Promise<Record<string, string>> {
+  static async _apiHeaders(token?: string, installationId?: string): Promise<Record<string, string>> {
     const pat = token || process.env.GITHUB_PAT;
     let credential = pat;
-    if (!credential && this.isConfigured()) {
+    const appConfigured = !!(
+      process.env.GITHUB_APP_ID
+      && process.env.GITHUB_APP_PRIVATE_KEY
+      && (installationId || process.env.GITHUB_APP_INSTALLATION_ID_COMMONLY)
+    );
+    if (!credential && appConfigured) {
       const installation = await this.getInstallationToken(
-        process.env.GITHUB_APP_INSTALLATION_ID_COMMONLY as string,
+        installationId || process.env.GITHUB_APP_INSTALLATION_ID_COMMONLY as string,
       );
       credential = installation.token;
     }
@@ -185,8 +196,8 @@ class GitHubAppService {
   /**
    * List open issues for a repo (excludes pull requests).
    */
-  static async listOpenIssues({ owner = 'Team-Commonly', repo = 'commonly', perPage = 20 }: ListIssuesOptions = {}): Promise<GitHubIssue[]> {
-    const headers = await this._apiHeaders();
+  static async listOpenIssues({ owner = 'Team-Commonly', repo = 'commonly', perPage = 20, installationId }: ListIssuesOptions = {}): Promise<GitHubIssue[]> {
+    const headers = await this._apiHeaders(undefined, installationId);
     const res = await axios.get(
       `https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=${perPage}`,
       { headers },
@@ -197,8 +208,8 @@ class GitHubAppService {
   /**
    * Create a new GitHub issue.
    */
-  static async createIssue({ owner = 'Team-Commonly', repo = 'commonly', title, body, labels }: CreateIssueOptions): Promise<GitHubIssue> {
-    const headers = await this._apiHeaders();
+  static async createIssue({ owner = 'Team-Commonly', repo = 'commonly', title, body, labels, installationId }: CreateIssueOptions): Promise<GitHubIssue> {
+    const headers = await this._apiHeaders(undefined, installationId);
     const payload: Record<string, unknown> = { title };
     if (body) payload.body = body;
     if (labels?.length) payload.labels = labels;
@@ -213,8 +224,8 @@ class GitHubAppService {
   /**
    * Add a comment to an existing issue.
    */
-  static async addIssueComment({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, body }: IssueCommentOptions): Promise<unknown> {
-    const headers = await this._apiHeaders();
+  static async addIssueComment({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, body, installationId }: IssueCommentOptions): Promise<unknown> {
+    const headers = await this._apiHeaders(undefined, installationId);
     const res = await axios.post(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
       { body },
@@ -226,11 +237,11 @@ class GitHubAppService {
   /**
    * Close an issue (optionally with a final comment).
    */
-  static async closeIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, comment }: CloseIssueOptions): Promise<unknown> {
+  static async closeIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, comment, installationId }: CloseIssueOptions): Promise<unknown> {
     if (comment) {
-      await this.addIssueComment({ owner, repo, issueNumber, body: comment });
+      await this.addIssueComment({ owner, repo, issueNumber, body: comment, installationId });
     }
-    const headers = await this._apiHeaders();
+    const headers = await this._apiHeaders(undefined, installationId);
     const res = await axios.patch(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
       { state: 'closed' },
@@ -240,8 +251,8 @@ class GitHubAppService {
   }
 
   /** Fetch one issue without exposing the server credential to the caller. */
-  static async getIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber }: IssueNumberOptions): Promise<GitHubIssue> {
-    const headers = await this._apiHeaders();
+  static async getIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber, installationId }: IssueNumberOptions): Promise<GitHubIssue> {
+    const headers = await this._apiHeaders(undefined, installationId);
     const res = await axios.get(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
       { headers },
@@ -250,8 +261,8 @@ class GitHubAppService {
   }
 
   /** Fetch one pull request. */
-  static async getPullRequest({ owner = 'Team-Commonly', repo = 'commonly', pullNumber }: PullRequestOptions): Promise<unknown> {
-    const headers = await this._apiHeaders();
+  static async getPullRequest({ owner = 'Team-Commonly', repo = 'commonly', pullNumber, installationId }: PullRequestOptions): Promise<unknown> {
+    const headers = await this._apiHeaders(undefined, installationId);
     const res = await axios.get(
       `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}`,
       { headers },
@@ -260,8 +271,8 @@ class GitHubAppService {
   }
 
   /** List files changed by one pull request. */
-  static async listPullRequestFiles({ owner = 'Team-Commonly', repo = 'commonly', pullNumber }: PullRequestOptions): Promise<unknown[]> {
-    const headers = await this._apiHeaders();
+  static async listPullRequestFiles({ owner = 'Team-Commonly', repo = 'commonly', pullNumber, installationId }: PullRequestOptions): Promise<unknown[]> {
+    const headers = await this._apiHeaders(undefined, installationId);
     const res = await axios.get(
       `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/files`,
       { headers },
@@ -277,8 +288,9 @@ class GitHubAppService {
     commitTitle,
     commitMessage,
     mergeMethod = 'squash',
+    installationId,
   }: MergePullRequestOptions): Promise<unknown> {
-    const headers = await this._apiHeaders();
+    const headers = await this._apiHeaders(undefined, installationId);
     const payload: Record<string, unknown> = { merge_method: mergeMethod };
     if (commitTitle) payload.commit_title = commitTitle;
     if (commitMessage) payload.commit_message = commitMessage;

--- a/backend/services/githubAppService.ts
+++ b/backend/services/githubAppService.ts
@@ -49,6 +49,24 @@ interface CloseIssueOptions {
   comment?: string;
 }
 
+interface IssueNumberOptions {
+  owner?: string;
+  repo?: string;
+  issueNumber: number;
+}
+
+interface PullRequestOptions {
+  owner?: string;
+  repo?: string;
+  pullNumber: number;
+}
+
+interface MergePullRequestOptions extends PullRequestOptions {
+  commitTitle?: string;
+  commitMessage?: string;
+  mergeMethod?: 'merge' | 'squash' | 'rebase';
+}
+
 type PullReviewEvent = 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
 
 interface PullDiffOptions {
@@ -149,8 +167,16 @@ class GitHubAppService {
    */
   static async _apiHeaders(token?: string): Promise<Record<string, string>> {
     const pat = token || process.env.GITHUB_PAT;
+    let credential = pat;
+    if (!credential && this.isConfigured()) {
+      const installation = await this.getInstallationToken(
+        process.env.GITHUB_APP_INSTALLATION_ID_COMMONLY as string,
+      );
+      credential = installation.token;
+    }
+    if (!credential) throw new Error('github_not_configured');
     return {
-      Authorization: `Bearer ${pat}`,
+      Authorization: `Bearer ${credential}`,
       Accept: 'application/vnd.github+json',
       'X-GitHub-Api-Version': '2022-11-28',
     };
@@ -208,6 +234,57 @@ class GitHubAppService {
     const res = await axios.patch(
       `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
       { state: 'closed' },
+      { headers },
+    );
+    return res.data;
+  }
+
+  /** Fetch one issue without exposing the server credential to the caller. */
+  static async getIssue({ owner = 'Team-Commonly', repo = 'commonly', issueNumber }: IssueNumberOptions): Promise<GitHubIssue> {
+    const headers = await this._apiHeaders();
+    const res = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
+      { headers },
+    );
+    return res.data;
+  }
+
+  /** Fetch one pull request. */
+  static async getPullRequest({ owner = 'Team-Commonly', repo = 'commonly', pullNumber }: PullRequestOptions): Promise<unknown> {
+    const headers = await this._apiHeaders();
+    const res = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}`,
+      { headers },
+    );
+    return res.data;
+  }
+
+  /** List files changed by one pull request. */
+  static async listPullRequestFiles({ owner = 'Team-Commonly', repo = 'commonly', pullNumber }: PullRequestOptions): Promise<unknown[]> {
+    const headers = await this._apiHeaders();
+    const res = await axios.get(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/files`,
+      { headers },
+    );
+    return res.data;
+  }
+
+  /** Merge a pull request; callers must satisfy the broker approval gate. */
+  static async mergePullRequest({
+    owner = 'Team-Commonly',
+    repo = 'commonly',
+    pullNumber,
+    commitTitle,
+    commitMessage,
+    mergeMethod = 'squash',
+  }: MergePullRequestOptions): Promise<unknown> {
+    const headers = await this._apiHeaders();
+    const payload: Record<string, unknown> = { merge_method: mergeMethod };
+    if (commitTitle) payload.commit_title = commitTitle;
+    if (commitMessage) payload.commit_message = commitMessage;
+    const res = await axios.put(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/merge`,
+      payload,
       { headers },
     );
     return res.data;

--- a/backend/services/roomGrantService.ts
+++ b/backend/services/roomGrantService.ts
@@ -208,6 +208,11 @@ const loadGrantLineage = async (
   return lineage;
 };
 
+/** Return the grant and its parents, ordered child-first for callers that
+ * need to inspect lineage. Usability still performs the active/revoked checks
+ * separately so this helper does not weaken the broker guard. */
+export const getGrantLineage = loadGrantLineage;
+
 const assertGrantLineageActive = async (
   grant: IRoomGrant | Record<string, unknown>,
   now = new Date(),
@@ -434,6 +439,7 @@ export default {
   attenuateGrant,
   revokeGrant,
   assertGrantUsable,
+  getGrantLineage,
   effectiveAudience,
   getEffectiveAudience,
   RoomGrantError,

--- a/backend/services/toolBrokerService.ts
+++ b/backend/services/toolBrokerService.ts
@@ -114,6 +114,7 @@ const listIssues: ToolDefinition = {
       owner: connection.owner,
       repo: connection.repo,
       installationId: connection.installationId,
+      forceApp: true,
       perPage,
     });
     return { issues: (issues || []).map((issue: Record<string, unknown>) => issueView(issue)) };
@@ -150,6 +151,7 @@ const createIssue: ToolDefinition = {
       owner: connection.owner,
       repo: connection.repo,
       installationId: connection.installationId,
+      forceApp: true,
       title,
       body: rawArgs.body as string | undefined,
       labels: rawArgs.labels as string[] | undefined,
@@ -175,6 +177,7 @@ const getIssue: ToolDefinition = {
       owner: connection.owner,
       repo: connection.repo,
       installationId: connection.installationId,
+      forceApp: true,
       issueNumber: positiveInteger(rawArgs.issueNumber, 'issueNumber'),
     });
     return issueView(issue as Record<string, unknown>);
@@ -198,6 +201,7 @@ const getPullRequest: ToolDefinition = {
       owner: connection.owner,
       repo: connection.repo,
       installationId: connection.installationId,
+      forceApp: true,
       pullNumber: positiveInteger(rawArgs.pullNumber, 'pullNumber'),
     });
     return pullView(pull as Record<string, unknown>);
@@ -221,6 +225,7 @@ const listPullRequestFiles: ToolDefinition = {
       owner: connection.owner,
       repo: connection.repo,
       installationId: connection.installationId,
+      forceApp: true,
       pullNumber: positiveInteger(rawArgs.pullNumber, 'pullNumber'),
     });
     return {
@@ -256,6 +261,7 @@ const commentIssue: ToolDefinition = {
       owner: connection.owner,
       repo: connection.repo,
       installationId: connection.installationId,
+      forceApp: true,
       issueNumber,
       body,
     });
@@ -269,73 +275,27 @@ const closeIssue: ToolDefinition = {
   description: 'Close an issue in the connected GitHub repository.',
   requiredWriteMode: 'write-with-confirm',
   connectionType: 'github-app',
-  irreversible: (args) => typeof args.comment === 'string' && args.comment.trim().length > 0,
+  // Closing an issue is reversible (it can be reopened). Agent text is a
+  // separate comment tool so the approval tier is not argument-dependent.
   inputSchema: {
     type: 'object',
     properties: {
       issueNumber: { type: 'integer', minimum: 1 },
-      comment: { type: 'string' },
     },
     required: ['issueNumber'],
     additionalProperties: false,
   },
   async call(rawArgs, connection) {
-    assertNoUnknown(rawArgs, ['issueNumber', 'comment']);
+    assertNoUnknown(rawArgs, ['issueNumber']);
     const issueNumber = positiveInteger(rawArgs.issueNumber, 'issueNumber');
-    if (rawArgs.comment !== undefined && typeof rawArgs.comment !== 'string') {
-      throw new RoomGrantError('invalid_tool_args', 'comment must be a string', 400);
-    }
     const issue = await GitHubAppService.closeIssue({
       owner: connection.owner,
       repo: connection.repo,
       installationId: connection.installationId,
+      forceApp: true,
       issueNumber,
-      comment: rawArgs.comment as string | undefined,
     });
     return issueView(issue as Record<string, unknown>);
-  },
-};
-
-const mergePullRequest: ToolDefinition = {
-  name: 'github.merge_pull_request',
-  description: 'Merge a pull request in the Commonly repository.',
-  requiredWriteMode: 'write-with-confirm',
-  connectionType: 'github-app',
-  irreversible: true,
-  inputSchema: {
-    type: 'object',
-    properties: {
-      pullNumber: { type: 'integer', minimum: 1 },
-      commitTitle: { type: 'string' },
-      commitMessage: { type: 'string' },
-      mergeMethod: { type: 'string', enum: ['merge', 'squash', 'rebase'] },
-    },
-    required: ['pullNumber'],
-    additionalProperties: false,
-  },
-  async call(rawArgs, connection) {
-    assertNoUnknown(rawArgs, ['pullNumber', 'commitTitle', 'commitMessage', 'mergeMethod']);
-    if (rawArgs.commitTitle !== undefined && typeof rawArgs.commitTitle !== 'string') {
-      throw new RoomGrantError('invalid_tool_args', 'commitTitle must be a string', 400);
-    }
-    if (rawArgs.commitMessage !== undefined && typeof rawArgs.commitMessage !== 'string') {
-      throw new RoomGrantError('invalid_tool_args', 'commitMessage must be a string', 400);
-    }
-    if (rawArgs.mergeMethod !== undefined
-      && !['merge', 'squash', 'rebase'].includes(String(rawArgs.mergeMethod))) {
-      throw new RoomGrantError('invalid_tool_args', 'mergeMethod is invalid', 400);
-    }
-    const result = await GitHubAppService.mergePullRequest({
-      owner: connection.owner,
-      repo: connection.repo,
-      installationId: connection.installationId,
-      pullNumber: positiveInteger(rawArgs.pullNumber, 'pullNumber'),
-      commitTitle: rawArgs.commitTitle as string | undefined,
-      commitMessage: rawArgs.commitMessage as string | undefined,
-      mergeMethod: rawArgs.mergeMethod as 'merge' | 'squash' | 'rebase' | undefined,
-    });
-    const merge = result && typeof result === 'object' ? result as Record<string, unknown> : {};
-    return { merged: merge.merged, sha: merge.sha, message: merge.message };
   },
 };
 
@@ -347,7 +307,6 @@ export const TOOL_DEFINITIONS: Record<string, ToolDefinition> = {
   [createIssue.name]: createIssue,
   [commentIssue.name]: commentIssue,
   [closeIssue.name]: closeIssue,
-  [mergePullRequest.name]: mergePullRequest,
 };
 
 export const getToolDefinitions = (): ToolDefinition[] => Object.values(TOOL_DEFINITIONS);

--- a/backend/services/toolBrokerService.ts
+++ b/backend/services/toolBrokerService.ts
@@ -1,0 +1,398 @@
+import { randomUUID } from 'crypto';
+import Pod from '../models/Pod';
+import RoomGrant, { IRoomGrant, RoomGrantWriteMode } from '../models/RoomGrant';
+import ToolCall, { digestArgs, reserveBudget } from '../models/ToolCall';
+import {
+  assertGrantUsable,
+  RoomGrantError,
+} from './roomGrantService';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const GitHubAppService = require('./githubAppService');
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  requiredWriteMode: RoomGrantWriteMode;
+  inputSchema: Record<string, unknown>;
+  call: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface BrokerCallInput {
+  grantId: string;
+  agentUserId: string;
+  tool: string;
+  args?: unknown;
+}
+
+export interface BrokerCallResult {
+  callId: string;
+  result: unknown;
+}
+
+const PINNED_OWNER = 'Team-Commonly';
+const PINNED_REPO = 'commonly';
+
+const issueView = (issue: Record<string, unknown>): Record<string, unknown> => ({
+  number: issue.number,
+  title: issue.title,
+  body: issue.body || '',
+  url: issue.html_url,
+  labels: Array.isArray(issue.labels)
+    ? issue.labels.map((label: unknown) => String((label as Record<string, unknown>)?.name || label))
+    : [],
+  milestone: issue.milestone && typeof issue.milestone === 'object'
+    ? String((issue.milestone as Record<string, unknown>).title || '') || null
+    : null,
+});
+
+const pullView = (pull: Record<string, unknown>): Record<string, unknown> => ({
+  number: pull.number,
+  title: pull.title,
+  body: pull.body || '',
+  url: pull.html_url,
+  state: pull.state,
+  merged: pull.merged,
+  base: pull.base && typeof pull.base === 'object'
+    ? String((pull.base as Record<string, unknown>).ref || '') : undefined,
+  head: pull.head && typeof pull.head === 'object'
+    ? String((pull.head as Record<string, unknown>).ref || '') : undefined,
+});
+
+const objectArgs = (args: unknown): Record<string, unknown> => {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) {
+    throw new RoomGrantError('invalid_tool_args', 'tool arguments must be an object', 400);
+  }
+  return args as Record<string, unknown>;
+};
+
+const assertNoUnknown = (args: Record<string, unknown>, allowed: string[]): void => {
+  const unknown = Object.keys(args).filter((key) => !allowed.includes(key));
+  if (unknown.length) {
+    throw new RoomGrantError('invalid_tool_args', `unknown tool argument: ${unknown[0]}`, 400);
+  }
+};
+
+const positiveInteger = (value: unknown, field: string, fallback?: number): number => {
+  if (value === undefined && fallback !== undefined) return fallback;
+  if (!Number.isInteger(value) || Number(value) < 1) {
+    throw new RoomGrantError('invalid_tool_args', `${field} must be a positive integer`, 400);
+  }
+  return Number(value);
+};
+
+const nonEmptyString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new RoomGrantError('invalid_tool_args', `${field} is required`, 400);
+  }
+  return value.trim();
+};
+
+const listIssues: ToolDefinition = {
+  name: 'github.list_issues',
+  description: 'List open issues in the Commonly repository.',
+  requiredWriteMode: 'read',
+  inputSchema: {
+    type: 'object',
+    properties: { perPage: { type: 'integer', minimum: 1, maximum: 100 } },
+    additionalProperties: false,
+  },
+  async call(rawArgs) {
+    assertNoUnknown(rawArgs, ['perPage']);
+    const perPage = positiveInteger(rawArgs.perPage, 'perPage', 20);
+    if (perPage > 100) throw new RoomGrantError('invalid_tool_args', 'perPage must be at most 100', 400);
+    const issues = await GitHubAppService.listOpenIssues({
+      owner: PINNED_OWNER,
+      repo: PINNED_REPO,
+      perPage,
+    });
+    return { issues: (issues || []).map((issue: Record<string, unknown>) => issueView(issue)) };
+  },
+};
+
+const createIssue: ToolDefinition = {
+  name: 'github.create_issue',
+  description: 'Create an issue in the Commonly repository.',
+  requiredWriteMode: 'write-with-confirm',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      title: { type: 'string', minLength: 1 },
+      body: { type: 'string' },
+      labels: { type: 'array', items: { type: 'string' }, maxItems: 20 },
+    },
+    required: ['title'],
+    additionalProperties: false,
+  },
+  async call(rawArgs) {
+    assertNoUnknown(rawArgs, ['title', 'body', 'labels']);
+    const title = nonEmptyString(rawArgs.title, 'title');
+    if (rawArgs.body !== undefined && typeof rawArgs.body !== 'string') {
+      throw new RoomGrantError('invalid_tool_args', 'body must be a string', 400);
+    }
+    if (rawArgs.labels !== undefined
+      && (!Array.isArray(rawArgs.labels) || rawArgs.labels.some((label) => typeof label !== 'string'))) {
+      throw new RoomGrantError('invalid_tool_args', 'labels must be an array of strings', 400);
+    }
+    const issue = await GitHubAppService.createIssue({
+      owner: PINNED_OWNER,
+      repo: PINNED_REPO,
+      title,
+      body: rawArgs.body as string | undefined,
+      labels: rawArgs.labels as string[] | undefined,
+    });
+    return issueView(issue as Record<string, unknown>);
+  },
+};
+
+const getIssue: ToolDefinition = {
+  name: 'github.get_issue',
+  description: 'Fetch one issue from the Commonly repository.',
+  requiredWriteMode: 'read',
+  inputSchema: {
+    type: 'object',
+    properties: { issueNumber: { type: 'integer', minimum: 1 } },
+    required: ['issueNumber'],
+    additionalProperties: false,
+  },
+  async call(rawArgs) {
+    assertNoUnknown(rawArgs, ['issueNumber']);
+    const issue = await GitHubAppService.getIssue({
+      owner: PINNED_OWNER,
+      repo: PINNED_REPO,
+      issueNumber: positiveInteger(rawArgs.issueNumber, 'issueNumber'),
+    });
+    return issueView(issue as Record<string, unknown>);
+  },
+};
+
+const getPullRequest: ToolDefinition = {
+  name: 'github.get_pull_request',
+  description: 'Fetch one pull request from the Commonly repository.',
+  requiredWriteMode: 'read',
+  inputSchema: {
+    type: 'object',
+    properties: { pullNumber: { type: 'integer', minimum: 1 } },
+    required: ['pullNumber'],
+    additionalProperties: false,
+  },
+  async call(rawArgs) {
+    assertNoUnknown(rawArgs, ['pullNumber']);
+    const pull = await GitHubAppService.getPullRequest({
+      owner: PINNED_OWNER,
+      repo: PINNED_REPO,
+      pullNumber: positiveInteger(rawArgs.pullNumber, 'pullNumber'),
+    });
+    return pullView(pull as Record<string, unknown>);
+  },
+};
+
+const listPullRequestFiles: ToolDefinition = {
+  name: 'github.list_pull_request_files',
+  description: 'List files changed by a pull request in the Commonly repository.',
+  requiredWriteMode: 'read',
+  inputSchema: {
+    type: 'object',
+    properties: { pullNumber: { type: 'integer', minimum: 1 } },
+    required: ['pullNumber'],
+    additionalProperties: false,
+  },
+  async call(rawArgs) {
+    assertNoUnknown(rawArgs, ['pullNumber']);
+    const files = await GitHubAppService.listPullRequestFiles({
+      owner: PINNED_OWNER,
+      repo: PINNED_REPO,
+      pullNumber: positiveInteger(rawArgs.pullNumber, 'pullNumber'),
+    });
+    return {
+      files: (files || []).map((file: Record<string, unknown>) => ({
+        filename: file.filename,
+        status: file.status,
+        additions: file.additions,
+        deletions: file.deletions,
+        changes: file.changes,
+        url: file.blob_url,
+      })),
+    };
+  },
+};
+
+const commentIssue: ToolDefinition = {
+  name: 'github.comment_on_issue',
+  description: 'Add a comment to an issue in the Commonly repository.',
+  requiredWriteMode: 'write',
+  inputSchema: {
+    type: 'object',
+    properties: { issueNumber: { type: 'integer', minimum: 1 }, body: { type: 'string', minLength: 1 } },
+    required: ['issueNumber', 'body'],
+    additionalProperties: false,
+  },
+  async call(rawArgs) {
+    assertNoUnknown(rawArgs, ['issueNumber', 'body']);
+    const issueNumber = positiveInteger(rawArgs.issueNumber, 'issueNumber');
+    const body = nonEmptyString(rawArgs.body, 'body');
+    const result = await GitHubAppService.addIssueComment({
+      owner: PINNED_OWNER,
+      repo: PINNED_REPO,
+      issueNumber,
+      body,
+    });
+    const comment = (result && typeof result === 'object') ? result as Record<string, unknown> : {};
+    return { id: comment.id, url: comment.html_url, issueNumber };
+  },
+};
+
+const mergePullRequest: ToolDefinition = {
+  name: 'github.merge_pull_request',
+  description: 'Merge a pull request in the Commonly repository.',
+  requiredWriteMode: 'write-with-confirm',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      pullNumber: { type: 'integer', minimum: 1 },
+      commitTitle: { type: 'string' },
+      commitMessage: { type: 'string' },
+      mergeMethod: { type: 'string', enum: ['merge', 'squash', 'rebase'] },
+    },
+    required: ['pullNumber'],
+    additionalProperties: false,
+  },
+  async call(rawArgs) {
+    assertNoUnknown(rawArgs, ['pullNumber', 'commitTitle', 'commitMessage', 'mergeMethod']);
+    if (rawArgs.commitTitle !== undefined && typeof rawArgs.commitTitle !== 'string') {
+      throw new RoomGrantError('invalid_tool_args', 'commitTitle must be a string', 400);
+    }
+    if (rawArgs.commitMessage !== undefined && typeof rawArgs.commitMessage !== 'string') {
+      throw new RoomGrantError('invalid_tool_args', 'commitMessage must be a string', 400);
+    }
+    if (rawArgs.mergeMethod !== undefined
+      && !['merge', 'squash', 'rebase'].includes(String(rawArgs.mergeMethod))) {
+      throw new RoomGrantError('invalid_tool_args', 'mergeMethod is invalid', 400);
+    }
+    const result = await GitHubAppService.mergePullRequest({
+      owner: PINNED_OWNER,
+      repo: PINNED_REPO,
+      pullNumber: positiveInteger(rawArgs.pullNumber, 'pullNumber'),
+      commitTitle: rawArgs.commitTitle as string | undefined,
+      commitMessage: rawArgs.commitMessage as string | undefined,
+      mergeMethod: rawArgs.mergeMethod as 'merge' | 'squash' | 'rebase' | undefined,
+    });
+    const merge = result && typeof result === 'object' ? result as Record<string, unknown> : {};
+    return { merged: merge.merged, sha: merge.sha, message: merge.message };
+  },
+};
+
+export const TOOL_DEFINITIONS: Record<string, ToolDefinition> = {
+  [listIssues.name]: listIssues,
+  [getIssue.name]: getIssue,
+  [getPullRequest.name]: getPullRequest,
+  [listPullRequestFiles.name]: listPullRequestFiles,
+  [createIssue.name]: createIssue,
+  [commentIssue.name]: commentIssue,
+  [mergePullRequest.name]: mergePullRequest,
+};
+
+export const getToolDefinitions = (): ToolDefinition[] => Object.values(TOOL_DEFINITIONS);
+
+const currentMemberIds = async (grant: IRoomGrant | Record<string, unknown>): Promise<string[]> => {
+  const target = (grant as Record<string, unknown>).target as { kind?: string; id?: string } | undefined;
+  if (!target?.kind || !target.id) throw new RoomGrantError('invalid_target', 'grant target is invalid', 403);
+  if (target.kind === 'seat') {
+    return ((grant as Record<string, unknown>).audience as unknown[] || []).map(String);
+  }
+  const pod = await Pod.findById(target.id).select('members').lean();
+  if (!pod) throw new RoomGrantError('target_not_found', 'target pod not found', 404);
+  return (pod.members || []).map((member) => String(member));
+};
+
+const safeReason = (error: unknown): string => {
+  if (error instanceof RoomGrantError) return error.code;
+  const code = (error as { code?: unknown })?.code;
+  if (typeof code === 'string' && code.length <= 255) return code;
+  return 'broker_error';
+};
+
+const recordCall = async (
+  input: BrokerCallInput,
+  grant: IRoomGrant | Record<string, unknown> | undefined,
+  outcome: 'ok' | 'refused' | 'failed' | 'pending_approval',
+  startedAt: number,
+  reason?: string,
+): Promise<string> => {
+  const callId = `tool_call_${randomUUID()}`;
+  await ToolCall.create({
+    callId,
+    grantId: input.grantId,
+    podId: grant ? String(((grant as Record<string, unknown>).target as { id?: string })?.id || '') : undefined,
+    installationId: grant ? String((grant as Record<string, unknown>).installationId || '') : undefined,
+    agentUserId: input.agentUserId,
+    tool: input.tool,
+    argsDigest: digestArgs(input.args),
+    at: new Date(startedAt),
+    outcome,
+    reason,
+    durationMs: Math.max(0, Date.now() - startedAt),
+  });
+  return callId;
+};
+
+/**
+ * Execute one brokered tool call. The only identity accepted here is the
+ * middleware-derived agentUserId; a request argument with that name is never
+ * consulted. Membership is loaded for every call so leavers lose access.
+ */
+export const callTool = async (input: BrokerCallInput): Promise<BrokerCallResult> => {
+  const startedAt = Date.now();
+  const definition = TOOL_DEFINITIONS[input.tool];
+  let grant: IRoomGrant | Record<string, unknown> | undefined;
+
+  try {
+    if (!input.agentUserId) throw new RoomGrantError('agent_identity_required', 'agent identity is required', 403);
+    grant = (await RoomGrant.findOne({ grantId: input.grantId })) || undefined;
+    if (!grant) throw new RoomGrantError('grant_not_found', 'grant not found', 404);
+    if (!definition) throw new RoomGrantError('tool_not_found', 'tool is not registered', 404);
+
+    const members = await currentMemberIds(grant);
+    await assertGrantUsable({
+      grant,
+      agentUserId: input.agentUserId,
+      currentMemberIds: members,
+      tool: definition.name,
+      // Required mode comes only from this server-side definition map.
+      requiredWriteMode: definition.requiredWriteMode,
+    });
+
+    // Validate the shape before reserving a budget slot; malformed requests
+    // are refusals, not spendable calls.
+    const parsedArgs = objectArgs(input.args);
+
+    const budget = (grant as Record<string, unknown>).budget as { calls?: number; windowMs?: number } | undefined;
+    if (budget?.calls !== undefined) {
+      const reserved = await reserveBudget(input.grantId, budget.calls, budget.windowMs);
+      if (!reserved) throw new RoomGrantError('budget_exhausted', 'grant call budget is exhausted', 403);
+    }
+
+    const result = await definition.call(parsedArgs);
+    const callId = await recordCall(input, grant, 'ok', startedAt);
+    return { callId, result };
+  } catch (error) {
+    const reason = safeReason(error);
+    // Audit refusals and failures with the token-derived identity. If the
+    // audit store itself is unavailable, surface that failure rather than
+    // claiming a call happened without a durable trail.
+    const outcome = error instanceof RoomGrantError ? 'refused' : 'failed';
+    const callId = await recordCall(input, grant, outcome, startedAt, reason);
+    if (error instanceof RoomGrantError) {
+      Object.assign(error, { details: { ...(error.details || {}), callId } });
+    }
+    throw error;
+  }
+};
+
+// Exported for route tests and for the MCP catalogue projection.
+export default { callTool, getToolDefinitions, TOOL_DEFINITIONS };
+
+// CJS compat: let require() return the default export directly.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports["default"];
+Object.assign(module.exports, exports);

--- a/backend/services/toolBrokerService.ts
+++ b/backend/services/toolBrokerService.ts
@@ -356,7 +356,9 @@ const currentMemberIds = async (grant: IRoomGrant | Record<string, unknown>): Pr
   const target = (grant as Record<string, unknown>).target as { kind?: string; id?: string } | undefined;
   if (!target?.kind || !target.id) throw new RoomGrantError('invalid_target', 'grant target is invalid', 403);
   if (target.kind === 'seat') {
-    return ((grant as Record<string, unknown>).audience as unknown[] || []).map(String);
+    // A seat grant can authorize exactly its target seat. Do not treat a
+    // malformed audience list as a live-membership source for another agent.
+    return [String(target.id)];
   }
   const pod = await Pod.findById(target.id).select('members').lean();
   if (!pod) throw new RoomGrantError('target_not_found', 'target pod not found', 404);

--- a/backend/services/toolBrokerService.ts
+++ b/backend/services/toolBrokerService.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from 'crypto';
 import Pod from '../models/Pod';
+import Integration from '../models/Integration';
 import RoomGrant, { IRoomGrant, RoomGrantWriteMode } from '../models/RoomGrant';
-import ToolCall, { digestArgs, reserveBudget } from '../models/ToolCall';
+import ToolCall, { digestArgs, reserveBudgetLineage } from '../models/ToolCall';
 import {
   assertGrantUsable,
+  getGrantLineage,
   RoomGrantError,
 } from './roomGrantService';
 
@@ -14,8 +16,17 @@ export interface ToolDefinition {
   name: string;
   description: string;
   requiredWriteMode: RoomGrantWriteMode;
+  connectionType: 'github-app';
+  irreversible?: boolean | ((args: Record<string, unknown>) => boolean);
   inputSchema: Record<string, unknown>;
-  call: (args: Record<string, unknown>) => Promise<unknown>;
+  call: (args: Record<string, unknown>, connection: ToolConnection) => Promise<unknown>;
+}
+
+export interface ToolConnection {
+  type: 'github-app';
+  installationId: string;
+  owner: string;
+  repo: string;
 }
 
 export interface BrokerCallInput {
@@ -29,9 +40,6 @@ export interface BrokerCallResult {
   callId: string;
   result: unknown;
 }
-
-const PINNED_OWNER = 'Team-Commonly';
-const PINNED_REPO = 'commonly';
 
 const issueView = (issue: Record<string, unknown>): Record<string, unknown> => ({
   number: issue.number,
@@ -92,18 +100,20 @@ const listIssues: ToolDefinition = {
   name: 'github.list_issues',
   description: 'List open issues in the Commonly repository.',
   requiredWriteMode: 'read',
+  connectionType: 'github-app',
   inputSchema: {
     type: 'object',
     properties: { perPage: { type: 'integer', minimum: 1, maximum: 100 } },
     additionalProperties: false,
   },
-  async call(rawArgs) {
+  async call(rawArgs, connection) {
     assertNoUnknown(rawArgs, ['perPage']);
     const perPage = positiveInteger(rawArgs.perPage, 'perPage', 20);
     if (perPage > 100) throw new RoomGrantError('invalid_tool_args', 'perPage must be at most 100', 400);
     const issues = await GitHubAppService.listOpenIssues({
-      owner: PINNED_OWNER,
-      repo: PINNED_REPO,
+      owner: connection.owner,
+      repo: connection.repo,
+      installationId: connection.installationId,
       perPage,
     });
     return { issues: (issues || []).map((issue: Record<string, unknown>) => issueView(issue)) };
@@ -114,6 +124,8 @@ const createIssue: ToolDefinition = {
   name: 'github.create_issue',
   description: 'Create an issue in the Commonly repository.',
   requiredWriteMode: 'write-with-confirm',
+  connectionType: 'github-app',
+  irreversible: true,
   inputSchema: {
     type: 'object',
     properties: {
@@ -124,7 +136,7 @@ const createIssue: ToolDefinition = {
     required: ['title'],
     additionalProperties: false,
   },
-  async call(rawArgs) {
+  async call(rawArgs, connection) {
     assertNoUnknown(rawArgs, ['title', 'body', 'labels']);
     const title = nonEmptyString(rawArgs.title, 'title');
     if (rawArgs.body !== undefined && typeof rawArgs.body !== 'string') {
@@ -135,8 +147,9 @@ const createIssue: ToolDefinition = {
       throw new RoomGrantError('invalid_tool_args', 'labels must be an array of strings', 400);
     }
     const issue = await GitHubAppService.createIssue({
-      owner: PINNED_OWNER,
-      repo: PINNED_REPO,
+      owner: connection.owner,
+      repo: connection.repo,
+      installationId: connection.installationId,
       title,
       body: rawArgs.body as string | undefined,
       labels: rawArgs.labels as string[] | undefined,
@@ -149,17 +162,19 @@ const getIssue: ToolDefinition = {
   name: 'github.get_issue',
   description: 'Fetch one issue from the Commonly repository.',
   requiredWriteMode: 'read',
+  connectionType: 'github-app',
   inputSchema: {
     type: 'object',
     properties: { issueNumber: { type: 'integer', minimum: 1 } },
     required: ['issueNumber'],
     additionalProperties: false,
   },
-  async call(rawArgs) {
+  async call(rawArgs, connection) {
     assertNoUnknown(rawArgs, ['issueNumber']);
     const issue = await GitHubAppService.getIssue({
-      owner: PINNED_OWNER,
-      repo: PINNED_REPO,
+      owner: connection.owner,
+      repo: connection.repo,
+      installationId: connection.installationId,
       issueNumber: positiveInteger(rawArgs.issueNumber, 'issueNumber'),
     });
     return issueView(issue as Record<string, unknown>);
@@ -170,17 +185,19 @@ const getPullRequest: ToolDefinition = {
   name: 'github.get_pull_request',
   description: 'Fetch one pull request from the Commonly repository.',
   requiredWriteMode: 'read',
+  connectionType: 'github-app',
   inputSchema: {
     type: 'object',
     properties: { pullNumber: { type: 'integer', minimum: 1 } },
     required: ['pullNumber'],
     additionalProperties: false,
   },
-  async call(rawArgs) {
+  async call(rawArgs, connection) {
     assertNoUnknown(rawArgs, ['pullNumber']);
     const pull = await GitHubAppService.getPullRequest({
-      owner: PINNED_OWNER,
-      repo: PINNED_REPO,
+      owner: connection.owner,
+      repo: connection.repo,
+      installationId: connection.installationId,
       pullNumber: positiveInteger(rawArgs.pullNumber, 'pullNumber'),
     });
     return pullView(pull as Record<string, unknown>);
@@ -191,17 +208,19 @@ const listPullRequestFiles: ToolDefinition = {
   name: 'github.list_pull_request_files',
   description: 'List files changed by a pull request in the Commonly repository.',
   requiredWriteMode: 'read',
+  connectionType: 'github-app',
   inputSchema: {
     type: 'object',
     properties: { pullNumber: { type: 'integer', minimum: 1 } },
     required: ['pullNumber'],
     additionalProperties: false,
   },
-  async call(rawArgs) {
+  async call(rawArgs, connection) {
     assertNoUnknown(rawArgs, ['pullNumber']);
     const files = await GitHubAppService.listPullRequestFiles({
-      owner: PINNED_OWNER,
-      repo: PINNED_REPO,
+      owner: connection.owner,
+      repo: connection.repo,
+      installationId: connection.installationId,
       pullNumber: positiveInteger(rawArgs.pullNumber, 'pullNumber'),
     });
     return {
@@ -220,20 +239,23 @@ const listPullRequestFiles: ToolDefinition = {
 const commentIssue: ToolDefinition = {
   name: 'github.comment_on_issue',
   description: 'Add a comment to an issue in the Commonly repository.',
-  requiredWriteMode: 'write',
+  requiredWriteMode: 'write-with-confirm',
+  connectionType: 'github-app',
+  irreversible: true,
   inputSchema: {
     type: 'object',
     properties: { issueNumber: { type: 'integer', minimum: 1 }, body: { type: 'string', minLength: 1 } },
     required: ['issueNumber', 'body'],
     additionalProperties: false,
   },
-  async call(rawArgs) {
+  async call(rawArgs, connection) {
     assertNoUnknown(rawArgs, ['issueNumber', 'body']);
     const issueNumber = positiveInteger(rawArgs.issueNumber, 'issueNumber');
     const body = nonEmptyString(rawArgs.body, 'body');
     const result = await GitHubAppService.addIssueComment({
-      owner: PINNED_OWNER,
-      repo: PINNED_REPO,
+      owner: connection.owner,
+      repo: connection.repo,
+      installationId: connection.installationId,
       issueNumber,
       body,
     });
@@ -242,10 +264,44 @@ const commentIssue: ToolDefinition = {
   },
 };
 
+const closeIssue: ToolDefinition = {
+  name: 'github.close_issue',
+  description: 'Close an issue in the connected GitHub repository.',
+  requiredWriteMode: 'write-with-confirm',
+  connectionType: 'github-app',
+  irreversible: (args) => typeof args.comment === 'string' && args.comment.trim().length > 0,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      issueNumber: { type: 'integer', minimum: 1 },
+      comment: { type: 'string' },
+    },
+    required: ['issueNumber'],
+    additionalProperties: false,
+  },
+  async call(rawArgs, connection) {
+    assertNoUnknown(rawArgs, ['issueNumber', 'comment']);
+    const issueNumber = positiveInteger(rawArgs.issueNumber, 'issueNumber');
+    if (rawArgs.comment !== undefined && typeof rawArgs.comment !== 'string') {
+      throw new RoomGrantError('invalid_tool_args', 'comment must be a string', 400);
+    }
+    const issue = await GitHubAppService.closeIssue({
+      owner: connection.owner,
+      repo: connection.repo,
+      installationId: connection.installationId,
+      issueNumber,
+      comment: rawArgs.comment as string | undefined,
+    });
+    return issueView(issue as Record<string, unknown>);
+  },
+};
+
 const mergePullRequest: ToolDefinition = {
   name: 'github.merge_pull_request',
   description: 'Merge a pull request in the Commonly repository.',
   requiredWriteMode: 'write-with-confirm',
+  connectionType: 'github-app',
+  irreversible: true,
   inputSchema: {
     type: 'object',
     properties: {
@@ -257,7 +313,7 @@ const mergePullRequest: ToolDefinition = {
     required: ['pullNumber'],
     additionalProperties: false,
   },
-  async call(rawArgs) {
+  async call(rawArgs, connection) {
     assertNoUnknown(rawArgs, ['pullNumber', 'commitTitle', 'commitMessage', 'mergeMethod']);
     if (rawArgs.commitTitle !== undefined && typeof rawArgs.commitTitle !== 'string') {
       throw new RoomGrantError('invalid_tool_args', 'commitTitle must be a string', 400);
@@ -270,8 +326,9 @@ const mergePullRequest: ToolDefinition = {
       throw new RoomGrantError('invalid_tool_args', 'mergeMethod is invalid', 400);
     }
     const result = await GitHubAppService.mergePullRequest({
-      owner: PINNED_OWNER,
-      repo: PINNED_REPO,
+      owner: connection.owner,
+      repo: connection.repo,
+      installationId: connection.installationId,
       pullNumber: positiveInteger(rawArgs.pullNumber, 'pullNumber'),
       commitTitle: rawArgs.commitTitle as string | undefined,
       commitMessage: rawArgs.commitMessage as string | undefined,
@@ -289,6 +346,7 @@ export const TOOL_DEFINITIONS: Record<string, ToolDefinition> = {
   [listPullRequestFiles.name]: listPullRequestFiles,
   [createIssue.name]: createIssue,
   [commentIssue.name]: commentIssue,
+  [closeIssue.name]: closeIssue,
   [mergePullRequest.name]: mergePullRequest,
 };
 
@@ -303,6 +361,44 @@ const currentMemberIds = async (grant: IRoomGrant | Record<string, unknown>): Pr
   const pod = await Pod.findById(target.id).select('members').lean();
   if (!pod) throw new RoomGrantError('target_not_found', 'target pod not found', 404);
   return (pod.members || []).map((member) => String(member));
+};
+
+const resolveConnection = async (
+  grant: IRoomGrant | Record<string, unknown>,
+  definition: ToolDefinition,
+): Promise<ToolConnection> => {
+  const connectionId = String((grant as Record<string, unknown>).connectionId || '').trim();
+  if (!connectionId) throw new RoomGrantError('connection_mismatch', 'grant connection is missing', 403);
+  let connection = await Integration.findOne({ type: definition.connectionType, installationId: connectionId });
+  // Grants commonly retain the Mongo connection _id. Avoid putting an
+  // untrusted string into a BSON _id selector when it is not an ObjectId.
+  if (!connection && /^[a-f\d]{24}$/i.test(connectionId)) {
+    connection = await Integration.findById(connectionId);
+  }
+  const row = connection as unknown as {
+    type?: string;
+    status?: string;
+    revokedAt?: Date | null;
+    config?: { installationId?: string; owner?: string; repo?: string };
+  } | null;
+  const config = row?.config;
+  if (
+    !row
+    || row.type !== definition.connectionType
+    || row.status !== 'connected'
+    || row.revokedAt
+    || !config?.installationId
+    || !config.owner
+    || !config.repo
+  ) {
+    throw new RoomGrantError('connection_mismatch', 'grant connection is not a connected GitHub App installation', 403);
+  }
+  return {
+    type: 'github-app',
+    installationId: String(config.installationId),
+    owner: String(config.owner),
+    repo: String(config.repo),
+  };
 };
 
 const safeReason = (error: unknown): string => {
@@ -362,17 +458,37 @@ export const callTool = async (input: BrokerCallInput): Promise<BrokerCallResult
       requiredWriteMode: definition.requiredWriteMode,
     });
 
+    const connection = await resolveConnection(grant, definition);
+
     // Validate the shape before reserving a budget slot; malformed requests
     // are refusals, not spendable calls.
     const parsedArgs = objectArgs(input.args);
 
-    const budget = (grant as Record<string, unknown>).budget as { calls?: number; windowMs?: number } | undefined;
-    if (budget?.calls !== undefined) {
-      const reserved = await reserveBudget(input.grantId, budget.calls, budget.windowMs);
+    const irreversible = typeof definition.irreversible === 'function'
+      ? definition.irreversible(parsedArgs)
+      : definition.irreversible === true;
+    // ApprovalAction is added by the next broker cut. Park irreversible
+    // writes now, before spending budget or touching the provider.
+    if (irreversible && (grant as Record<string, unknown>).writeMode === 'write-with-confirm') {
+      throw new RoomGrantError('approval_required', 'irreversible tool call requires approval', 403);
+    }
+
+    const lineage = await getGrantLineage(grant);
+    const budgetEntries = lineage.reverse().flatMap((item) => {
+      const budget = (item as Record<string, unknown>).budget as { calls?: number; windowMs?: number } | undefined;
+      if (budget?.calls === undefined) return [];
+      return [{
+        grantId: String((item as Record<string, unknown>).grantId),
+        calls: budget.calls,
+        windowMs: budget.windowMs,
+      }];
+    });
+    if (budgetEntries.length > 0) {
+      const reserved = await reserveBudgetLineage(budgetEntries);
       if (!reserved) throw new RoomGrantError('budget_exhausted', 'grant call budget is exhausted', 403);
     }
 
-    const result = await definition.call(parsedArgs);
+    const result = await definition.call(parsedArgs, connection);
     const callId = await recordCall(input, grant, 'ok', startedAt);
     return { callId, result };
   } catch (error) {
@@ -380,7 +496,9 @@ export const callTool = async (input: BrokerCallInput): Promise<BrokerCallResult
     // Audit refusals and failures with the token-derived identity. If the
     // audit store itself is unavailable, surface that failure rather than
     // claiming a call happened without a durable trail.
-    const outcome = error instanceof RoomGrantError ? 'refused' : 'failed';
+    const outcome = error instanceof RoomGrantError
+      ? (error.code === 'approval_required' ? 'pending_approval' : 'refused')
+      : 'failed';
     const callId = await recordCall(input, grant, outcome, startedAt, reason);
     if (error instanceof RoomGrantError) {
       Object.assign(error, { details: { ...(error.details || {}), callId } });


### PR DESCRIPTION
## Summary
- add stateless MCP Streamable HTTP grant endpoint authenticated by agent runtime tokens
- broker first-party GitHub tools through a server-side allow-list and required write modes
- add Postgres ToolCall audit trail and atomic grant budget ledger
- refresh pod membership for every grant usability assertion; never return credential material

## Tests
- `npx jest --runInBand __tests__/unit/models/ToolCall.budget.test.js __tests__/unit/services/toolBrokerService.test.js __tests__/unit/routes/mcpGrants.test.js --no-cache`
- `npm run tsc:check -- --pretty false`
- `npx eslint models/ToolCall.ts services/toolBrokerService.ts routes/mcpGrants.ts __tests__/unit/models/ToolCall.budget.test.js __tests__/unit/services/toolBrokerService.test.js __tests__/unit/routes/mcpGrants.test.js --ext .ts --ext .js`
