### PR TITLE
fix(integrations): X/Instagram token fields are write-only once a token is on file

### DIFF
--- a/backend/__tests__/unit/routes/admin.globalIntegrations.test.js
+++ b/backend/__tests__/unit/routes/admin.globalIntegrations.test.js
@@ -191,6 +191,120 @@ describe('admin global integrations route', () => {
     });
   });
 
+  it('the admin X save keeps the stored token when the body omits it', async () => {
+    const handler = getRouteHandler('/x', 'post');
+    const req = {
+      userId: 'admin-1',
+      body: {
+        enabled: true,
+        username: 'commonly',
+        userId: 'x-user-id',
+      },
+    };
+    const res = createRes();
+    const stored = {
+      _id: 'x-int-1',
+      type: 'x',
+      status: 'connected',
+      config: { accessToken: 'stored-x-token', refreshToken: 'stored-refresh', username: 'old' },
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    Integration.findOne.mockResolvedValueOnce(stored);
+
+    await handler(req, res);
+
+    expect(Integration.findOne).toHaveBeenCalledTimes(1);
+    expect(Integration.create).not.toHaveBeenCalled();
+    expect(stored.save).toHaveBeenCalled();
+    expect(stored.config.accessToken).toBe('stored-x-token');
+    expect(stored.config.refreshToken).toBe('stored-refresh');
+    expect(stored.config.username).toBe('commonly');
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ success: true, integration: stored });
+  });
+
+  it('the admin X save replaces the stored token when a new one is typed', async () => {
+    const handler = getRouteHandler('/x', 'post');
+    const req = {
+      userId: 'admin-1',
+      body: { enabled: true, accessToken: 'fresh-x-token', username: 'commonly', userId: 'x-user-id' },
+    };
+    const res = createRes();
+    const stored = {
+      _id: 'x-int-1',
+      type: 'x',
+      status: 'connected',
+      config: { accessToken: 'stored-x-token' },
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    Integration.findOne.mockResolvedValueOnce(stored);
+
+    await handler(req, res);
+
+    expect(stored.config.accessToken).toBe('fresh-x-token');
+    expect(res.json).toHaveBeenCalledWith({ success: true, integration: stored });
+  });
+
+  it('a new admin X integration still needs a token', async () => {
+    const handler = getRouteHandler('/x', 'post');
+    const req = {
+      userId: 'admin-1',
+      body: { enabled: true, username: 'commonly', userId: 'x-user-id' },
+    };
+    const res = createRes();
+
+    Integration.findOne.mockResolvedValueOnce(null);
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(Integration.create).not.toHaveBeenCalled();
+  });
+
+  it('the admin Instagram save keeps the stored token when the body omits it', async () => {
+    const handler = getRouteHandler('/instagram', 'post');
+    const req = {
+      userId: 'admin-1',
+      body: { enabled: true, username: 'commonly', igUserId: 'ig-1' },
+    };
+    const res = createRes();
+    const stored = {
+      _id: 'ig-int-1',
+      type: 'instagram',
+      status: 'connected',
+      config: { accessToken: 'stored-ig-token', username: 'old' },
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    Integration.findOne.mockResolvedValueOnce(stored);
+
+    await handler(req, res);
+
+    expect(stored.save).toHaveBeenCalled();
+    expect(stored.config.accessToken).toBe('stored-ig-token');
+    expect(stored.config.username).toBe('commonly');
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ success: true, integration: stored });
+  });
+
+  it('a new admin Instagram integration still needs a token', async () => {
+    const handler = getRouteHandler('/instagram', 'post');
+    const req = {
+      userId: 'admin-1',
+      body: { enabled: true, username: 'commonly', igUserId: 'ig-1' },
+    };
+    const res = createRes();
+
+    Integration.findOne.mockResolvedValueOnce(null);
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(Integration.create).not.toHaveBeenCalled();
+  });
+
   it('lists OAuth following accounts for connected global X integration', async () => {
     const handler = getRouteHandler('/x/following', 'get');
     const req = { userId: 'admin-1', query: { limit: '2' } };

--- a/backend/routes/admin/globalIntegrations.ts
+++ b/backend/routes/admin/globalIntegrations.ts
@@ -1,8 +1,10 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const crypto: any = require('crypto');
 const axios = require('axios');
 const auth = require('../../middleware/auth');
 const adminAuth = require('../../middleware/adminAuth');
+const { cloudflareIpRateLimitKeyGenerator } = require('../../middleware/ipRateLimit');
 const Integration = require('../../models/Integration');
 const OAuthState = require('../../models/OAuthState');
 const Pod = require('../../models/Pod');
@@ -140,6 +142,22 @@ const normalizeBoolean = (value: any, fallback = false) => {
   }
   return fallback;
 };
+
+// The two admin saves below read the stored row before writing. Generous
+// for a human operator, bounded against token-stuffing on the admin surface
+// (CodeQL js/missing-rate-limiting); same shape as routes/admin/users.ts.
+const adminWriteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: () => process.env.NODE_ENV === 'test',
+  keyGenerator: cloudflareIpRateLimitKeyGenerator,
+  handler: (_req: any, res: any) => res.status(429).json({
+    message: 'rate limit exceeded: 60 admin writes per 15 minutes',
+    code: 'rate_limited',
+  }),
+});
 
 /**
  * The admin forms send accessToken only when a new one is typed; a blank
@@ -513,7 +531,7 @@ router.post('/policy', auth, adminAuth, async (req: any, res: any) => {
  * Save X global integration
  * POST /api/admin/integrations/global/x
  */
