### PR TITLE
feat(grants): the Tools page's three read routes (piece 4, option A)

### DIFF
--- a/backend/__tests__/unit/models/ToolCall.counts.test.js
+++ b/backend/__tests__/unit/models/ToolCall.counts.test.js
@@ -1,0 +1,29 @@
+// The page's three numbers are COUNT(*) by outcome on the trail (tools plan
+// §6): run the GROUP BY on pg-mem's real adapter, the way the budget test does.
+jest.mock('../../../config/db-pg', () => {
+  // eslint-disable-next-line global-require
+  const { newDb } = require('pg-mem');
+  const db = newDb();
+  const { Pool } = db.adapters.createPg();
+  return { pool: new Pool() };
+});
+
+// eslint-disable-next-line import/no-unresolved, import/extensions
+const ToolCall = require('../../../models/ToolCall');
+
+const row = (over) => ({
+  callId: `call-${Math.random().toString(36).slice(2)}`, grantId: 'grant-1', agentUserId: 'agent-a',
+  tool: 'github.list_issues', argsDigest: 'a'.repeat(64), outcome: 'ok', ...over,
+});
+
+describe('ToolCall.countsForGrant', () => {
+  it('counts every outcome for the grant and nothing from other grants', async () => {
+    await ToolCall.create(row({}));
+    await ToolCall.create(row({ outcome: 'ok' }));
+    await ToolCall.create(row({ outcome: 'refused', reason: 'not_in_audience' }));
+    await ToolCall.create(row({ outcome: 'pending_approval', approvalId: 'appr-1' }));
+    await ToolCall.create(row({ grantId: 'grant-2', outcome: 'failed' }));
+    await expect(ToolCall.countsForGrant('grant-1')).resolves.toEqual({ total: 4, ok: 2, refused: 1, pending_approval: 1, failed: 0 });
+    await expect(ToolCall.countsForGrant('grant-none')).resolves.toEqual({ total: 0, ok: 0, refused: 0, pending_approval: 0, failed: 0 });
+  });
+});

