### PR TITLE
fix: make irreversible tool approval a floor

### DIFF
--- a/backend/__tests__/unit/services/toolBrokerService.test.js
+++ b/backend/__tests__/unit/services/toolBrokerService.test.js
@@ -265,4 +265,18 @@ describe('tool broker guard rails', () => {
     expect(mockGithub.closeIssue).toHaveBeenCalledTimes(1);
     expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'ok' }));
   });
+
+  it('parks a reversible write under a write-with-confirm grant', async () => {
+    mockRoomGrant.findOne.mockResolvedValue(seatGrant({
+      tools: ['github.close_issue'], writeMode: 'write-with-confirm', budget: { calls: 1 },
+    }));
+    await expect(callTool({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.close_issue', args: { issueNumber: 7 },
+    })).rejects.toMatchObject({ code: 'approval_required' });
+    expect(mockReserveBudgetLineage).not.toHaveBeenCalled();
+    expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: 'pending_approval', reason: 'approval_required',
+    }));
+    expect(mockGithub.closeIssue).not.toHaveBeenCalled();
+  });
 });

--- a/backend/__tests__/unit/services/toolBrokerService.test.js
+++ b/backend/__tests__/unit/services/toolBrokerService.test.js
@@ -144,10 +144,10 @@ describe('tool broker guard rails', () => {
   });
 
   it('writes one trail row with token identity when the body names another agent', async () => {
-    const grant = seatGrant({ tools: ['github.create_issue'], writeMode: 'write' });
+    const grant = seatGrant({ tools: ['github.close_issue'], writeMode: 'write' });
     mockRoomGrant.findOne.mockResolvedValue(grant);
     await callTool({
-      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.create_issue',
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.close_issue',
       args: { title: 'x', agentUserId: 'agent-b' },
     }).catch(() => {});
     expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({
@@ -233,5 +233,36 @@ describe('tool broker guard rails', () => {
     expect(mockReserveBudgetLineage).not.toHaveBeenCalled();
     expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'pending_approval', reason: 'approval_required' }));
     expect(mockGithub.createIssue).not.toHaveBeenCalled();
+  });
+
+  it('parks an irreversible tool under a write grant', async () => {
+    mockRoomGrant.findOne.mockResolvedValue(seatGrant({
+      tools: ['github.create_issue'], writeMode: 'write', budget: { calls: 1 },
+    }));
+    await expect(callTool({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.create_issue', args: { title: 'needs approval' },
+    })).rejects.toMatchObject({ code: 'approval_required' });
+    expect(mockReserveBudgetLineage).not.toHaveBeenCalled();
+    expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({
+      outcome: 'pending_approval', reason: 'approval_required',
+    }));
+    expect(mockGithub.createIssue).not.toHaveBeenCalled();
+  });
+
+  it('a write grant runs a reversible write unattended', async () => {
+    mockRoomGrant.findOne.mockResolvedValue(seatGrant({
+      tools: ['github.close_issue'], writeMode: 'write',
+    }));
+    mockGithub.closeIssue.mockResolvedValue({
+      number: 7, title: 'closed', html_url: 'https://github.com/Team-Commonly/commonly/issues/7',
+      state: 'closed',
+    });
+    await expect(callTool({
+      grantId: 'grant-1', agentUserId: 'agent-a', tool: 'github.close_issue', args: { issueNumber: 7 },
+    })).resolves.toEqual(expect.objectContaining({
+      result: expect.objectContaining({ number: 7, title: 'closed' }),
+    }));
+    expect(mockGithub.closeIssue).toHaveBeenCalledTimes(1);
+    expect(mockToolCall.create).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'ok' }));
   });
 });

--- a/backend/services/toolBrokerService.ts
+++ b/backend/services/toolBrokerService.ts
@@ -430,9 +430,11 @@ export const callTool = async (input: BrokerCallInput): Promise<BrokerCallResult
       : definition.irreversible === true;
     // Confirmation is a floor set by the tool: every irreversible operation
     // parks for a human, including when the grant is otherwise full `write`.
-    // Reversible writes may run unattended under `write`; the tool definition
-    // still supplies the required mode to the grant usability check above.
-    if (irreversible) {
+    // A `write-with-confirm` grant also confirms every write; full `write`
+    // alone is the tier that permits reversible writes to run unattended.
+    const requiresConfirmation = irreversible
+      || (grant.writeMode === 'write-with-confirm' && definition.requiredWriteMode !== 'read');
+    if (requiresConfirmation) {
       throw new RoomGrantError('approval_required', 'irreversible tool call requires approval', 403);
     }
 

--- a/backend/services/toolBrokerService.ts
+++ b/backend/services/toolBrokerService.ts
@@ -428,9 +428,11 @@ export const callTool = async (input: BrokerCallInput): Promise<BrokerCallResult
     const irreversible = typeof definition.irreversible === 'function'
       ? definition.irreversible(parsedArgs)
       : definition.irreversible === true;
-    // ApprovalAction is added by the next broker cut. Park irreversible
-    // writes now, before spending budget or touching the provider.
-    if (irreversible && (grant as Record<string, unknown>).writeMode === 'write-with-confirm') {
+    // Confirmation is a floor set by the tool: every irreversible operation
+    // parks for a human, including when the grant is otherwise full `write`.
+    // Reversible writes may run unattended under `write`; the tool definition
+    // still supplies the required mode to the grant usability check above.
+    if (irreversible) {
       throw new RoomGrantError('approval_required', 'irreversible tool call requires approval', 403);
     }
 


### PR DESCRIPTION
## Summary
- park every irreversible broker tool under both `write` and `write-with-confirm` grants
- keep reversible writes unattended for full `write` grants
- add the two named broker guard tests

## Verification
- `npm test -- --runInBand __tests__/unit/services/toolBrokerService.test.js`
- `npm run tsc:check -- --pretty false`