-router.post('/x', auth, adminAuth, async (req: any, res: any) => {
+router.post('/x', adminWriteLimiter, auth, adminAuth, async (req: any, res: any) => {
   try {
     const requesterId = getUserId(req);
     if (!requesterId) {
@@ -572,7 +590,7 @@ router.post('/x', auth, adminAuth, async (req: any, res: any) => {
  * Save Instagram global integration
  * POST /api/admin/integrations/global/instagram
  */
-router.post('/instagram', auth, adminAuth, async (req: any, res: any) => {
+router.post('/instagram', adminWriteLimiter, auth, adminAuth, async (req: any, res: any) => {
   try {
     const userId = getUserId(req);
     if (!userId) {

--- a/backend/routes/admin/globalIntegrations.ts
+++ b/backend/routes/admin/globalIntegrations.ts
@@ -141,6 +141,14 @@ const normalizeBoolean = (value: any, fallback = false) => {
   return fallback;
 };
 
+/**
+ * The admin forms send accessToken only when a new one is typed; a blank
+ * field keeps the token already on file. A new integration still needs one.
+ */
+const keepOrReplaceAccessToken = (typed: unknown, existing: any): string => (
+  typed ? String(typed) : String(existing?.config?.accessToken || '')
+);
+
 const upsertXIntegration = async ({
   requesterId,
   globalPodId,
@@ -157,6 +165,7 @@ const upsertXIntegration = async ({
   followFromAuthenticatedUser,
   followingWhitelistUserIds,
   followingMaxUsers,
+  existing,
 }: {
   requesterId: any;
   globalPodId: any;
@@ -173,11 +182,11 @@ const upsertXIntegration = async ({
   followFromAuthenticatedUser?: any;
   followingWhitelistUserIds?: any;
   followingMaxUsers?: any;
+  existing?: any;
 }) => {
-  let xIntegration = await Integration.findOne({
-    type: 'x',
-    podId: globalPodId,
-  });
+  let xIntegration = existing === undefined
+    ? await Integration.findOne({ type: 'x', podId: globalPodId })
+    : existing;
   const hasFollowUsernames = followUsernames !== undefined;
   const hasFollowUserIds = followUserIds !== undefined;
   const normalizedFollowUsernames = hasFollowUsernames
@@ -523,17 +532,23 @@ router.post('/x', auth, adminAuth, async (req: any, res: any) => {
     } = req.body;
 
     // Validate required fields
-    if (!username || !userId || !accessToken) {
+    if (!username || !userId) {
       return res.status(400).json({ error: 'Username, userId, and accessToken are required' });
     }
 
     // Find or create global pod
     const globalPod = await ensureGlobalSocialFeedPod(requesterId);
+    const existing = await Integration.findOne({ type: 'x', podId: globalPod._id });
+    const effectiveAccessToken = keepOrReplaceAccessToken(accessToken, existing);
+    if (!effectiveAccessToken) {
+      return res.status(400).json({ error: 'Username, userId, and accessToken are required' });
+    }
     const xIntegration = await upsertXIntegration({
       requesterId,
       globalPodId: globalPod._id,
       enabled,
-      accessToken,
+      accessToken: effectiveAccessToken,
+      existing,
       username,
       userId,
       followUsernames,
@@ -568,7 +583,7 @@ router.post('/instagram', auth, adminAuth, async (req: any, res: any) => {
     } = req.body;
 
     // Validate required fields
-    if (!username || !igUserId || !accessToken) {
+    if (!username || !igUserId) {
       return res.status(400).json({ error: 'Username, igUserId, and accessToken are required' });
     }
 
@@ -580,12 +595,16 @@ router.post('/instagram', auth, adminAuth, async (req: any, res: any) => {
       type: 'instagram',
       podId: globalPod._id,
     });
+    const effectiveAccessToken = keepOrReplaceAccessToken(accessToken, instagramIntegration);
+    if (!effectiveAccessToken) {
+      return res.status(400).json({ error: 'Username, igUserId, and accessToken are required' });
+    }
 
     if (instagramIntegration) {
       // Update existing
       instagramIntegration.config = {
         ...instagramIntegration.config,
-        accessToken,
+        accessToken: effectiveAccessToken,
         username,
         igUserId,
         category: 'Social',
@@ -604,7 +623,7 @@ router.post('/instagram', auth, adminAuth, async (req: any, res: any) => {
         status: enabled ? 'connected' : 'disconnected',
         isActive: enabled,
         config: {
-          accessToken,
+          accessToken: effectiveAccessToken,
           username,
           igUserId,
           category: 'Social',

--- a/frontend/src/components/ChatRoom.tsx
+++ b/frontend/src/components/ChatRoom.tsx
@@ -269,6 +269,10 @@ const buildAgentUsername = (agentName, instanceId) => {
 
 const normalizeIdentityKey = (value) => String(value || '').trim().toLowerCase();
 
+// Saved tokens never come back from the API; the field is write-only once one is on file.
+const SAVED_TOKEN_PLACEHOLDER = 'Saved \u2014 leave blank to keep';
+const SAVED_TOKEN_HELPER = 'A token is on file. Paste a new one to replace it.';
+
 interface TypingAgentEntry {
     key: string;
     agentName: string;
@@ -610,6 +614,8 @@ const ChatRoom = () => {
     const [xIntegration, setXIntegration] = useState(null);
     const [xDraftIntegrationId, setXDraftIntegrationId] = useState(null);
     const [xAccessToken, setXAccessToken] = useState('');
+    // The API never returns a saved token; this flag stands in for "one is on file".
+    const [xTokenOnFile, setXTokenOnFile] = useState(false);
     const [xUsername, setXUsername] = useState('');
     const [xCategory, setXCategory] = useState('');
     const [xError, setXError] = useState('');
@@ -619,6 +625,7 @@ const ChatRoom = () => {
     const [instagramIntegration, setInstagramIntegration] = useState(null);
     const [instagramDraftIntegrationId, setInstagramDraftIntegrationId] = useState(null);
     const [instagramAccessToken, setInstagramAccessToken] = useState('');
+    const [instagramTokenOnFile, setInstagramTokenOnFile] = useState(false);
     const [instagramUserId, setInstagramUserId] = useState('');
     const [instagramUsername, setInstagramUsername] = useState('');
     const [instagramCategory, setInstagramCategory] = useState('');
@@ -1480,6 +1487,7 @@ const ChatRoom = () => {
         xDiscardOnCreateRef.current = false;
         setXError('');
         setXAccessToken('');
+        setXTokenOnFile(false);
         setXUsername('');
         setXCategory('');
         setXIntegration(null);
@@ -1488,7 +1496,7 @@ const ChatRoom = () => {
 
         if (existingIntegration) {
             setXIntegration(existingIntegration);
-            setXAccessToken(existingIntegration.config?.accessToken || '');
+            setXTokenOnFile(existingIntegration.status === 'connected');
             setXUsername(existingIntegration.config?.username || '');
             setXCategory(existingIntegration.config?.category || '');
             setXSaving(false);
@@ -1545,7 +1553,7 @@ const ChatRoom = () => {
             setXError('Integration not ready yet.');
             return;
         }
-        if (!xAccessToken.trim() || !xUsername.trim()) {
+        if ((!xAccessToken.trim() && !xTokenOnFile) || !xUsername.trim()) {
             setXError('Please provide both the access token and username.');
             return;
         }
@@ -1557,7 +1565,8 @@ const ChatRoom = () => {
             const token = localStorage.getItem('token');
             await axios.patch(`/api/integrations/${xIntegration._id}`, {
                 config: {
-                    accessToken: xAccessToken.trim(),
+                    // Omitted when blank: the PATCH only writes the keys it receives.
+                    accessToken: xAccessToken.trim() || undefined,
                     username: xUsername.trim(),
                     category: xCategory.trim() || undefined
                 },
@@ -1605,6 +1614,7 @@ const ChatRoom = () => {
         instagramDiscardOnCreateRef.current = false;
         setInstagramError('');
         setInstagramAccessToken('');
+        setInstagramTokenOnFile(false);
         setInstagramUserId('');
         setInstagramUsername('');
         setInstagramCategory('');
@@ -1614,7 +1624,7 @@ const ChatRoom = () => {
 
         if (existingIntegration) {
             setInstagramIntegration(existingIntegration);
-            setInstagramAccessToken(existingIntegration.config?.accessToken || '');
+            setInstagramTokenOnFile(existingIntegration.status === 'connected');
             setInstagramUserId(existingIntegration.config?.igUserId || '');
             setInstagramUsername(existingIntegration.config?.username || '');
             setInstagramCategory(existingIntegration.config?.category || '');
@@ -1672,7 +1682,7 @@ const ChatRoom = () => {
             setInstagramError('Integration not ready yet.');
             return;
         }
-        if (!instagramAccessToken.trim() || !instagramUserId.trim()) {
+        if ((!instagramAccessToken.trim() && !instagramTokenOnFile) || !instagramUserId.trim()) {
             setInstagramError('Please provide both the access token and IG user ID.');
             return;
         }
@@ -1684,7 +1694,7 @@ const ChatRoom = () => {
             const token = localStorage.getItem('token');
             await axios.patch(`/api/integrations/${instagramIntegration._id}`, {
                 config: {
-                    accessToken: instagramAccessToken.trim(),
+                    accessToken: instagramAccessToken.trim() || undefined,
                     igUserId: instagramUserId.trim(),
                     username: instagramUsername.trim() || undefined,
                     category: instagramCategory.trim() || undefined
@@ -3923,6 +3933,9 @@ const ChatRoom = () => {
                                             type="password"
                                             value={xAccessToken}
                                             onChange={(event) => setXAccessToken(event.target.value)}
+                                            placeholder={xTokenOnFile ? SAVED_TOKEN_PLACEHOLDER : undefined}
+                                            helperText={xTokenOnFile ? SAVED_TOKEN_HELPER : undefined}
+                                            InputLabelProps={xTokenOnFile ? { shrink: true } : undefined}
                                         />
                                         <TextField
                                             label="Username"
@@ -3986,6 +3999,9 @@ const ChatRoom = () => {
                                             type="password"
                                             value={instagramAccessToken}
                                             onChange={(event) => setInstagramAccessToken(event.target.value)}
+                                            placeholder={instagramTokenOnFile ? SAVED_TOKEN_PLACEHOLDER : undefined}
+                                            helperText={instagramTokenOnFile ? SAVED_TOKEN_HELPER : undefined}
+                                            InputLabelProps={instagramTokenOnFile ? { shrink: true } : undefined}
                                         />
                                         <TextField
                                             label="IG User ID"

--- a/frontend/src/components/admin/GlobalIntegrations.tsx
+++ b/frontend/src/components/admin/GlobalIntegrations.tsx
@@ -80,6 +80,10 @@ const OPENCLAW_MODEL_OPTIONS = {
   anthropic: ANTHROPIC_MODELS,
 };
 
+// Saved tokens never come back from the API; the field is write-only once one is on file.
+const SAVED_TOKEN_PLACEHOLDER = 'Saved \u2014 leave blank to keep';
+const SAVED_TOKEN_HELPER = 'A token is on file. Paste a new one to replace it.';
+
 const GlobalIntegrations = () => {
   const v2Embedded = useV2Embedded();
   const location = useLocation();
@@ -121,6 +125,7 @@ const GlobalIntegrations = () => {
   const [xConfig, setXConfig] = useState({
     enabled: false,
     accessToken: '',
+    tokenOnFile: false,
     username: '',
     userId: '',
     followUsernames: '',
@@ -135,6 +140,7 @@ const GlobalIntegrations = () => {
   const [instagramConfig, setInstagramConfig] = useState({
     enabled: false,
     accessToken: '',
+    tokenOnFile: false,
     username: '',
     igUserId: '',
     status: 'disconnected'
@@ -177,7 +183,9 @@ const GlobalIntegrations = () => {
       if (x) {
         setXConfig({
           enabled: x.status === 'connected',
-          accessToken: x.config?.accessToken || '',
+          // The API never returns the saved token; a stored row always carries one.
+          accessToken: '',
+          tokenOnFile: true,
           username: x.config?.username || '',
           userId: x.config?.userId || '',
           followUsernames: Array.isArray(x.config?.followUsernames) ? x.config.followUsernames.join(', ') : '',
@@ -196,7 +204,8 @@ const GlobalIntegrations = () => {
       if (instagram) {
         setInstagramConfig({
           enabled: instagram.status === 'connected',
-          accessToken: instagram.config?.accessToken || '',
+          accessToken: '',
+          tokenOnFile: true,
           username: instagram.config?.username || '',
           igUserId: instagram.config?.igUserId || '',
           status: instagram.status
@@ -369,7 +378,8 @@ const GlobalIntegrations = () => {
       await axios.post('/api/admin/integrations/global/x',
         {
           enabled: xConfig.enabled,
-          accessToken: xConfig.accessToken,
+          // Omitted when blank: the server keeps the token on file.
+          accessToken: xConfig.accessToken || undefined,
           username: xConfig.username,
           userId: xConfig.userId,
           followUsernames: xConfig.followUsernames,
@@ -403,7 +413,7 @@ const GlobalIntegrations = () => {
       await axios.post('/api/admin/integrations/global/instagram',
         {
           enabled: instagramConfig.enabled,
-          accessToken: instagramConfig.accessToken,
+          accessToken: instagramConfig.accessToken || undefined,
           username: instagramConfig.username,
           igUserId: instagramConfig.igUserId
         },
@@ -615,13 +625,14 @@ const GlobalIntegrations = () => {
 
                 <TextField
                   label="Access Token"
-                  placeholder="Bearer token..."
+                  placeholder={xConfig.tokenOnFile ? SAVED_TOKEN_PLACEHOLDER : 'Bearer token...'}
                   value={xConfig.accessToken}
                   onChange={(e) => setXConfig({ ...xConfig, accessToken: e.target.value })}
                   fullWidth
                   size="small"
                   type="password"
-                  helperText="OAuth 2.0 Bearer token"
+                  helperText={xConfig.tokenOnFile ? SAVED_TOKEN_HELPER : 'OAuth 2.0 Bearer token'}
+                  InputLabelProps={xConfig.tokenOnFile ? { shrink: true } : undefined}
                 />
 
                 <TextField
@@ -694,7 +705,7 @@ const GlobalIntegrations = () => {
                     variant="contained"
                     startIcon={<SaveIcon />}
                     onClick={handleSaveX}
-                    disabled={saving || !xConfig.username || !xConfig.userId || !xConfig.accessToken}
+                    disabled={saving || !xConfig.username || !xConfig.userId || !(xConfig.accessToken || xConfig.tokenOnFile)}
                     fullWidth
                   >
                     Save X Configuration
@@ -791,13 +802,14 @@ const GlobalIntegrations = () => {
 
                 <TextField
                   label="Access Token"
-                  placeholder="Long-lived access token..."
+                  placeholder={instagramConfig.tokenOnFile ? SAVED_TOKEN_PLACEHOLDER : 'Long-lived access token...'}
                   value={instagramConfig.accessToken}
                   onChange={(e) => setInstagramConfig({ ...instagramConfig, accessToken: e.target.value })}
                   fullWidth
                   size="small"
                   type="password"
-                  helperText="Long-lived access token from Facebook Graph API"
+                  helperText={instagramConfig.tokenOnFile ? SAVED_TOKEN_HELPER : 'Long-lived access token from Facebook Graph API'}
+                  InputLabelProps={instagramConfig.tokenOnFile ? { shrink: true } : undefined}
                 />
 
                 <Box display="flex" gap={1} mt={1}>
@@ -805,7 +817,7 @@ const GlobalIntegrations = () => {
                     variant="contained"
                     startIcon={<SaveIcon />}
                     onClick={handleSaveInstagram}
-                    disabled={saving || !instagramConfig.username || !instagramConfig.igUserId || !instagramConfig.accessToken}
+                    disabled={saving || !instagramConfig.username || !instagramConfig.igUserId || !(instagramConfig.accessToken || instagramConfig.tokenOnFile)}
                     fullWidth
                   >
                     Save Instagram Configuration

--- a/frontend/src/components/admin/__tests__/GlobalIntegrations.tokenField.test.tsx
+++ b/frontend/src/components/admin/__tests__/GlobalIntegrations.tokenField.test.tsx
@@ -1,0 +1,124 @@
+// @ts-nocheck
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import GlobalIntegrations from '../GlobalIntegrations';
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: (...args) => mockGet(...args),
+    post: (...args) => mockPost(...args),
+    patch: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  },
+}));
+
+// What the admin GET returns after #1673: rows exist, credentials are stripped.
+const globalResponse = {
+  data: {
+    x: {
+      _id: 'x-1',
+      type: 'x',
+      status: 'connected',
+      config: { username: 'CommonlyHQ', userId: '42' },
+    },
+    instagram: {
+      _id: 'ig-1',
+      type: 'instagram',
+      status: 'connected',
+      config: { username: 'commonly', igUserId: '77' },
+    },
+    socialPolicy: null,
+    modelPolicy: null,
+    globalPodId: 'pod-global',
+  },
+};
+
+const renderPage = () => render(
+  <MemoryRouter initialEntries={['/admin/integrations/global']}>
+    <GlobalIntegrations />
+  </MemoryRouter>,
+);
+
+const tokenFields = () => screen.getAllByLabelText('Access Token');
+const postBody = (path) => mockPost.mock.calls.find(([url]) => url === path)?.[1];
+
+describe('GlobalIntegrations token fields', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.setItem('token', 'jwt');
+    mockGet.mockResolvedValue(globalResponse);
+    mockPost.mockResolvedValue({ data: { success: true } });
+  });
+
+  it('a saved token shows the leave-blank placeholder instead of the secret', async () => {
+    renderPage();
+
+    await waitFor(() => expect(screen.getByDisplayValue('CommonlyHQ')).toBeInTheDocument());
+
+    const [xToken, igToken] = tokenFields();
+    expect(xToken).toHaveValue('');
+    expect(igToken).toHaveValue('');
+    expect(xToken).toHaveAttribute('placeholder', 'Saved — leave blank to keep');
+    expect(igToken).toHaveAttribute('placeholder', 'Saved — leave blank to keep');
+    expect(screen.getAllByText('A token is on file. Paste a new one to replace it.')).toHaveLength(2);
+  });
+
+  it('saving with the token blank omits accessToken so the server keeps it', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByDisplayValue('CommonlyHQ')).toBeInTheDocument());
+
+    const saveX = screen.getByRole('button', { name: 'Save X Configuration' });
+    expect(saveX).not.toBeDisabled();
+    fireEvent.click(saveX);
+    await waitFor(() => expect(postBody('/api/admin/integrations/global/x')).toBeDefined());
+    const xBody = postBody('/api/admin/integrations/global/x');
+    expect(xBody.username).toBe('CommonlyHQ');
+    expect(JSON.parse(JSON.stringify(xBody))).not.toHaveProperty('accessToken');
+
+    const saveIg = screen.getByRole('button', { name: 'Save Instagram Configuration' });
+    expect(saveIg).not.toBeDisabled();
+    fireEvent.click(saveIg);
+    await waitFor(() => expect(postBody('/api/admin/integrations/global/instagram')).toBeDefined());
+    expect(JSON.parse(JSON.stringify(postBody('/api/admin/integrations/global/instagram'))))
+      .not.toHaveProperty('accessToken');
+  });
+
+  it('a typed token is sent and replaces the saved one', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByDisplayValue('CommonlyHQ')).toBeInTheDocument());
+
+    const [xToken] = tokenFields();
+    fireEvent.change(xToken, { target: { value: 'fresh-x-token' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save X Configuration' }));
+
+    await waitFor(() => expect(postBody('/api/admin/integrations/global/x')).toBeDefined());
+    expect(postBody('/api/admin/integrations/global/x').accessToken).toBe('fresh-x-token');
+  });
+
+  it('a new integration still needs a token before it can be saved', async () => {
+    mockGet.mockResolvedValue({ data: { x: null, instagram: null, socialPolicy: null, modelPolicy: null } });
+    renderPage();
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    const [xToken] = tokenFields();
+    expect(xToken).toHaveAttribute('placeholder', 'Bearer token...');
+
+    fireEvent.change(screen.getAllByLabelText('Username')[0], { target: { value: 'CommonlyHQ' } });
+    fireEvent.change(screen.getByLabelText('User ID'), { target: { value: '42' } });
+    expect(screen.getByRole('button', { name: 'Save X Configuration' })).toBeDisabled();
+
+    fireEvent.change(xToken, { target: { value: 'first-token' } });
+    expect(screen.getByRole('button', { name: 'Save X Configuration' })).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
Follow-up to #1673, which stopped returning `config.accessToken`: the X and Instagram token fields in the pod ChatRoom dialogs and the admin Global Integrations page prefilled empty and every re-save demanded the token again. Ruled in the pod (Sam 67866, Vera 67868): a "saved, leave blank to keep" placeholder, saves send `accessToken` only when typed, the empty-refusal stays on the create path.

1. **Four fields go write-only once a token is on file.** `ChatRoom.tsx` (X and Instagram dialogs) and `admin/GlobalIntegrations.tsx` (X and Instagram cards) show the placeholder "Saved — leave blank to keep" with the helper "A token is on file. Paste a new one to replace it." ChatRoom treats a `connected` row as having a token; the admin page treats any stored row that way (both admin POST routes and the OAuth callback always store one).
2. **Saves send `accessToken` only when typed.** ChatRoom's PATCH `/api/integrations/:id` already writes only the keys it receives, so omitting the key keeps the stored token. The admin `POST /x` and `POST /instagram` now keep the stored token when the body omits it (`keepOrReplaceAccessToken`), instead of answering 400.
3. **A new integration still needs a token.** Admin routes 400 on the create path when nothing is typed and nothing is stored; the admin Save buttons stay disabled until a token is typed; ChatRoom's validation still refuses an empty token when no token is on file.

Tests
- `admin.globalIntegrations.test.js`: `the admin X save keeps the stored token when the body omits it`, `the admin X save replaces the stored token when a new one is typed`, `a new admin X integration still needs a token`, and the Instagram pair.
- `GlobalIntegrations.tokenField.test.tsx` (new): placeholder shown instead of the secret, blank save omits `accessToken`, typed token is sent, new integration stays disabled without a token. Frontend suite: 106 suites / 850 tests green locally.

UI hold: 1440/390 before/after shots (admin page and both ChatRoom dialogs) are posted in the Connectors v2 pod for Sam. Not stacked; branched from main `f32c571e`.


**Second commit (aaab9f20):** CodeQL flagged `js/missing-rate-limiting` on the two admin save handlers this PR touched. They now sit behind an `adminWriteLimiter` with the same shape as `routes/admin/users.ts` (60 writes / 15 min, Cloudflare client-IP key, skipped under `NODE_ENV=test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