--- a/backend/__tests__/unit/routes/grants.read.test.js
+++ b/backend/__tests__/unit/routes/grants.read.test.js
@@ -1,0 +1,214 @@
+/**
+ * Tools plan §6 — the three read routes the page needs, by their named tests.
+ * RoomGrant runs on memory Mongo (the query shape is the thing under test);
+ * the pod, the connection owner and the Postgres trail are mocked at their
+ * module boundaries, as the pod-agents route suite does.
+ */
+const express = require('express');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+
+// Human identity from a header so one app can be called as several people.
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  const id = req.get('x-test-user');
+  if (!id) return res.status(401).json({ error: 'unauthorized' });
+  req.user = { id };
+  req.userId = id;
+  return next();
+});
+jest.mock('../../../middleware/agentRuntimeAuth', () => (req, res, next) => {
+  const id = req.get('x-test-agent');
+  if (!id) return res.status(401).json({ error: 'agent_token_invalid' });
+  req.agentUser = { _id: id };
+  return next();
+});
+jest.mock('../../../models/Pod', () => ({ findById: jest.fn() }));
+jest.mock('../../../models/Integration', () => ({ findById: jest.fn(), findOne: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => ({
+  listForGrant: jest.fn(),
+  countsForGrant: jest.fn(),
+}));
+jest.mock('../../../services/dmService', () => ({
+  canViewPod: jest.fn(async (userId, pod) => (pod.members || []).map(String).includes(String(userId))),
+}));
+
+const Pod = require('../../../models/Pod');
+const Integration = require('../../../models/Integration');
+const ToolCall = require('../../../models/ToolCall');
+
+const POD = 'aaaaaaaaaaaaaaaaaaaaaa01';
+const OWNER = 'bbbbbbbbbbbbbbbbbbbbbb01'; // installed the App: every grant's granter
+const MEMBER = 'bbbbbbbbbbbbbbbbbbbbbb02';
+const STRANGER = 'bbbbbbbbbbbbbbbbbbbbbb03';
+const SEAT = 'cccccccccccccccccccccc01'; // an agent user in the pod
+const OTHER_SEAT = 'cccccccccccccccccccccc02';
+const GONE = 'dddddddddddddddddddddd01'; // in the audience snapshot, no longer a member
+
+let mongod;
+let RoomGrant;
+let app;
+
+const grant = (over = {}) => ({
+  grantId: `grant_${Math.random().toString(36).slice(2)}`,
+  connectionId: 'conn-1',
+  installationId: 'install-1',
+  target: { kind: 'pod', id: POD },
+  tools: ['github.list_issues', 'github.comment'],
+  writeMode: 'write-with-confirm',
+  budget: { calls: 10, windowMs: 60000 },
+  audience: [SEAT, GONE],
+  expiresAt: new Date('2026-10-01T00:00:00.000Z'),
+  brokerId: 'broker-1',
+  ...over,
+});
+
+const trailRow = (over = {}) => ({
+  callId: 'call-1', grantId: 'g', podId: POD, installationId: 'install-1', agentUserId: SEAT,
+  tool: 'github.list_issues', argsDigest: 'a'.repeat(64), at: new Date('2026-09-11T04:00:00.000Z'),
+  outcome: 'ok', reason: undefined, approvalId: undefined, durationMs: 120,
+  // What the trail must never carry, even if a row somehow did.
+  args: { repo: 'secret/private' },
+  ...over,
+});
+
+const FIELDS = ['grantId', 'installationId', 'target', 'tools', 'writeMode', 'budget', 'effectiveAudience',
+  'expiresAt', 'revokedAt', 'parentGrantId', 'rootGrantId', 'createdAt', 'grantedBy'];
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  RoomGrant = require('../../../models/RoomGrant');
+  const grants = require('../../../routes/grants');
+  app = express();
+  app.use(express.json());
+  app.use('/api/grants', grants);
+  app.use('/api/pods', grants.podGrantsRouter);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await RoomGrant.deleteMany({});
+  Pod.findById.mockImplementation((id) => ({
+    select: () => ({ lean: async () => (String(id) === POD ? { _id: POD, type: 'team', members: [OWNER, MEMBER, SEAT, OTHER_SEAT] } : null) }),
+  }));
+  Integration.findById.mockResolvedValue(null);
+  Integration.findOne.mockImplementation(async ({ installationId }) => (installationId === 'conn-1'
+    ? { _id: 'conn-1', type: 'github-app', status: 'connected', createdBy: OWNER }
+    : null));
+  ToolCall.listForGrant.mockResolvedValue([]);
+  ToolCall.countsForGrant.mockResolvedValue({ total: 0, ok: 0, refused: 0, pending_approval: 0, failed: 0 });
+});
+
+describe('GET /api/pods/:podId/grants', () => {
+  test('the pod grants list refuses a non-member', async () => {
+    await RoomGrant.create(grant());
+    const stranger = await request(app).get(`/api/pods/${POD}/grants`).set('x-test-user', STRANGER);
+    expect(stranger.status).toBe(403);
+    expect(stranger.body.grants).toBeUndefined();
+    const malformed = await request(app).get('/api/pods/not-an-id/grants').set('x-test-user', MEMBER);
+    expect(malformed.status).toBe(403);
+    const anon = await request(app).get(`/api/pods/${POD}/grants`);
+    expect(anon.status).toBe(401);
+  });
+
+  test('a member sees the pod grants and the seat grants of seats in the pod, each in the field list', async () => {
+    const podGrant = await RoomGrant.create(grant());
+    const seatGrant = await RoomGrant.create(grant({ target: { kind: 'seat', id: SEAT }, audience: [SEAT] }));
+    await RoomGrant.create(grant({ target: { kind: 'seat', id: 'eeeeeeeeeeeeeeeeeeeeee01' }, audience: ['eeeeeeeeeeeeeeeeeeeeee01'] })); // a seat elsewhere
+    await RoomGrant.create(grant({ target: { kind: 'pod', id: 'aaaaaaaaaaaaaaaaaaaaaa02' } })); // another pod
+    const res = await request(app).get(`/api/pods/${POD}/grants`).set('x-test-user', MEMBER);
+    expect(res.status).toBe(200);
+    expect(res.body.podId).toBe(POD);
+    expect(res.body.grants.map((row) => row.grantId).sort()).toEqual([podGrant.grantId, seatGrant.grantId].sort());
+    for (const row of res.body.grants) {
+      expect(Object.keys(row).sort()).toEqual([...FIELDS].sort());
+      expect(row.grantedBy).toBe(OWNER);
+      expect(JSON.stringify(row)).not.toMatch(/conn-1|broker-1/);
+    }
+    const podRow = res.body.grants.find((row) => row.grantId === podGrant.grantId);
+    // The raw snapshot names GONE; the page only ever sees the effective audience.
+    expect(podRow.effectiveAudience).toEqual([SEAT]);
+    expect(podRow.audience).toBeUndefined();
+    const seatRow = res.body.grants.find((row) => row.grantId === seatGrant.grantId);
+    expect(seatRow.effectiveAudience).toEqual([SEAT]);
+  });
+});
+
+describe('GET /api/grants/:grantId/calls', () => {
+  test('the trail refuses a non-member and never returns args', async () => {
+    const row = await RoomGrant.create(grant());
+    ToolCall.listForGrant.mockResolvedValue([trailRow({ grantId: row.grantId }), trailRow({ grantId: row.grantId, callId: 'call-2', outcome: 'refused', reason: 'not_in_audience' })]);
+    ToolCall.countsForGrant.mockResolvedValue({ total: 3, ok: 1, refused: 1, pending_approval: 1, failed: 0 });
+
+    const stranger = await request(app).get(`/api/grants/${row.grantId}/calls`).set('x-test-user', STRANGER);
+    expect(stranger.status).toBe(403);
+    expect(stranger.body.calls).toBeUndefined();
+
+    const member = await request(app).get(`/api/grants/${row.grantId}/calls`).set('x-test-user', MEMBER);
+    expect(member.status).toBe(200);
+    expect(member.body.counts).toEqual({ total: 3, ok: 1, refused: 1, pending_approval: 1, failed: 0 });
+    expect(member.body.calls).toHaveLength(2);
+    for (const line of member.body.calls) {
+      expect(line.argsDigest).toHaveLength(64);
+      expect(line).not.toHaveProperty('args');
+    }
+    expect(JSON.stringify(member.body)).not.toContain('secret/private');
+    expect(member.body.calls[1]).toMatchObject({ callId: 'call-2', outcome: 'refused', reason: 'not_in_audience', agentUserId: SEAT, tool: 'github.list_issues' });
+    expect(ToolCall.listForGrant).toHaveBeenCalledWith(row.grantId, 100);
+
+    // The seat the pod grant covers reads it too, on its runtime token.
+    const seat = await request(app).get(`/api/grants/${row.grantId}/calls`).set('Authorization', 'Bearer cm_agent_x').set('x-test-agent', SEAT);
+    expect(seat.status).toBe(200);
+    const foreignAgent = await request(app).get(`/api/grants/${row.grantId}/calls`).set('Authorization', 'Bearer cm_agent_x').set('x-test-agent', 'eeeeeeeeeeeeeeeeeeeeee01');
+    expect(foreignAgent.status).toBe(403);
+  });
+
+  test("a seat grant's trail is visible only to its granter and the seat", async () => {
+    const row = await RoomGrant.create(grant({ target: { kind: 'seat', id: SEAT }, audience: [SEAT] }));
+    const read = (headers) => request(app).get(`/api/grants/${row.grantId}/calls`).set(headers);
+    expect((await read({ 'x-test-user': OWNER })).status).toBe(200);
+    expect((await read({ Authorization: 'Bearer cm_agent_x', 'x-test-agent': SEAT })).status).toBe(200);
+    // A pod member who is not the granter, and another seat in the same pod, both refused.
+    expect((await read({ 'x-test-user': MEMBER })).status).toBe(403);
+    expect((await read({ Authorization: 'Bearer cm_agent_x', 'x-test-agent': OTHER_SEAT })).status).toBe(403);
+    expect((await read({ 'x-test-user': STRANGER })).status).toBe(403);
+    // Membership never substitutes for the granter check on a seat grant.
+    const dm = require('../../../services/dmService');
+    expect(dm.canViewPod).not.toHaveBeenCalled();
+  });
+
+  test('an unknown grant is 404 and the limit is clamped', async () => {
+    expect((await request(app).get('/api/grants/grant_nope/calls').set('x-test-user', MEMBER)).status).toBe(404);
+    const row = await RoomGrant.create(grant());
+    await request(app).get(`/api/grants/${row.grantId}/calls?limit=9999`).set('x-test-user', MEMBER);
+    expect(ToolCall.listForGrant).toHaveBeenLastCalledWith(row.grantId, 500);
+  });
+});
+
+describe('GET /api/grants/:grantId', () => {
+  test('GET /api/grants/:id returns the field list and never connectionId or brokerId', async () => {
+    const row = await RoomGrant.create(grant({ parentGrantId: null, rootGrantId: 'grant_root' }));
+    const res = await request(app).get(`/api/grants/${row.grantId}`).set('x-test-user', MEMBER);
+    expect(res.status).toBe(200);
+    expect(Object.keys(res.body).sort()).toEqual([...FIELDS].sort());
+    expect(res.body).toMatchObject({
+      grantId: row.grantId, installationId: 'install-1', target: { kind: 'pod', id: POD },
+      tools: ['github.list_issues', 'github.comment'], writeMode: 'write-with-confirm',
+      budget: { calls: 10, windowMs: 60000 }, effectiveAudience: [SEAT], revokedAt: null,
+      parentGrantId: null, rootGrantId: 'grant_root', grantedBy: OWNER,
+    });
+    expect(res.body.connectionId).toBeUndefined();
+    expect(res.body.brokerId).toBeUndefined();
+    expect(res.body.audience).toBeUndefined();
+    expect(res.body._id).toBeUndefined();
+    expect(JSON.stringify(res.body)).not.toMatch(/conn-1|broker-1|dddddddddddddddddddddd01/);
+    // Still member-scoped, as before the tightening.
+    expect((await request(app).get(`/api/grants/${row.grantId}`).set('x-test-user', STRANGER)).status).toBe(403);
+  });
+});

