### PR TITLE
fix(integrations): platformIntegration joins only the Discord model (#1672)

### DIFF
--- a/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
+++ b/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
@@ -11,9 +11,13 @@ const request = require('supertest');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const mongoose = require('mongoose');
 
+// Identity from a header so one app can be called as a member and a stranger.
+// Pod stays real: the admin list populates `podId`, so the model has to be
+// registered, and the pod list's canViewPod gate runs against real rows.
 jest.mock('../../../middleware/auth', () => (req, res, next) => {
-  req.user = { id: 'admin-1' };
-  req.userId = 'admin-1';
+  const id = req.get('x-test-user') || 'bbbbbbbbbbbbbbbbbbbbbb01';
+  req.user = { id };
+  req.userId = id;
   next();
 });
 jest.mock('../../../middleware/adminAuth', () => (req, res, next) => next());
@@ -21,8 +25,11 @@ jest.mock('../../../middleware/adminAuth', () => (req, res, next) => next());
 const POD = new mongoose.Types.ObjectId();
 const OTHER_POD = new mongoose.Types.ObjectId();
 const CREATOR = new mongoose.Types.ObjectId();
+const MEMBER = 'bbbbbbbbbbbbbbbbbbbbbb01'; // the auth mock's default caller
+const STRANGER = 'bbbbbbbbbbbbbbbbbbbbbb02';
 
 let mongod;
+let Pod;
 let Integration;
 let DiscordIntegration;
 let app;
@@ -40,6 +47,7 @@ const row = (over = {}) => ({
 beforeAll(async () => {
   mongod = await MongoMemoryServer.create();
   await mongoose.connect(mongod.getUri());
+  Pod = require('../../../models/Pod');
   Integration = require('../../../models/Integration');
   DiscordIntegration = require('../../../models/DiscordIntegration');
   const routes = require('../../../routes/integrations');
@@ -54,8 +62,13 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+  await Pod.deleteMany({});
   await Integration.deleteMany({});
   await DiscordIntegration.deleteMany({});
+  await Pod.create([
+    { _id: POD, name: 'Ops', createdBy: CREATOR, members: [MEMBER] },
+    { _id: OTHER_POD, name: 'Guild', createdBy: CREATOR, members: [MEMBER] },
+  ]);
 });
 
 const seedTelegramAndDiscord = async () => {
@@ -97,7 +110,7 @@ describe('platformIntegration virtual (#1672)', () => {
     expect(joined.platformIntegration).toMatchObject({ serverId: 'srv-1', channelId: 'chan-1' });
   });
 
-  it('the Discord join never returns the bot token or the webhook URL', async () => {
+  it('the integration lists never return the bot token or webhook secret', async () => {
     await seedTelegramAndDiscord();
 
     const admin = await request(app).get('/api/integrations/admin/all');
@@ -122,5 +135,16 @@ describe('platformIntegration virtual (#1672)', () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
     expect(res.body[0].type).toBe('telegram');
+  });
+
+  it('the pod list is gated by canViewPod', async () => {
+    await seedTelegramAndDiscord();
+
+    const stranger = await request(app).get(`/api/integrations/${POD}`).set('x-test-user', STRANGER);
+    const missing = await request(app).get(`/api/integrations/${new mongoose.Types.ObjectId()}`);
+
+    expect(stranger.status).toBe(403);
+    expect(stranger.body).toEqual({ message: 'Access denied' });
+    expect(missing.status).toBe(404);
   });
 });

--- a/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
+++ b/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
@@ -137,7 +137,7 @@ describe('platformIntegration virtual (#1672)', () => {
     expect(res.body[0].type).toBe('telegram');
   });
 
-  it('the pod list is gated by canViewPod', async () => {
+  it('the pod integrations list refuses a non-member', async () => {
     await seedTelegramAndDiscord();
 
     const stranger = await request(app).get(`/api/integrations/${POD}`).set('x-test-user', STRANGER);
@@ -146,5 +146,44 @@ describe('platformIntegration virtual (#1672)', () => {
     expect(stranger.status).toBe(403);
     expect(stranger.body).toEqual({ message: 'Access denied' });
     expect(missing.status).toBe(404);
+  });
+
+  // Vera's 67858 probe: with the 500 gone, the pod list and the admin list
+  // returned every credential the config carries. A member still sees the
+  // Telegram connectCode, which is the one value the Connectors page pastes.
+  it('no integration response carries a credential', async () => {
+    const SECRETS = {
+      botToken: 'tg-bot-token',
+      secretToken: 'tg-secret-token',
+      signingSecret: 'slack-signing-secret',
+      accessToken: 'x-access-token',
+      refreshToken: 'x-refresh-token',
+      webhookUrl: 'https://hooks.slack.com/services/T1/B1/hook-secret',
+      botTokenRef: 'cs_ref_1',
+      oauthStateNonce: 'nonce-1',
+    };
+    await Integration.create([
+      row({ type: 'telegram', config: { chatId: '-100', connectCode: 'CODE-1', botToken: SECRETS.botToken, secretToken: SECRETS.secretToken, botTokenRef: SECRETS.botTokenRef } }),
+      row({ type: 'x', config: { username: 'ops', accessToken: SECRETS.accessToken, refreshToken: SECRETS.refreshToken } }),
+      row({ type: 'slack', config: { teamId: 'T1', signingSecret: SECRETS.signingSecret, webhookUrl: SECRETS.webhookUrl, oauthStateNonce: SECRETS.oauthStateNonce, pendingBind: { teamId: 'T1', botTokenRef: SECRETS.botTokenRef } } }),
+    ]);
+
+    const admin = await request(app).get('/api/integrations/admin/all');
+    const pod = await request(app).get(`/api/integrations/${POD}`);
+
+    expect(admin.status).toBe(200);
+    expect(pod.status).toBe(200);
+    for (const body of [admin.body, pod.body]) {
+      expect(body).toHaveLength(3);
+      const configs = body.map((entry) => entry.config);
+      Object.keys(SECRETS).forEach((key) => {
+        configs.forEach((config) => expect(config).not.toHaveProperty(key));
+      });
+      const slack = body.find((entry) => entry.type === 'slack');
+      expect(slack.config.pendingBind).toEqual({ teamId: 'T1' });
+      const serialized = JSON.stringify(body);
+      Object.values(SECRETS).forEach((value) => expect(serialized).not.toContain(value));
+      expect(body.find((entry) => entry.type === 'telegram').config.connectCode).toBe('CODE-1');
+    }
   });
 });

--- a/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
+++ b/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
@@ -1,0 +1,109 @@
+/**
+ * #1672 — the `platformIntegration` virtual named models nothing registers
+ * ('TelegramIntegration', 'SlackIntegration', 'MessengerIntegration'), so the
+ * first non-Discord row made Mongoose throw MissingSchemaError inside every
+ * populate of it: the admin Apps list and the pod list both answered 500.
+ * Integration and DiscordIntegration run on memory Mongo because the populate
+ * itself is the thing under test.
+ */
+const express = require('express');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const mongoose = require('mongoose');
+
+jest.mock('../../../middleware/auth', () => (req, res, next) => {
+  req.user = { id: 'admin-1' };
+  req.userId = 'admin-1';
+  next();
+});
+jest.mock('../../../middleware/adminAuth', () => (req, res, next) => next());
+
+const POD = new mongoose.Types.ObjectId();
+const OTHER_POD = new mongoose.Types.ObjectId();
+const CREATOR = new mongoose.Types.ObjectId();
+
+let mongod;
+let Integration;
+let DiscordIntegration;
+let app;
+
+const row = (over = {}) => ({
+  podId: POD,
+  scope: 'pod',
+  status: 'connected',
+  createdBy: CREATOR,
+  isActive: true,
+  config: {},
+  ...over,
+});
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  Integration = require('../../../models/Integration');
+  DiscordIntegration = require('../../../models/DiscordIntegration');
+  const routes = require('../../../routes/integrations');
+  app = express();
+  app.use(express.json());
+  app.use('/api/integrations', routes);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  await Integration.deleteMany({});
+  await DiscordIntegration.deleteMany({});
+});
+
+const seedTelegramAndDiscord = async () => {
+  await Integration.create(row({ type: 'telegram', config: { chatId: '-100', chatTitle: 'Ops' } }));
+  const discord = await Integration.create(row({ type: 'discord', podId: OTHER_POD }));
+  await DiscordIntegration.create({
+    integrationId: discord._id,
+    serverId: 'srv-1',
+    serverName: 'Guild',
+    channelId: 'chan-1',
+    channelName: 'general',
+    webhookUrl: 'https://discord.com/api/webhooks/1/x',
+    webhookId: '1',
+    botToken: 'bot-token',
+  });
+  return discord;
+};
+
+describe('platformIntegration virtual (#1672)', () => {
+  it('the admin list answers 200 with a Telegram row', async () => {
+    await seedTelegramAndDiscord();
+
+    const res = await request(app).get('/api/integrations/admin/all');
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((entry) => entry.type).sort()).toEqual(['discord', 'telegram']);
+    const telegram = res.body.find((entry) => entry.type === 'telegram');
+    expect(telegram.platformIntegration == null).toBe(true);
+  });
+
+  it('the Discord row still joins its platform record', async () => {
+    const discord = await seedTelegramAndDiscord();
+
+    const res = await request(app).get('/api/integrations/admin/all');
+
+    expect(res.status).toBe(200);
+    const joined = res.body.find((entry) => entry.type === 'discord');
+    expect(String(joined._id)).toBe(String(discord._id));
+    expect(joined.platformIntegration).toMatchObject({ serverId: 'srv-1', channelId: 'chan-1' });
+  });
+
+  it('the pod list answers 200 with a Telegram row', async () => {
+    await seedTelegramAndDiscord();
+
+    const res = await request(app).get(`/api/integrations/${POD}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].type).toBe('telegram');
+  });
+});

--- a/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
+++ b/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
@@ -97,6 +97,23 @@ describe('platformIntegration virtual (#1672)', () => {
     expect(joined.platformIntegration).toMatchObject({ serverId: 'srv-1', channelId: 'chan-1' });
   });
 
+  it('the Discord join never returns the bot token or the webhook URL', async () => {
+    await seedTelegramAndDiscord();
+
+    const admin = await request(app).get('/api/integrations/admin/all');
+    const pod = await request(app).get(`/api/integrations/${OTHER_POD}`);
+
+    expect(admin.status).toBe(200);
+    expect(pod.status).toBe(200);
+    for (const body of [admin.body, pod.body]) {
+      const joined = body.find((entry) => entry.type === 'discord').platformIntegration;
+      expect(joined).toMatchObject({ serverId: 'srv-1', webhookId: '1' });
+      expect(joined).not.toHaveProperty('botToken');
+      expect(joined).not.toHaveProperty('webhookUrl');
+      expect(JSON.stringify(body)).not.toMatch(/bot-token|api\/webhooks/);
+    }
+  });
+
   it('the pod list answers 200 with a Telegram row', async () => {
     await seedTelegramAndDiscord();
 

--- a/backend/__tests__/unit/services/installableCatalogService.test.js
+++ b/backend/__tests__/unit/services/installableCatalogService.test.js
@@ -45,6 +45,13 @@ describe('installable catalog service', () => {
       config: {
         botTokenRef: 'secret-ref',
         oauthStateNonce: 'nonce',
+        botToken: 'tg-bot-token',
+        secretToken: 'tg-secret-token',
+        accessToken: 'x-access-token',
+        refreshToken: 'x-refresh-token',
+        signingSecret: 'slack-signing-secret',
+        webhookUrl: 'https://hooks.slack.com/services/T1/B1/hook-secret',
+        connectCode: 'CODE-1',
         chatTitle: 'Ops',
         adminPause: {
           reason: 'Safety review in progress.',
@@ -71,6 +78,7 @@ describe('installable catalog service', () => {
         integration: expect.objectContaining({
           installationId,
           config: {
+            connectCode: 'CODE-1',
             chatTitle: 'Ops',
             adminPause: {
               reason: 'Safety review in progress.',
@@ -88,7 +96,7 @@ describe('installable catalog service', () => {
       }),
     ]);
     expect(InstallableInstallation.find).toHaveBeenCalledWith(expect.objectContaining({ targetId: userId }));
-    expect(JSON.stringify(catalog)).not.toMatch(/SLACK_|CONNECTOR_SECRET|private-claim|secret-ref|nonce|adminId|admin-private-id/);
+    expect(JSON.stringify(catalog)).not.toMatch(/SLACK_|CONNECTOR_SECRET|private-claim|secret-ref|nonce|adminId|admin-private-id|-token|signing-secret|hook-secret/);
   });
 
   it('does not read projections when the caller has no live parent', async () => {

--- a/backend/models/DiscordIntegration.ts
+++ b/backend/models/DiscordIntegration.ts
@@ -81,7 +81,19 @@ DiscordIntegrationSchema.virtual('recentMessages').get(function (this: IDiscordI
     .slice(0, 50);
 });
 
-DiscordIntegrationSchema.set('toJSON', { virtuals: true });
+// The record joins onto Integration as `platformIntegration` and rides out
+// through every list that populates it (admin Apps list, pod list, create).
+// botToken is the instance-wide DISCORD_BOT_TOKEN and webhookUrl carries the
+// webhook's secret; both stay server-only in every JSON response. Server code
+// reads them off the document, never off its JSON.
+DiscordIntegrationSchema.set('toJSON', {
+  virtuals: true,
+  transform: (_doc: unknown, returned: Record<string, unknown>) => {
+    delete returned.botToken;
+    delete returned.webhookUrl;
+    return returned;
+  },
+});
 DiscordIntegrationSchema.set('toObject', { virtuals: true });
 
 export default mongoose.model<IDiscordIntegration>('DiscordIntegration', DiscordIntegrationSchema);

--- a/backend/models/Integration.ts
+++ b/backend/models/Integration.ts
@@ -341,15 +341,13 @@ IntegrationSchema.index({ 'ingestTokens.tokenHash': 1 });
 // solely by its workspace and channel, then still checks isActive.
 IntegrationSchema.index({ type: 1, 'config.teamId': 1, 'config.chatId': 1, isActive: 1 });
 
+// Only Discord keeps platform state in a collection of its own; every other
+// connector carries it in `config`. A ref naming a model nothing registers is
+// not a no-op: Mongoose throws MissingSchemaError at populate time, and one
+// Telegram row took the admin list down with it (#1672). Null skips the join.
 IntegrationSchema.virtual('platformIntegration', {
   ref() {
-    switch ((this as IIntegration).type) {
-      case 'discord': return 'DiscordIntegration';
-      case 'telegram': return 'TelegramIntegration';
-      case 'slack': return 'SlackIntegration';
-      case 'messenger': return 'MessengerIntegration';
-      default: return null;
-    }
+    return (this as IIntegration).type === 'discord' ? 'DiscordIntegration' : null;
   },
   localField: '_id',
   foreignField: 'integrationId',

--- a/backend/models/Integration.ts
+++ b/backend/models/Integration.ts
@@ -1,4 +1,5 @@
 import mongoose, { Document, Schema, Types } from 'mongoose';
+import { toPublicIntegrationConfig } from './integrationPublicConfig';
 
 export type IntegrationType =
   | 'discord'
@@ -354,25 +355,14 @@ IntegrationSchema.virtual('platformIntegration', {
   justOne: true,
 });
 
-// A ConnectorSecret reference is itself not a bearer credential, but returning
-// it still widens the set of clients that can reason about server-side secret
-// storage. Keep it server-only in every normal JSON response, including the
-// pending OAuth bind that needs to show its workspace/user details.
+// Bearer credentials and the references that point at one are server-only in
+// every normal JSON response, including the pending OAuth bind that needs to
+// show its workspace/user details. The key list lives in
+// integrationPublicConfig so the lean catalog read strips the same fields.
 IntegrationSchema.set('toJSON', {
   virtuals: true,
   transform: (_doc: unknown, returned: { config?: Record<string, unknown> }) => {
-    if (!returned.config) return returned;
-    delete returned.config.botTokenRef;
-    delete returned.config.oauthStateNonce;
-    const pending = returned.config.pendingBind;
-    if (pending && typeof pending === 'object') {
-      delete (pending as Record<string, unknown>).botTokenRef;
-    }
-    const adminPause = returned.config.adminPause;
-    if (adminPause && typeof adminPause === 'object') {
-      const { reason, at } = adminPause as { reason?: unknown; at?: unknown };
-      returned.config.adminPause = { reason, at };
-    }
+    toPublicIntegrationConfig(returned.config);
     return returned;
   },
 });

--- a/backend/models/integrationPublicConfig.ts
+++ b/backend/models/integrationPublicConfig.ts
@@ -1,0 +1,48 @@
+/**
+ * The one list of Integration config keys that never leave the server.
+ *
+ * Bearer credentials (bot tokens, signing secrets, OAuth access and refresh
+ * tokens, webhook URLs that embed their secret) and the references that point
+ * at one (a ConnectorSecret ref, a browser-bound OAuth nonce). The providers
+ * read all of them off the document; no browser needs any of them, and until
+ * #1673 the X and Instagram edit forms prefilled accessToken from the pod list
+ * because it happened to be there. `connectCode` is deliberately NOT here: it
+ * is the one-time enable code a member pastes into Telegram, and ChatRoom and
+ * the Connectors page read it from the pod list.
+ *
+ * Every JSON path an Integration takes out of the server runs through
+ * toPublicIntegrationConfig: the model's toJSON, and the lean catalog read in
+ * installableCatalogService that bypasses toJSON. Add a key here, not at the
+ * call sites.
+ */
+export const INTEGRATION_SECRET_CONFIG_KEYS = [
+  'botToken',
+  'signingSecret',
+  'secretToken',
+  'accessToken',
+  'refreshToken',
+  'webhookUrl',
+  'botTokenRef',
+  'oauthStateNonce',
+] as const;
+
+export const toPublicIntegrationConfig = (
+  config: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null | undefined => {
+  if (!config || typeof config !== 'object') return config;
+  INTEGRATION_SECRET_CONFIG_KEYS.forEach((key) => { delete config[key]; });
+  const pending = config.pendingBind;
+  if (pending && typeof pending === 'object') {
+    delete (pending as Record<string, unknown>).botTokenRef;
+  }
+  const adminPause = config.adminPause;
+  if (adminPause && typeof adminPause === 'object') {
+    const { reason, at } = adminPause as { reason?: unknown; at?: unknown };
+    config.adminPause = { reason, at };
+  }
+  return config;
+};
+
+// CJS compat: let require() return the named exports directly
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+module.exports = exports;

--- a/backend/routes/integrations.ts
+++ b/backend/routes/integrations.ts
@@ -319,7 +319,10 @@ router.delete('/:id/ingest-tokens/:tokenId', auth, async (req: AuthReq, res: Res
   }
 });
 
-router.get('/:podId', auth, async (req: AuthReq, res: Res) => {
+// Same read bucket as /user/all: token-hash/IP keyed, ahead of auth, so the
+// membership lookup below cannot be driven unmetered (CodeQL
+// js/missing-rate-limiting on the gated route).
+router.get('/:podId', listIntegrationsRateLimit, auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
     // Pod-scoped content: canViewPod decides (members, admins, the agent-dm

--- a/backend/routes/integrations.ts
+++ b/backend/routes/integrations.ts
@@ -322,8 +322,16 @@ router.delete('/:id/ingest-tokens/:tokenId', auth, async (req: AuthReq, res: Res
 router.get('/:podId', auth, async (req: AuthReq, res: Res) => {
   try {
     const { podId } = req.params || {};
+    // Pod-scoped content: canViewPod decides (members, admins, the agent-dm
+    // fan-out), the same gate every other pod-scoped read uses. Until #1673
+    // any signed-in user could list any pod's rows.
+    const pod = await Pod.findById(podId);
+    if (!pod) return res.status(404).json({ message: 'Pod not found' });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    const DMService = require('../services/dmService');
+    if (!await DMService.canViewPod(req.user?.id, pod)) return res.status(403).json({ message: 'Access denied' });
     const integrations = await Integration.find({ podId, isActive: true }).populate('createdBy', 'username email').populate('platformIntegration');
-    res.json(integrations);
+    return res.json(integrations);
   } catch (error) {
     console.error('Error fetching integrations:', error);
     res.status(500).json({ message: 'Server error' });

--- a/backend/services/installable/installableCatalogService.ts
+++ b/backend/services/installable/installableCatalogService.ts
@@ -5,6 +5,8 @@ const InstallableInstallation = require('../../models/InstallableInstallation');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
 const Integration = require('../../models/Integration');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+const { toPublicIntegrationConfig } = require('../../models/integrationPublicConfig');
+// eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
 const { manifests } = require('../../integrations/manifests');
 
 type ProviderReadiness = { available: boolean; reason?: 'not_configured' };
@@ -25,9 +27,9 @@ const providerReadiness = (installableId: string): ProviderReadiness | null => {
   return typeof manifest?.readiness === 'function' ? manifest.readiness() : null;
 };
 
-// Mongoose's Integration toJSON transform is the normal guard. Keep this
-// explicit mapper for lean catalog reads too, so the API can never serialize a
-// ConnectorSecret reference or a browser-bound OAuth nonce by accident.
+// Mongoose's Integration toJSON transform is the normal guard. Lean catalog
+// reads bypass it, so they run the same strip explicitly: one key list, so a
+// credential can never be serialized here that toJSON would have dropped.
 const publicIntegration = (integration: unknown): unknown => {
   if (!integration || typeof integration !== 'object') return integration;
   const raw = typeof (integration as { toJSON?: () => unknown }).toJSON === 'function'
@@ -35,16 +37,7 @@ const publicIntegration = (integration: unknown): unknown => {
     : JSON.parse(JSON.stringify(integration));
   if (!raw || typeof raw !== 'object') return raw;
   const result = raw as { config?: Record<string, unknown> };
-  if (!result.config) return result;
-  delete result.config.botTokenRef;
-  delete result.config.oauthStateNonce;
-  const pending = result.config.pendingBind;
-  if (pending && typeof pending === 'object') delete (pending as Record<string, unknown>).botTokenRef;
-  const adminPause = result.config.adminPause;
-  if (adminPause && typeof adminPause === 'object') {
-    const { reason, at } = adminPause as { reason?: unknown; at?: unknown };
-    result.config.adminPause = { reason, at };
-  }
+  toPublicIntegrationConfig(result.config);
   return result;
 };
 


### PR DESCRIPTION
Closes #1672.

## What

`Integration.platformIntegration` is a virtual whose `ref()` named `'TelegramIntegration'`, `'SlackIntegration'` and `'MessengerIntegration'`. Nothing registers those models: only Discord keeps platform state in a collection of its own, and every other connector carries it in `config`. Mongoose throws `MissingSchemaError` at populate time for a ref no model registers, so the first Telegram row made `GET /api/integrations/admin/all` (the admin Apps list) answer 500. `GET /api/integrations/:podId` populates the same virtual and had the same failure for any pod with a non-Discord row.

The fix is at the virtual, not the routes: `ref()` resolves `'DiscordIntegration'` for `discord` and `null` for every other type, which makes Mongoose skip the join for that row. `discordService`, `discordController` and the scheduler's Discord sync keep the join they rely on.

Restoring the join exposed what the 500 had been hiding. Sam's merge condition (67860): the same head closes both the access gap and the credential leak.

1. **Discord secrets (Vera, 67855).** The Discord record serialised with `botToken` (the instance-wide `DISCORD_BOT_TOKEN`) and `webhookUrl` with the webhook's secret. `DiscordIntegration`'s `toJSON` now drops both, so every response that carries the join keeps `serverId`/`channelId`/`webhookId` and nothing secret.
2. **Membership gate (Vera, 67856).** `GET /api/integrations/:podId` checked only that the caller was signed in. It now loads the pod (404 when missing) and asks `DMService.canViewPod` (members, admins, the agent-dm fan-out), the gate every other pod-scoped read uses; strangers get 403.
3. **Config credentials (Vera, 67858).** `Integration.toJSON` stripped only `botTokenRef` and `oauthStateNonce`; `config.botToken`, `signingSecret`, `secretToken`, `accessToken`, `refreshToken` and the secret-bearing `webhookUrl` went out on both lists. The key list now lives in `backend/models/integrationPublicConfig.ts` and both JSON paths run through it: the model's `toJSON`, and the lean catalog read in `installableCatalogService` that bypasses `toJSON`. `connectCode` stays: it is the one-time enable code a member pastes into Telegram, and ChatRoom and the Connectors page read it from the pod list. Providers read every stripped field off the document.

4. **Rate limiting (Sam, 67863).** CodeQL flagged the gated `GET /:podId` for an unmetered database access. It now shares `listIntegrationsRateLimit` (token-hash/IP keyed, ESM import from `middleware/integrationRateLimit`) ahead of `auth`, the same bucket `/user/all` and the installables list use.

**UI consequence, not changed here:** the X and Instagram edit forms (`ChatRoom.tsx`, admin `GlobalIntegrations.tsx`) prefilled `accessToken` from this list. The field is now blank on edit and the token is re-entered to save (both forms already refuse to save without one; GroupMe omits an empty token from its PATCH, so nothing is overwritten).

## Tests

`backend/__tests__/unit/routes/integrations.platformIntegration.test.js`, on memory Mongo with real `Pod`, `Integration` and `DiscordIntegration` rows:

- `the admin list answers 200 with a Telegram row`
- `the Discord row still joins its platform record`
- `the integration lists never return the bot token or webhook secret` (both routes; Vera's 67855 probe)
- `the pod list answers 200 with a Telegram row`
- `the pod integrations list refuses a non-member` (403 stranger, 404 missing pod)
- `no integration response carries a credential` (Telegram, X and Slack rows on both lists, including `pendingBind.botTokenRef`; the member still sees `connectCode`; Vera's 67858 probe, red on the previous model)

`installableCatalogService.test.js`'s strip test now carries the same fields through the lean read. The first, second and fourth route tests fail on `main` at 46e84197 with the `MissingSchemaError` from the issue. 23 suites across integrations, installables, Slack, Discord, decision cards and webhooks pass alongside (199 tests); four `agentsRuntime.integrations.*` / `decisionCard*` suites fail to load identically on a clean `main` checkout under local Node 26, unrelated.

Backend-only, no UI hold. Independent of #1670 (not stacked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