--- a/backend/__tests__/unit/routes/grants.read.test.js
+++ b/backend/__tests__/unit/routes/grants.read.test.js
@@ -29,6 +29,15 @@ jest.mock('../../../models/ToolCall', () => ({
   listForGrant: jest.fn(),
   countsForGrant: jest.fn(),
 }));
+// pods.ts ends with `router.get('/:type/:id', getPodById)`, which would answer
+// `/:podId/grants` as type=<podId>, id='grants' if it were mounted first
+// (Wren 67721 / Vera 67727). The controller is stubbed so that shadowing shows.
+jest.mock('../../../controllers/podController', () => ({
+  getAllPods: jest.fn((req, res) => res.status(500).json({ shadowed: 'getAllPods' })),
+  getPodsByType: jest.fn((req, res) => res.status(500).json({ shadowed: 'getPodsByType' })),
+  getPodById: jest.fn((req, res) => res.status(500).json({ shadowed: 'getPodById', params: req.params })),
+  createPod: jest.fn(), joinPod: jest.fn(), leavePod: jest.fn(), removeMember: jest.fn(), deletePod: jest.fn(),
+}));
 jest.mock('../../../services/dmService', () => ({
   canViewPod: jest.fn(async (userId, pod) => (pod.members || []).map(String).includes(String(userId))),
 }));
@@ -83,7 +92,9 @@ beforeAll(async () => {
   app = express();
   app.use(express.json());
   app.use('/api/grants', grants);
+  // Same order as server.ts: the grants list before the pod routes' catch-all.
   app.use('/api/pods', grants.podGrantsRouter);
+  app.use('/api/pods', require('../../../routes/pods'));
 });
 
 afterAll(async () => {
@@ -106,6 +117,14 @@ beforeEach(async () => {
 });
 
 describe('GET /api/pods/:podId/grants', () => {
+  test('GET /api/pods/:podId/grants is reachable with the pod routes mounted', async () => {
+    await RoomGrant.create(grant());
+    const res = await request(app).get(`/api/pods/${POD}/grants`).set('x-test-user', MEMBER);
+    expect(res.status).toBe(200);
+    expect(res.body.shadowed).toBeUndefined();
+    expect(res.body.grants).toHaveLength(1);
+  });
+
   test('the pod grants list refuses a non-member', async () => {
     await RoomGrant.create(grant());
     const stranger = await request(app).get(`/api/pods/${POD}/grants`).set('x-test-user', STRANGER);

--- a/backend/__tests__/unit/routes/grants.read.test.js
+++ b/backend/__tests__/unit/routes/grants.read.test.js
@@ -211,4 +211,21 @@ describe('GET /api/grants/:grantId', () => {
     // Still member-scoped, as before the tightening.
     expect((await request(app).get(`/api/grants/${row.grantId}`).set('x-test-user', STRANGER)).status).toBe(403);
   });
+
+  test("a seat grant's read is gated like its trail: granter and seat only (Vera 67727)", async () => {
+    const row = await RoomGrant.create(grant({ target: { kind: 'seat', id: SEAT }, audience: [SEAT] }));
+    const read = (headers) => request(app).get(`/api/grants/${row.grantId}`).set(headers);
+    const owner = await read({ 'x-test-user': OWNER });
+    expect(owner.status).toBe(200);
+    expect(owner.body.grantedBy).toBe(OWNER);
+    expect(owner.body.effectiveAudience).toEqual([SEAT]);
+    expect((await read({ Authorization: 'Bearer cm_agent_x', 'x-test-agent': SEAT })).status).toBe(200);
+    // A stranger in no pod, a pod member who is not the granter, another seat: 403, tools and granter unseen.
+    for (const headers of [{ 'x-test-user': STRANGER }, { 'x-test-user': MEMBER }, { Authorization: 'Bearer cm_agent_x', 'x-test-agent': OTHER_SEAT }]) {
+      const res = await read(headers);
+      expect(res.status).toBe(403);
+      expect(res.body.tools).toBeUndefined();
+      expect(res.body.grantedBy).toBeUndefined();
+    }
+  });
 });

--- a/backend/models/ToolCall.ts
+++ b/backend/models/ToolCall.ts
@@ -180,6 +180,8 @@ export const reserveBudget = async (
 ): Promise<boolean> => reserveBudgetLineage([{ grantId, calls, windowMs }]);
 
 class ToolCall {
+  static countsForGrant: (grantId: string) => Promise<ToolCallCounts>;
+
   static async create(record: ToolCallRecord): Promise<void> {
     const db = await ensureTables();
     await db.query(
@@ -231,6 +233,31 @@ class ToolCall {
     }));
   }
 }
+
+export interface ToolCallCounts {
+  total: number;
+  ok: number;
+  refused: number;
+  pending_approval: number;
+  failed: number;
+}
+
+/** The page's three numbers are COUNT(*) by outcome; nothing is estimated. */
+ToolCall.countsForGrant = async function countsForGrant(grantId: string): Promise<ToolCallCounts> {
+  const db = await ensureTables();
+  const result = await db.query(
+    'SELECT outcome, COUNT(*) AS n FROM tool_calls WHERE grant_id = $1 GROUP BY outcome',
+    [grantId],
+  );
+  const counts: ToolCallCounts = { total: 0, ok: 0, refused: 0, pending_approval: 0, failed: 0 };
+  for (const row of result.rows) {
+    const outcome = String(row.outcome) as ToolCallOutcome;
+    const n = Number(row.n) || 0;
+    if (outcome in counts) counts[outcome] = n;
+    counts.total += n;
+  }
+  return counts;
+};
 
 export { ToolCall };
 export default ToolCall;

--- a/backend/routes/grants.ts
+++ b/backend/routes/grants.ts
@@ -5,6 +5,8 @@ import { Types } from 'mongoose';
 import Integration from '../models/Integration';
 import Pod from '../models/Pod';
 import RoomGrant from '../models/RoomGrant';
+import ToolCall from '../models/ToolCall';
+import type { IRoomGrant } from '../models/RoomGrant';
 import {
   assertGrantUsable,
   attenuateGrant,
@@ -19,8 +21,21 @@ import type { RoomGrantCreateInput } from '../services/roomGrantService';
 const auth = require('../middleware/auth');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const agentRuntimeAuth = require('../middleware/agentRuntimeAuth');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const DMService = require('../services/dmService');
 
 const router = express.Router();
+
+// The trail is read by the people in the room and by the seat it was granted
+// to, so the calls route takes either identity — the shape reactions and
+// artifacts use.
+const dualAuth = (req: any, res: any, next: any) => {
+  const bearer = ((req.header?.('Authorization') || '').replace('Bearer ', '')).trim();
+  const altHeader = (req.header?.('x-commonly-agent-token') || '').trim();
+  const token = bearer || altHeader;
+  if (token.startsWith('cm_agent_')) return agentRuntimeAuth(req, res, next);
+  return auth(req, res, next);
+};
 
 const grantRateLimit = rateLimit({
   windowMs: 60_000,
@@ -38,6 +53,49 @@ const grantRateLimit = rateLimit({
 interface AuthenticatedRequest extends express.Request {
   userId?: string;
 }
+
+/**
+ * What the page may see of a grant (tools plan §6, Vera 67560/67568): the
+ * explicit list and nothing else. `connectionId` and `brokerId` are the
+ * broker's business; the raw `audience` snapshot still names agents who have
+ * left, so only the effective audience goes out.
+ */
+type GrantRow = Pick<IRoomGrant, 'grantId' | 'installationId' | 'target' | 'tools' | 'writeMode' | 'budget'
+  | 'expiresAt' | 'revokedAt' | 'parentGrantId' | 'rootGrantId' | 'createdAt'> & { audience?: string[]; connectionId?: string };
+
+const projectGrant = (grant: GrantRow, currentMembers: string[], grantedBy: string | null) => ({
+  grantId: grant.grantId,
+  installationId: grant.installationId,
+  target: { kind: grant.target.kind, id: grant.target.id },
+  tools: [...(grant.tools || [])],
+  writeMode: grant.writeMode,
+  budget: grant.budget ? { calls: grant.budget.calls, windowMs: grant.budget.windowMs } : null,
+  effectiveAudience: effectiveAudience(grant, currentMembers),
+  expiresAt: grant.expiresAt,
+  revokedAt: grant.revokedAt ?? null,
+  parentGrantId: grant.parentGrantId ?? null,
+  rootGrantId: grant.rootGrantId ?? null,
+  createdAt: grant.createdAt,
+  grantedBy,
+});
+
+/** `grantedBy` is the Connection's owner (plan §9); one lookup per connection. */
+const resolveGranters = async (connectionIds: string[]): Promise<Map<string, string | null>> => {
+  const granters = new Map<string, string | null>();
+  await Promise.all(Array.from(new Set(connectionIds)).map(async (connectionId) => {
+    const connection = await findConnection(connectionId).catch(() => null);
+    const owner = connectionOwnerId(connection);
+    granters.set(connectionId, owner || null);
+  }));
+  return granters;
+};
+
+const loadPod = async (podId: string) => (Types.ObjectId.isValid(podId)
+  ? Pod.findById(podId).select('type members').lean()
+  : null);
+
+const memberIdsOf = (pod: { members?: unknown[] } | null): string[] => (pod?.members || [])
+  .map((member: any) => String(member?._id ?? member));
 
 const callerId = (req: AuthenticatedRequest): string => {
   const user = req.user as { id?: string; _id?: string } | undefined;
@@ -198,19 +256,109 @@ const revokeHandler = async (req: AuthenticatedRequest, res: express.Response): 
 router.post('/:grantId/revoke', grantRateLimit, auth, revokeHandler);
 router.delete('/:grantId', grantRateLimit, auth, revokeHandler);
 
-// Read is intentionally member-scoped. The route exposes the effective
-// audience, never raw connection material or the owner's secret reference.
+/**
+ * The trail (plan §6): one line per ToolCall, newest first, plus COUNT(*) by
+ * outcome. Gated by canViewPod on the grant's target pod; a seat grant's trail
+ * goes only to the granter and that seat. A line carries `argsDigest`, never
+ * the arguments — the broker never stored them (ToolCall.digestArgs).
+ */
+router.get('/:grantId/calls', grantRateLimit, dualAuth, async (req: AuthenticatedRequest, res: express.Response) => {
+  try {
+    const grant = await RoomGrant.findOne({ grantId: req.params.grantId }).lean();
+    if (!grant) return res.status(404).json({ error: 'grant_not_found' });
+    const agentId = (req as any).agentUser?._id ? String((req as any).agentUser._id) : '';
+    const humanId = agentId ? '' : callerId(req);
+    if (!agentId && !humanId) return res.status(401).json({ error: 'unauthorized' });
+
+    if (grant.target.kind === 'seat') {
+      const granters = await resolveGranters([grant.connectionId]);
+      const isGranter = Boolean(humanId) && granters.get(grant.connectionId) === humanId;
+      const isSeat = Boolean(agentId) && agentId === String(grant.target.id);
+      if (!isGranter && !isSeat) return res.status(403).json({ error: 'access_denied' });
+    } else {
+      const pod = await loadPod(grant.target.id);
+      if (!pod) return res.status(404).json({ error: 'target_not_found' });
+      if (!await DMService.canViewPod(agentId || humanId, pod)) return res.status(403).json({ error: 'access_denied' });
+    }
+
+    const limitRaw = Number(req.query.limit);
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(500, Math.trunc(limitRaw)) : 100;
+    const [rows, counts] = await Promise.all([
+      ToolCall.listForGrant(grant.grantId, limit),
+      ToolCall.countsForGrant(grant.grantId),
+    ]);
+    return res.json({
+      grantId: grant.grantId,
+      calls: rows.map((row) => ({
+        callId: row.callId,
+        agentUserId: row.agentUserId,
+        tool: row.tool,
+        outcome: row.outcome,
+        reason: row.reason ?? null,
+        approvalId: row.approvalId ?? null,
+        argsDigest: row.argsDigest,
+        at: row.at ?? null,
+        durationMs: row.durationMs ?? null,
+      })),
+      counts,
+    });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+// Read is intentionally member-scoped and projected: the explicit field list
+// and nothing else — never connectionId, brokerId or the raw audience snapshot.
 router.get('/:grantId', grantRateLimit, auth, async (req: AuthenticatedRequest, res: express.Response) => {
   try {
     const grant = await RoomGrant.findOne({ grantId: req.params.grantId }).lean();
     if (!grant) return res.status(404).json({ error: 'grant_not_found' });
     const members = await ensureTargetAccess(grant.target, callerId(req));
     const currentMembers = grant.target.kind === 'seat' ? grant.audience : members;
-    return res.json({ ...grant, effectiveAudience: effectiveAudience(grant, currentMembers) });
+    const granters = await resolveGranters([grant.connectionId]);
+    return res.json(projectGrant(grant, currentMembers, granters.get(grant.connectionId) ?? null));
   } catch (error) {
     return handleError(res, error);
   }
 });
 
+/**
+ * GET /api/pods/:podId/grants — every grant whose target is the pod or a seat
+ * in it, gated by canViewPod, each row projected. Mounted under /api/pods by
+ * server.ts beside the pod routes.
+ */
+const podGrantsRouter = express.Router();
+podGrantsRouter.get('/:podId/grants', grantRateLimit, auth, async (req: AuthenticatedRequest, res: express.Response) => {
+  try {
+    const userId = callerId(req);
+    if (!userId) return res.status(401).json({ error: 'unauthorized' });
+    const podId = String(req.params.podId || '');
+    if (!Types.ObjectId.isValid(podId)) return res.status(403).json({ error: 'access_denied' });
+    const pod = await loadPod(podId);
+    if (!pod) return res.status(404).json({ error: 'pod_not_found' });
+    if (!await DMService.canViewPod(userId, pod)) return res.status(403).json({ error: 'access_denied' });
+    const members = memberIdsOf(pod);
+    const grants = await RoomGrant.find({
+      $or: [
+        { 'target.kind': 'pod', 'target.id': podId },
+        ...(members.length ? [{ 'target.kind': 'seat', 'target.id': { $in: members } }] : []),
+      ],
+    }).sort({ createdAt: -1 }).lean();
+    const granters = await resolveGranters(grants.map((grant) => grant.connectionId));
+    return res.json({
+      podId,
+      grants: grants.map((grant) => projectGrant(
+        grant,
+        grant.target.kind === 'seat' ? grant.audience : members,
+        granters.get(grant.connectionId) ?? null,
+      )),
+    });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+export { podGrantsRouter };
 export default router;
 module.exports = router;
+module.exports.podGrantsRouter = podGrantsRouter;

--- a/backend/routes/grants.ts
+++ b/backend/routes/grants.ts
@@ -262,24 +262,43 @@ router.delete('/:grantId', grantRateLimit, auth, revokeHandler);
  * goes only to the granter and that seat. A line carries `argsDigest`, never
  * the arguments — the broker never stored them (ToolCall.digestArgs).
  */
+/**
+ * One gate for both reads (Vera 67727): a pod grant belongs to the pod, so
+ * canViewPod decides for a human or a seat on its runtime token; a seat grant
+ * goes only to the granter (the Connection's owner) and that seat.
+ */
+const gateGrantRead = async (
+  grant: { target: { kind: 'pod' | 'seat'; id: string }; connectionId: string },
+  req: AuthenticatedRequest,
+): Promise<{ status: number; error: string } | { members: string[]; granter: string | null }> => {
+  const agentId = (req as any).agentUser?._id ? String((req as any).agentUser._id) : '';
+  const humanId = agentId ? '' : callerId(req);
+  if (!agentId && !humanId) return { status: 401, error: 'unauthorized' };
+  const granters = await resolveGranters([grant.connectionId]);
+  const granter = granters.get(grant.connectionId) ?? null;
+  if (grant.target.kind === 'seat') {
+    const isGranter = Boolean(humanId) && granter === humanId;
+    const isSeat = Boolean(agentId) && agentId === String(grant.target.id);
+    if (!isGranter && !isSeat) return { status: 403, error: 'access_denied' };
+    return { members: [], granter };
+  }
+  const pod = await loadPod(grant.target.id);
+  if (!pod) return { status: 404, error: 'target_not_found' };
+  if (!await DMService.canViewPod(agentId || humanId, pod)) return { status: 403, error: 'access_denied' };
+  return { members: memberIdsOf(pod), granter };
+};
+
+/**
+ * The trail (plan §6): one line per ToolCall, newest first, plus COUNT(*) by
+ * outcome. A line carries `argsDigest`, never the arguments — the broker never
+ * stored them (ToolCall.digestArgs).
+ */
 router.get('/:grantId/calls', grantRateLimit, dualAuth, async (req: AuthenticatedRequest, res: express.Response) => {
   try {
     const grant = await RoomGrant.findOne({ grantId: req.params.grantId }).lean();
     if (!grant) return res.status(404).json({ error: 'grant_not_found' });
-    const agentId = (req as any).agentUser?._id ? String((req as any).agentUser._id) : '';
-    const humanId = agentId ? '' : callerId(req);
-    if (!agentId && !humanId) return res.status(401).json({ error: 'unauthorized' });
-
-    if (grant.target.kind === 'seat') {
-      const granters = await resolveGranters([grant.connectionId]);
-      const isGranter = Boolean(humanId) && granters.get(grant.connectionId) === humanId;
-      const isSeat = Boolean(agentId) && agentId === String(grant.target.id);
-      if (!isGranter && !isSeat) return res.status(403).json({ error: 'access_denied' });
-    } else {
-      const pod = await loadPod(grant.target.id);
-      if (!pod) return res.status(404).json({ error: 'target_not_found' });
-      if (!await DMService.canViewPod(agentId || humanId, pod)) return res.status(403).json({ error: 'access_denied' });
-    }
+    const gate = await gateGrantRead(grant, req);
+    if ('status' in gate) return res.status(gate.status).json({ error: gate.error });
 
     const limitRaw = Number(req.query.limit);
     const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(500, Math.trunc(limitRaw)) : 100;
@@ -307,16 +326,16 @@ router.get('/:grantId/calls', grantRateLimit, dualAuth, async (req: Authenticate
   }
 });
 
-// Read is intentionally member-scoped and projected: the explicit field list
-// and nothing else — never connectionId, brokerId or the raw audience snapshot.
-router.get('/:grantId', grantRateLimit, auth, async (req: AuthenticatedRequest, res: express.Response) => {
+// Read is gated exactly as the trail is, and projected: the explicit field
+// list and nothing else — never connectionId, brokerId or the raw audience.
+router.get('/:grantId', grantRateLimit, dualAuth, async (req: AuthenticatedRequest, res: express.Response) => {
   try {
     const grant = await RoomGrant.findOne({ grantId: req.params.grantId }).lean();
     if (!grant) return res.status(404).json({ error: 'grant_not_found' });
-    const members = await ensureTargetAccess(grant.target, callerId(req));
-    const currentMembers = grant.target.kind === 'seat' ? grant.audience : members;
-    const granters = await resolveGranters([grant.connectionId]);
-    return res.json(projectGrant(grant, currentMembers, granters.get(grant.connectionId) ?? null));
+    const gate = await gateGrantRead(grant, req);
+    if ('status' in gate) return res.status(gate.status).json({ error: gate.error });
+    const currentMembers = grant.target.kind === 'seat' ? grant.audience : gate.members;
+    return res.json(projectGrant(grant, currentMembers, gate.granter));
   } catch (error) {
     return handleError(res, error);
   }

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -208,6 +208,8 @@ app.use('/api/users', userRoutes);
 // GET must mount before `/api/pods`. Its `/:type/:id` catch-all would
 // otherwise consume that request as a pod lookup.
 app.use('/api', podInvitesRoutes);
+// Before podRoutes: its `/:type/:id` catch-all would answer `/:podId/grants` as type=<podId>, id='grants' (Wren 67721).
+app.use('/api/pods', require('./routes/grants').podGrantsRouter); // tools plan §6: GET /api/pods/:podId/grants, the page's list
 app.use('/api/pods', podRoutes);
 app.use('/api/billing', require('./routes/billing'));
 app.use('/api/messages', messageRoutes);
@@ -238,7 +240,6 @@ app.use('/api/v1/tasks', tasksApiRoutes); // Task management for dev agents
 app.use('/api/registry', registryRoutes); // Agent Registry (package manager for agents)
 app.use('/api/credentials', require('./routes/credentials')); // ADR-026 Phase 0: credential lineage + revocation
 app.use('/api/grants', require('./routes/grants')); // ADR-001 room-grant record: server-enforced attenuation + cascade revocation
-app.use('/api/pods', require('./routes/grants').podGrantsRouter); // tools plan §6: GET /api/pods/:podId/grants, the page's list
 app.use('/api/mcp/grants', require('./routes/mcpGrants')); // ADR-001 tool broker: stateless MCP transport + attributed trail
 app.use('/api/agent-binding', require('./routes/agentBinding')); // ADR-026 D3: machine adoption CAS
 app.use('/api/machines', require('./routes/machines')); // ADR-026 Phase 1: local daemon lifecycle

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -238,6 +238,7 @@ app.use('/api/v1/tasks', tasksApiRoutes); // Task management for dev agents
 app.use('/api/registry', registryRoutes); // Agent Registry (package manager for agents)
 app.use('/api/credentials', require('./routes/credentials')); // ADR-026 Phase 0: credential lineage + revocation
 app.use('/api/grants', require('./routes/grants')); // ADR-001 room-grant record: server-enforced attenuation + cascade revocation
+app.use('/api/pods', require('./routes/grants').podGrantsRouter); // tools plan §6: GET /api/pods/:podId/grants, the page's list
 app.use('/api/mcp/grants', require('./routes/mcpGrants')); // ADR-001 tool broker: stateless MCP transport + attributed trail
 app.use('/api/agent-binding', require('./routes/agentBinding')); // ADR-026 D3: machine adoption CAS
 app.use('/api/machines', require('./routes/machines')); // ADR-026 Phase 1: local daemon lifecycle


### PR DESCRIPTION
Piece 4 of the connectors build, option A — the read routes named in `docs/plans/tools-catalogue-room-grants.md` §6 **Sequencing**, before the page. Assignment: Connectors v2 pod 67699. Reviewer: Vera clears the exact head.

**Routes**
1. `GET /api/pods/:podId/grants` — every grant whose target is the pod or a seat in it (seat id ∈ pod members), gated by `DMService.canViewPod`, each row projected. Malformed id → 403, missing pod → 404. Mounted under `/api/pods` beside the pod routes (`server.ts`).
2. `GET /api/grants/:grantId/calls` — `ToolCall.listForGrant` (limit ≤500, default 100) plus `counts` = COUNT(*) by outcome (`{total, ok, refused, pending_approval, failed}`; new `ToolCall.countsForGrant`). Pod target: `canViewPod` for a human or a seat on its runtime token (dualAuth). Seat target: only the granter (Connection owner) or that seat; membership never substitutes. Lines carry `argsDigest`, never `args`.
3. `GET /api/grants/:grantId` — tightened to the explicit field list: `grantId, installationId, target, tools, writeMode, budget, effectiveAudience, expiresAt, revokedAt, parentGrantId, rootGrantId, createdAt, grantedBy`. Never `connectionId`, `brokerId`, `audience`, `_id` (Vera 67560/67568). `grantedBy` is resolved from the Connection's owner.

**Named tests** (`backend/__tests__/unit/routes/grants.read.test.js`, memory Mongo for `RoomGrant`; pod, connection and trail mocked at their module boundaries):
- `the pod grants list refuses a non-member`
- `the trail refuses a non-member and never returns args`
- `a seat grant's trail is visible only to its granter and the seat`
- `GET /api/grants/:id returns the field list and never connectionId or brokerId`
- plus: seat-in-pod list shape with effective audience only; 404 + limit clamp; `ToolCall.countsForGrant` on pg-mem (`ToolCall.counts.test.js`).

Backend 18/18 across the grant suites (`mcpGrants.test.js` needs `@modelcontextprotocol/sdk`, absent from my local node_modules — CI has it), `lint:ts` 0 errors. No frontend changes in this PR; the page follows in its own `wave/piece4-*` branch once these are cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DspLEe1mFV94dPGCqA1u5
