### PR TITLE
test(security): B1 leak matrix with a shrink-only exposure list

### DIFF
--- a/backend/__tests__/unit/security/leakMatrix.agentProfile.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.agentProfile.test.js
@@ -1,0 +1,20 @@
+/**
+ * B1 leak matrix — GET /api/agent-profile/:agentName/:instanceId? (public
+ * identity card, no auth; selects the bot User's agentConfig). Run as a
+ * stranger and as an unauthenticated caller. The agent User carries every User
+ * secret plus agentConfig.systemPrompt as sentinels; its AgentInstallation
+ * carries runtime secrets and a runtime-token hash.
+ * Skipped routes: /avatar/can-edit (authed owner check, not a public read).
+ * Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) if anything pulls it in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { agentProfile } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(agentProfile);

--- a/backend/__tests__/unit/security/leakMatrix.agentRuntime.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.agentRuntime.test.js
@@ -1,0 +1,20 @@
+/**
+ * B1 leak matrix — GET /api/agents/runtime/pods/:podId/integrations as an
+ * agent with integration:read in the pod, an agent in the pod without that
+ * scope, and an agent installed only in another pod. Pod integrations with
+ * agent access on/off and a global (globalAgentAccess) integration carry every
+ * Integration secret. agentRuntimeAuth is mocked to load the real bot User and
+ * its real AgentInstallations (see agentRuntimeAuthMock).
+ * Skipped routes: none. Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) and is pulled in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { agentRuntime } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(agentRuntime);

--- a/backend/__tests__/unit/security/leakMatrix.credentials.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.credentials.test.js
@@ -1,0 +1,16 @@
+/**
+ * B1 leak matrix — GET /api/credentials as owner / stranger / admin, with
+ * AgentCredential rows (daemon + child runtime) whose tokenHash is a sentinel.
+ * Skipped routes: none. Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) if anything pulls it in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { credentials } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(credentials);

--- a/backend/__tests__/unit/security/leakMatrix.grants.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.grants.test.js
@@ -1,0 +1,22 @@
+/**
+ * B1 leak matrix — RoomGrant read routes. Grants carry connectionId, brokerId
+ * and a raw audience (with a departed member) as sentinels; the connection
+ * Integration carries every Integration secret.
+ *   GET /api/grants/:grantId          [pod grant | seat grant]
+ *   GET /api/grants/:grantId/calls    [pod grant | seat grant]
+ *   GET /api/pods/:podId/grants       (mounted via grants.podGrantsRouter)
+ * Roles: owner (granter), member, stranger, admin, and the seat agent on the
+ * two dualAuth routes. ToolCall (Postgres) is mocked at its module boundary.
+ * Skipped routes: none. Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) if anything pulls it in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { grants } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(grants);

--- a/backend/__tests__/unit/security/leakMatrix.installables.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.installables.test.js
@@ -1,0 +1,18 @@
+/**
+ * B1 leak matrix — GET /api/installables (installableCatalogService's .lean()
+ * path, which bypasses the Integration toJSON transform), as the owner of
+ * connected telegram / pending slack / github-app connections carrying every
+ * sentinel, as a stranger, and as an admin.
+ * Skipped routes: none. Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) and is pulled in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { installables } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(installables);

--- a/backend/__tests__/unit/security/leakMatrix.integrations.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.integrations.test.js
@@ -1,0 +1,24 @@
+/**
+ * B1 leak matrix — Integration read routes, each as stranger / member / owner / admin:
+ *   GET /api/integrations/catalog
+ *   GET /api/integrations/:podId          (config.connectCode allowed to member/owner/admin here only)
+ *   GET /api/integrations/admin/all
+ *   GET /api/integrations/user/all
+ *   GET /api/integrations/:id/ingest-tokens
+ *   GET /api/discord/binding/:podId
+ *   GET /api/admin/integrations/global
+ * Skipped routes: none. Integration, DiscordIntegration, Pod, User run on
+ * memory Mongo so the real toJSON transforms and populates are exercised.
+ * Harness, sentinels and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) and is pulled in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { integrations } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(integrations);

--- a/backend/__tests__/unit/security/leakMatrix.machines.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.machines.test.js
@@ -1,0 +1,21 @@
+/**
+ * B1 leak matrix — machine and gateway reads:
+ *   GET /api/machines      (owner / stranger / admin: each lists its own)
+ *   GET /api/machines/me   (the owner's machine via its REAL cm_daemon_ bearer; human JWTs are 401)
+ *   GET /api/gateways      (admin only)
+ * Each machine's daemon AgentCredential is real: its raw bearer is a boundary
+ * sentinel and its stored tokenHash is registered as a sentinel by value. A
+ * gateway row carries metadata.gatewayToken as a sentinel.
+ * Skipped routes: none. Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) if anything pulls it in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { machines } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(machines);

--- a/backend/__tests__/unit/security/leakMatrix.ratchet.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.ratchet.test.js
@@ -94,8 +94,10 @@ describe('ratchet', () => {
     await disconnectMemoryMongo(mongod);
   });
 
+  // Replays every suite's world in one test: ~9s alone, but past jest's 30s
+  // default under the parallel full-suite run, so it carries its own budget.
   test('every KNOWN_EXPOSURES entry still reproduces (fixing one forces the list to shrink)', async () => {
     const problems = await assertKnownExposuresStillLeak(Object.values(SUITES));
     expect(problems).toEqual([]);
-  });
+  }, 120_000);
 });

--- a/backend/__tests__/unit/security/leakMatrix.ratchet.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.ratchet.test.js
@@ -1,0 +1,101 @@
+/**
+ * B1 leak matrix — the ratchet. Mounts every suite's routers in one app and
+ * replays each KNOWN_EXPOSURES entry against a freshly seeded world. If an
+ * allowlisted exposure no longer reproduces (the leak was fixed, the route now
+ * refuses, or the case it names no longer exists), this fails with "remove
+ * this entry from KNOWN_EXPOSURES", so the list can only shrink.
+ *
+ * It lives in one file because jest isolates modules per test file: the
+ * per-suite files cannot see each other's results. It also holds the list's
+ * own contract (sorted, duplicate-free, reasoned) and the pure case rules.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) and is pulled in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+// Same network backstop as leakMatrix.webhooks.test.js, so a replayed webhook case sees the same world.
+jest.mock('axios', () => require('../../utils/leakMatrix').axiosMock);
+
+const fs = require('fs');
+const {
+  ACCESS_2XX, KNOWN_EXPOSURES, assertKnownExposuresStillLeak, caseProblems, connectMemoryMongo,
+  disconnectMemoryMongo, exposureSortKey,
+} = require('../../utils/leakMatrix');
+const { SUITES } = require('../../utils/leakMatrixSuites');
+
+describe('KNOWN_EXPOSURES list contract', () => {
+  test('is sorted by (path, variant, method, role, sentinelKey) and duplicate-free', () => {
+    const keys = KNOWN_EXPOSURES.map(exposureSortKey);
+    const misplaced = keys
+      .map((key, i) => (i > 0 && !(keys[i - 1] < key) ? `${keys[i - 1]}  >=  ${key}` : null))
+      .filter(Boolean);
+    expect(misplaced).toEqual([]);
+  });
+
+  test('every entry is a complete tuple with a reason', () => {
+    const incomplete = KNOWN_EXPOSURES
+      .filter((e) => !e.method || !e.path || !e.role || !e.sentinelKey || !e.reason)
+      .map(exposureSortKey);
+    expect(incomplete).toEqual([]);
+  });
+
+  test('every suite has its own matrix file, and the ratchet replays every suite', () => {
+    const files = fs.readdirSync(__dirname)
+      .map((f) => /^leakMatrix\.(.+)\.test\.js$/.exec(f))
+      .filter(Boolean)
+      .map((m) => m[1])
+      .filter((name) => name !== 'ratchet')
+      .sort();
+    expect(files).toEqual(Object.keys(SUITES).sort());
+  });
+});
+
+describe('caseProblems: subtraction and ACCESS_2XX rules', () => {
+  const c = { method: 'GET', path: '/x', role: 'stranger', expect: 200, refuse: true };
+  const leakCase = { method: 'GET', path: '/y', role: 'owner', expect: 200 };
+  const entry = (over) => ({ method: 'GET', path: '/x', role: 'stranger', reason: 'r', ...over });
+
+  test('a refuse case answering 2xx with no ACCESS_2XX entry fails', () => {
+    expect(caseProblems(c, 200, [], { known: [], allowed: [] }))
+      .toEqual([`answered 200 to a role that must get 401/403 — unlisted ${ACCESS_2XX}`]);
+  });
+
+  test('a refuse case answering 2xx is accepted when pinned as ACCESS_2XX', () => {
+    expect(caseProblems(c, 200, [], { known: [entry({ sentinelKey: ACCESS_2XX })], allowed: [] })).toEqual([]);
+  });
+
+  test('ACCESS_2XX does not excuse a body leak on the same case', () => {
+    expect(caseProblems(c, 200, ['K'], { known: [entry({ sentinelKey: ACCESS_2XX })], allowed: [] }))
+      .toEqual(['unexpected sentinel K in 2xx body']);
+  });
+
+  test('a refused case only checks its status pin', () => {
+    expect(caseProblems({ ...c, expect: 403 }, 403, ['K'], { known: [], allowed: [] })).toEqual([]);
+    expect(caseProblems({ ...c, expect: 403 }, 200, [], { known: [], allowed: [] })[0]).toBe('status 200, pinned 403');
+  });
+
+  test('a listed leak passes, an unlisted one fails', () => {
+    const known = [{ method: 'GET', path: '/y', role: 'owner', sentinelKey: 'A', reason: 'r' }];
+    expect(caseProblems(leakCase, 200, ['A'], { known, allowed: [] })).toEqual([]);
+    expect(caseProblems(leakCase, 200, ['A', 'B'], { known, allowed: [] })).toEqual(['unexpected sentinel B in 2xx body']);
+  });
+});
+
+describe('ratchet', () => {
+  let mongod;
+
+  beforeAll(async () => {
+    mongod = await connectMemoryMongo();
+  });
+
+  afterAll(async () => {
+    await disconnectMemoryMongo(mongod);
+  });
+
+  test('every KNOWN_EXPOSURES entry still reproduces (fixing one forces the list to shrink)', async () => {
+    const problems = await assertKnownExposuresStillLeak(Object.values(SUITES));
+    expect(problems).toEqual([]);
+  });
+});

--- a/backend/__tests__/unit/security/leakMatrix.registry.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.registry.test.js
@@ -1,0 +1,23 @@
+/**
+ * B1 leak matrix — agent registry reads, each as owner (pod creator) / member /
+ * stranger / admin (not a member):
+ *   GET /api/registry/pods/:podId/agents/:name                 (persisted installation config)
+ *   GET /api/registry/pods/:podId/agents/:name/runtime-tokens  (selects agentRuntimeTokens)
+ *   GET /api/registry/pods/:podId/agents/:name/user-token      (selects +apiToken)
+ * The agent User carries apiToken / agentRuntimeTokens[].tokenHash sentinels;
+ * the AgentInstallation carries runtimeTokens[].tokenHash and a config with
+ * runtime.webhookSecret, authProfiles[].key and skillEnv values as sentinels.
+ * The full /api/registry router is mounted, as server.ts does.
+ * Skipped routes: none of the three. Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) if anything pulls it in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { registry } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(registry);

--- a/backend/__tests__/unit/security/leakMatrix.users.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.users.test.js
@@ -1,0 +1,22 @@
+/**
+ * B1 leak matrix — User read routes. Every user carries password, apiToken,
+ * agentRuntimeTokens[].tokenHash, deviceTokens[].tokenHash and
+ * digestUnsubscribeToken sentinels.
+ *   GET /api/auth/user, /api/auth/profile, /api/auth/api-token, /api/users/profile  (as self)
+ *   GET /api/users/:id   (the seeded user, as self / stranger / admin)
+ *   GET /api/admin/users (as self / stranger / admin)
+ * requireBrowserJwt is satisfied by the auth mock setting authType 'jwt', the
+ * value the real JWT branch of middleware/auth.ts sets.
+ * Skipped routes: none. Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) and authController imports it.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { users } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(users);

--- a/backend/__tests__/unit/security/leakMatrix.webhooks.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.webhooks.test.js
@@ -1,0 +1,23 @@
+/**
+ * B1 leak matrix — GET /api/webhooks/discord/channels/:integrationId
+ * (routes/webhooks/discord.ts). The router carries no auth middleware, so it is
+ * run as the integration's owner, a stranger, and an unauthenticated caller
+ * (no header at all). A stranger or anonymous 2xx is an access exposure (the
+ * correct answer is 401/403); the Integration and its DiscordIntegration carry
+ * every secret as a sentinel.
+ * DiscordService is REAL; only axios (the network boundary) is stubbed.
+ * Skipped routes: POST / and POST /test/:integrationId (not reads).
+ * Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
+ */
+jest.mock('../../../middleware/auth', () => require('../../utils/leakMatrix').authMock);
+jest.mock('../../../middleware/agentRuntimeAuth', () => require('../../utils/leakMatrix').agentRuntimeAuthMock);
+// Auth is mocked, so no JWT is ever verified; jsonwebtoken fails to load on
+// Node 26 (buffer-equal-constant-time) if anything pulls it in transitively.
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+jest.mock('../../../models/ToolCall', () => require('../../utils/leakMatrix').toolCallMock);
+jest.mock('axios', () => require('../../utils/leakMatrix').axiosMock);
+
+const { defineLeakMatrix } = require('../../utils/leakMatrix');
+const { webhooks } = require('../../utils/leakMatrixSuites');
+
+defineLeakMatrix(webhooks);

--- a/backend/__tests__/utils/leakMatrix.js
+++ b/backend/__tests__/utils/leakMatrix.js
@@ -1,0 +1,525 @@
+/**
+ * B1 leak matrix — shared harness.
+ *
+ * Every credential-bearing field is seeded with a unique, greppable SENTINEL
+ * string (hashes included: a tokenHash is server-internal and must not leave
+ * the server either). Each (route, role) case calls the real route through
+ * supertest, then searches the serialized 2xx body for every sentinel. A
+ * sentinel in a 2xx body is a leak.
+ *
+ * Known leaks on main are NOT skipped silently: they are listed in
+ * KNOWN_EXPOSURES as exact (method, path, role, sentinelKey) tuples. The matrix
+ * subtracts only those, so any other sentinel still fails. The ratchet test
+ * (leakMatrix.ratchet.test.js) replays every entry and fails when an entry no
+ * longer reproduces, so a fix forces this list to shrink.
+ *
+ * This file lives under __tests__/utils/ because jest's default testMatch
+ * collects every .js under __tests__/ regardless of suffix, and utils/ is the
+ * one directory jest.config.js ignores as tests.
+ */
+const express = require('express');
+const request = require('supertest');
+const mongoose = require('mongoose');
+
+const SENTINEL_SUFFIX = '7f3a';
+const sentinelValue = (key) => `SENTINEL_${key}_${SENTINEL_SUFFIX}`;
+
+/**
+ * A sentinel registry for one seeded world: `s('INT_TELEGRAM_BOTTOKEN')`
+ * returns the value and records it. `s.all` maps key -> value.
+ */
+const createSentinels = () => {
+  const all = {};
+  const s = (key) => {
+    if (all[key]) throw new Error(`duplicate sentinel key ${key}`);
+    all[key] = sentinelValue(key);
+    return all[key];
+  };
+  s.all = all;
+  return s;
+};
+
+/** Keys of every sentinel that appears anywhere in the response. */
+const findSentinels = (res, sentinels) => {
+  const haystack = `${JSON.stringify(res.body)}\n${res.text || ''}`;
+  return Object.keys(sentinels).filter((key) => haystack.includes(sentinels[key])).sort();
+};
+
+// ---------------------------------------------------------------------------
+// Auth mocks. Wired from each test file with
+//   jest.mock('<path>/middleware/auth', () => require('<path>/utils/leakMatrix').authMock)
+// ---------------------------------------------------------------------------
+
+/**
+ * Human identity from `x-test-user`, shaped like the JWT branch of
+ * middleware/auth.ts: `req.user = { id }`, `req.userId = id`,
+ * `req.authType = 'jwt'` (routes/auth.ts requireBrowserJwt reads authType).
+ * No header -> 401. adminAuth stays REAL, so admin is a real role:'admin' row.
+ */
+const authMock = (req, res, next) => {
+  const id = req.get('x-test-user');
+  if (!id) return res.status(401).json({ msg: 'No token, authorization denied' });
+  req.user = { id };
+  req.userId = id;
+  req.authType = 'jwt';
+  return next();
+};
+
+/**
+ * Agent identity from `x-test-agent` (a real bot User row id). Mirrors the
+ * User-row-token branch of middleware/agentRuntimeAuth.ts: loads the bot User,
+ * its active AgentInstallations by (agentName, instanceId), and derives
+ * agentAuthorizedPodIds from them. Only the token lookup itself is skipped.
+ */
+const agentRuntimeAuthMock = async (req, res, next) => {
+  const id = req.get('x-test-agent');
+  if (!id) return res.status(401).json({ message: 'Missing agent token' });
+  try {
+    // eslint-disable-next-line global-require
+    const User = require('../../models/User');
+    // eslint-disable-next-line global-require
+    const { AgentInstallation } = require('../../models/AgentRegistry');
+    const agentUser = await User.findById(id);
+    if (!agentUser) return res.status(401).json({ message: 'Invalid agent token' });
+    const agentName = String(agentUser.botMetadata?.agentName || '').toLowerCase();
+    const instanceId = agentUser.botMetadata?.instanceId || 'default';
+    const installations = await AgentInstallation.find({ agentName, instanceId, status: 'active' }).lean();
+    req.agentUser = agentUser;
+    req.agentInstallations = installations;
+    req.agentInstallation = installations[0] || null;
+    req.agentAuthorizedPodIds = installations.map((inst) => String(inst.podId));
+    return next();
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+/**
+ * ToolCall is Postgres-backed; mocked at the module boundary as
+ * grants.read.test.js does. The row carries an `args` field holding a
+ * sentinel: the broker never stores arguments, and the trail route must not
+ * serialize them even if a row somehow did.
+ */
+const TOOLCALL_ARGS_SENTINEL_KEY = 'TOOLCALL_ARGS';
+const toolCallMock = {
+  listForGrant: async (grantId) => [{
+    callId: 'call-leak-1',
+    grantId,
+    podId: 'p',
+    installationId: 'install-1',
+    agentUserId: 'seat',
+    tool: 'github.list_issues',
+    argsDigest: 'a'.repeat(64),
+    at: new Date('2026-09-11T04:00:00.000Z'),
+    outcome: 'ok',
+    durationMs: 120,
+    args: { token: sentinelValue(TOOLCALL_ARGS_SENTINEL_KEY) },
+  }],
+  countsForGrant: async () => ({ total: 1, ok: 1, refused: 0, pending_approval: 0, failed: 0 }),
+  digestArgs: () => 'a'.repeat(64),
+  reserveBudgetLineage: async () => ({ ok: true }),
+};
+
+/**
+ * Network backstop for suites whose routes construct a DiscordService: no
+ * request leaves the process. Wired with
+ *   jest.mock('axios', () => require('<path>/utils/leakMatrix').axiosMock)
+ * GET answers a fixed channel list that carries no credential (it never echoes
+ * the Authorization header). DiscordService itself stays REAL: a stubbed
+ * service returning channels would fabricate the status the case measures.
+ * Plain functions, not jest.fn: jest.config sets restoreMocks.
+ */
+const axiosMock = (() => {
+  const refuse = async () => { throw new Error('leak matrix: network disabled'); };
+  const stub = {
+    get: async () => ({ status: 200, data: [{ id: 'chan-1', name: 'general', type: 0, topic: '', position: 0 }] }),
+    post: refuse,
+    put: refuse,
+    patch: refuse,
+    delete: refuse,
+    request: refuse,
+    isAxiosError: () => false,
+    interceptors: { request: { use: () => 0 }, response: { use: () => 0 } },
+    defaults: { headers: { common: {} } },
+  };
+  stub.create = () => stub;
+  stub.default = stub;
+  return stub;
+})();
+
+// ---------------------------------------------------------------------------
+// Disclosures that are intended, and exposures that are known.
+// ---------------------------------------------------------------------------
+
+/**
+ * Intended disclosures — not leaks. config.connectCode is the one-time enable
+ * code a Telegram connector's owner pastes into Telegram. It is allowed exactly
+ * where a frontend surface reads it, and nowhere else:
+ *  - GET /api/integrations/:podId (owner/member/admin): ChatRoom's pod
+ *    integrations list (frontend/src/components/ChatRoom.tsx:957, :1184 fetch;
+ *    :1395 reads existingIntegration.config.connectCode). A stranger is 403.
+ *  - GET /api/installables (owner): the Connectors page builds each catalog
+ *    row's connector from entry.integration (V2ConnectorsPage.tsx:215 fetch,
+ *    :782-790 connectorForEntry, :794-799 items) and reads connectCode in
+ *    codeIsLive / the aside (:154-157, :1097-1099).
+ *  - GET /api/integrations/user/all (owner): the same page's legacy and
+ *    catalog-unavailable rows (V2ConnectorsPage.tsx:212 fetch, :217,
+ *    :802-805), read by the same :154-157 / :1097-1099 code.
+ * Telegram only: those reads sit behind isTelegram (:601, :1089). A Slack row's
+ * config.connectCode is its OAuth state (routes/installables.ts:278), never read
+ * by the frontend, so it stays a KNOWN_EXPOSURE. /api/integrations/admin/all
+ * (AppsManagement.tsx:153) never reads connectCode.
+ */
+const ALLOWED_DISCLOSURES = [
+  ...['owner', 'member', 'admin'].map((role) => ({
+    method: 'GET', path: '/api/integrations/:podId', role, sentinelKey: 'INT_TELEGRAM_CONNECTCODE',
+  })),
+  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_TELEGRAM_CONNECTCODE' },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_TELEGRAM_CONNECTCODE' },
+];
+
+/**
+ * An access exposure: a role that must be refused (401/403) gets a 2xx. It is
+ * listed with this literal in place of a sentinel key. The case keeps
+ * `expect` at today's 2xx and carries `refuse: true`; the ratchet checks the
+ * case still answers 2xx, so the entry must go when the route starts refusing.
+ */
+const ACCESS_2XX = 'ACCESS_2XX';
+
+/* eslint-disable max-len */
+const R_INT_SECRETS = 'Integration toJSON strips config secrets but not ingestTokens[].tokenHash, installationClaimId or config.oauthStateClaimId';
+const R_INT_CONNECTCODE = 'config.connectCode reaches a caller that is not the owner reading it from a surface that needs it';
+const R_INST_LEAN = 'installableCatalogService reads Integration with .lean(), bypassing the toJSON transform';
+const R_SLACK_OAUTH_STATE = 'a Slack row\'s config.connectCode is its OAuth state; no surface reads it';
+const R_USER_RUNTIME_HASH = 'User serialization keeps agentRuntimeTokens[].tokenHash';
+const R_USER_APITOKEN = 'returns the caller\'s raw apiToken; decide whether the browser may ever re-read it';
+const R_RT_PLAINTEXT = 'fix PR pending: stripped from the agent route (68039 item 1)';
+const R_GATEWAY_TOKEN = 'GET /api/gateways returns lean rows verbatim, including metadata.gatewayToken';
+const R_REG_WEBHOOKSECRET = 'sanitizeRuntimeConfig strips authProfiles/skillEnv but passes runtime.webhookSecret through';
+/* eslint-enable max-len */
+
+/**
+ * Leaks that reproduce on main today, sorted by (path, variant, method, role,
+ * sentinelKey). Each entry is an exact (method, path, role, sentinelKey) tuple
+ * observed in a real 2xx body, or an ACCESS_2XX tuple. The matrix fails on any
+ * leak not listed; the ratchet fails on any entry that no longer reproduces,
+ * so the list only shrinks. Remove an entry when its fix lands.
+ */
+/* eslint-disable max-len */
+const KNOWN_EXPOSURES = [
+  // GET /api/admin/integrations/global — follow-up: strip hashes/claim ids in the Integration toJSON transform
+  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  // GET /api/agents/runtime/pods/:podId/integrations — follow-up: the 68039 item-1 fix PR (plaintext botToken/accessToken to agents)
+  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_GLOBAL_X_ACCESSTOKEN', reason: R_RT_PLAINTEXT },
+  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_GLOBAL_X_BOTTOKEN', reason: R_RT_PLAINTEXT },
+  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_TELEGRAM_ACCESSTOKEN', reason: R_RT_PLAINTEXT },
+  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_TELEGRAM_BOTTOKEN', reason: R_RT_PLAINTEXT },
+  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_X_ACCESSTOKEN', reason: R_RT_PLAINTEXT },
+  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_X_BOTTOKEN', reason: R_RT_PLAINTEXT },
+  // GET /api/auth/api-token — follow-up: decide whether GET may return the raw apiToken at all
+  { method: 'GET', path: '/api/auth/api-token', role: 'self', sentinelKey: 'SELF_USER_APITOKEN', reason: R_USER_APITOKEN },
+  // GET /api/auth/profile — follow-up: drop agentRuntimeTokens[].tokenHash from User serialization
+  { method: 'GET', path: '/api/auth/profile', role: 'self', sentinelKey: 'SELF_USER_AGENTRUNTIMETOKEN_HASH', reason: R_USER_RUNTIME_HASH },
+  // GET /api/auth/user — follow-up: drop agentRuntimeTokens[].tokenHash from User serialization
+  { method: 'GET', path: '/api/auth/user', role: 'self', sentinelKey: 'SELF_USER_AGENTRUNTIMETOKEN_HASH', reason: R_USER_RUNTIME_HASH },
+  // GET /api/discord/binding/:podId — follow-up: strip hashes/claim ids in the Integration toJSON transform
+  { method: 'GET', path: '/api/discord/binding/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/discord/binding/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/discord/binding/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/discord/binding/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/discord/binding/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/discord/binding/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  // GET /api/gateways — follow-up: project Gateway rows; never return metadata.gatewayToken
+  { method: 'GET', path: '/api/gateways', role: 'admin', sentinelKey: 'GATEWAY_METADATA_GATEWAYTOKEN', reason: R_GATEWAY_TOKEN },
+  // GET /api/installables — follow-up: project Integration through toJSON/integrationPublicConfig in installableCatalogService
+  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_SLACK_CONNECTCODE', reason: R_SLACK_OAUTH_STATE },
+  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_SLACK_INGEST_TOKENHASH', reason: R_INST_LEAN },
+  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_SLACK_INSTALLATIONCLAIMID', reason: R_INST_LEAN },
+  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_SLACK_OAUTHSTATECLAIMID', reason: R_INST_LEAN },
+  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_TELEGRAM_INGEST_TOKENHASH', reason: R_INST_LEAN },
+  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INST_LEAN },
+  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INST_LEAN },
+  // GET /api/integrations/:podId — follow-up: strip hashes/claim ids in the Integration toJSON transform
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  // GET /api/integrations/admin/all — follow-up: strip hashes/claim ids in toJSON; drop connectCode from the admin list
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_TELEGRAM_CONNECTCODE', reason: R_INT_CONNECTCODE },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  // GET /api/integrations/user/all — follow-up: strip hashes/claim ids in the Integration toJSON transform
+  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
+  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  // GET /api/registry/pods/:podId/agents/:name — follow-up: strip runtime.webhookSecret in sanitizeRuntimeConfig
+  { method: 'GET', path: '/api/registry/pods/:podId/agents/:name', role: 'member', sentinelKey: 'REG_INSTALL_RUNTIME_WEBHOOKSECRET', reason: R_REG_WEBHOOKSECRET },
+  { method: 'GET', path: '/api/registry/pods/:podId/agents/:name', role: 'owner', sentinelKey: 'REG_INSTALL_RUNTIME_WEBHOOKSECRET', reason: R_REG_WEBHOOKSECRET },
+];
+/* eslint-enable max-len */
+
+// `variant` distinguishes two cases on one route template (a pod grant vs a
+// seat grant on GET /api/grants/:grantId); an entry must name it to match.
+const sameCase = (entry, c) => entry.method === c.method && entry.path === c.path && entry.role === c.role
+  && (entry.variant || null) === (c.variant || null);
+const keysFor = (list, c) => list.filter((e) => sameCase(e, c)).map((e) => e.sentinelKey);
+
+/** The order KNOWN_EXPOSURES must be written in; also its uniqueness key. */
+const exposureSortKey = (e) => [e.path, e.variant || '', e.method, e.role, e.sentinelKey].join('\u0000');
+const entryName = (e) => `${e.method} ${e.path}${e.variant ? ` [${e.variant}]` : ''} as ${e.role} (${e.sentinelKey})`;
+
+const is2xx = (status) => status >= 200 && status < 300;
+
+/**
+ * Everything wrong with one case's result, as readable strings. Pure, so the
+ * ACCESS_2XX and subtraction rules are testable without a route. `lists`
+ * defaults to the real ALLOWED_DISCLOSURES / KNOWN_EXPOSURES.
+ */
+const caseProblems = (c, status, found, lists = {}) => {
+  const allowedList = lists.allowed || ALLOWED_DISCLOSURES;
+  const knownList = lists.known || KNOWN_EXPOSURES;
+  const problems = [];
+  if (status !== c.expect) problems.push(`status ${status}, pinned ${c.expect}`);
+  if (!is2xx(status)) return problems; // refused: recorded by the status pin above
+  const known = keysFor(knownList, c);
+  if (c.refuse && !known.includes(ACCESS_2XX)) {
+    problems.push(`answered ${status} to a role that must get 401/403 — unlisted ${ACCESS_2XX}`);
+  }
+  const allowed = new Set([...keysFor(allowedList, c), ...known]);
+  found.filter((key) => !allowed.has(key)).forEach((key) => problems.push(`unexpected sentinel ${key} in 2xx body`));
+  return problems;
+};
+
+// ---------------------------------------------------------------------------
+// Store helpers.
+// ---------------------------------------------------------------------------
+
+const connectMemoryMongo = async () => {
+  // eslint-disable-next-line global-require
+  const { MongoMemoryServer } = require('mongodb-memory-server');
+  const mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  return mongod;
+};
+
+const disconnectMemoryMongo = async (mongod) => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+};
+
+const clearStore = async () => {
+  const collections = await mongoose.connection.db.collections();
+  await Promise.all(collections.map((col) => col.deleteMany({})));
+};
+
+/** Every raw document in the store, serialized — the positive control. */
+const rawStoreText = async () => {
+  const collections = await mongoose.connection.db.collections();
+  const dumps = await Promise.all(collections.map((col) => col.find({}).toArray()));
+  return JSON.stringify(dumps);
+};
+
+// ---------------------------------------------------------------------------
+// Matrix execution.
+// ---------------------------------------------------------------------------
+
+const buildApp = (suites) => {
+  const app = express();
+  app.use(express.json());
+  suites.forEach((suite) => suite.mount(app));
+  return app;
+};
+
+const caseName = (c) => `${c.method} ${c.path}${c.variant ? ` [${c.variant}]` : ''} as ${c.role}`;
+const caseKey = (c) => `${c.method} ${c.path}${c.variant ? ` [${c.variant}]` : ''}`;
+
+const runCase = async (app, ctx, c) => {
+  const identity = ctx.identities[c.role];
+  if (!identity) throw new Error(`suite has no identity for role ${c.role}`);
+  // An identity is { user } (human), { agent } (bot User row), { bearer } (a
+  // raw Authorization bearer checked by the route's REAL middleware, e.g. a
+  // cm_daemon_ token), or {} (anonymous: no credential at all).
+  let req = request(app)[c.method.toLowerCase()](c.url(ctx));
+  if (identity.user) req = req.set('x-test-user', String(identity.user));
+  if (identity.agent) {
+    // dualAuth routes pick agentRuntimeAuth only for a cm_agent_ bearer.
+    req = req.set('x-test-agent', String(identity.agent)).set('Authorization', 'Bearer cm_agent_leakmatrix');
+  }
+  if (identity.bearer) req = req.set('Authorization', `Bearer ${identity.bearer}`);
+  const res = await req;
+  return { status: res.status, found: findSentinels(res, ctx.sentinels), res };
+};
+
+/**
+ * Defines one describe block for a suite: a positive control proving the
+ * sentinels are really in the store, then one test per (route, role) case.
+ * Each case also pins its expected status, so a harness break that turns
+ * every call into a 500 cannot pass vacuously.
+ */
+const defineLeakMatrix = (suite) => {
+  describe(`leak matrix: ${suite.name}`, () => {
+    let mongod;
+    let app;
+    let ctx;
+
+    beforeAll(async () => {
+      mongod = await connectMemoryMongo();
+      app = buildApp([suite]);
+      ctx = await suite.seed();
+    });
+
+    afterAll(async () => {
+      await disconnectMemoryMongo(mongod);
+    });
+
+    test(`${suite.name}: every seeded sentinel is actually in the store (positive control)`, async () => {
+      const raw = await rawStoreText();
+      const boundary = new Set(ctx.boundarySentinels || []);
+      const missing = Object.keys(ctx.sentinels).filter((key) => !boundary.has(key) && !raw.includes(ctx.sentinels[key]));
+      expect(missing).toEqual([]);
+    });
+
+    suite.cases.forEach((c) => {
+      const name = caseName(c).replace(/ as (.*)$/, ' as $1 leaks no credential');
+      test(name, async () => {
+        const { status, found } = await runCase(app, ctx, c);
+        const problems = caseProblems(c, status, found);
+        expect({ case: caseName(c), problems }).toEqual({ case: caseName(c), problems: [] });
+      });
+    });
+  });
+};
+
+/**
+ * The ratchet: every KNOWN_EXPOSURES entry must name a real matrix case and
+ * still reproduce — a sentinel entry must still leak its sentinel in a 2xx
+ * body; an ACCESS_2XX entry must name a `refuse` case that still answers 2xx.
+ * Replays each entry against a freshly seeded world for its suite.
+ */
+const assertKnownExposuresStillLeak = async (suites, known = KNOWN_EXPOSURES) => {
+  const app = buildApp(suites);
+  const problems = [];
+  // eslint-disable-next-line no-restricted-syntax
+  for (const suite of suites) {
+    const entries = known.filter((e) => suite.cases.some((c) => sameCase(e, c)));
+    if (!entries.length) continue; // eslint-disable-line no-continue
+    // eslint-disable-next-line no-await-in-loop
+    await clearStore();
+    // eslint-disable-next-line no-await-in-loop
+    const ctx = await suite.seed();
+    // eslint-disable-next-line no-restricted-syntax
+    for (const entry of entries) {
+      const c = suite.cases.find((candidate) => sameCase(entry, candidate));
+      // eslint-disable-next-line no-await-in-loop
+      const { status, found } = await runCase(app, ctx, c);
+      if (entry.sentinelKey === ACCESS_2XX) {
+        if (!c.refuse) {
+          problems.push(`${entryName(entry)} names a case not marked refuse: true — mark the case or drop the entry`);
+        } else if (!is2xx(status)) {
+          problems.push(`${entryName(entry)} no longer answers 2xx (status ${status}) — remove this entry from KNOWN_EXPOSURES`);
+        }
+      } else if (!is2xx(status) || !found.includes(entry.sentinelKey)) {
+        problems.push(`${entryName(entry)} no longer leaks (status ${status}) — remove this entry from KNOWN_EXPOSURES`);
+      }
+    }
+  }
+  const orphans = known.filter((e) => !suites.some((suite) => suite.cases.some((c) => sameCase(e, c))));
+  orphans.forEach((e) => problems.push(`${entryName(e)} matches no matrix case — remove this entry from KNOWN_EXPOSURES`));
+  return problems;
+};
+
+module.exports = {
+  ACCESS_2XX,
+  ALLOWED_DISCLOSURES,
+  KNOWN_EXPOSURES,
+  SENTINEL_SUFFIX,
+  TOOLCALL_ARGS_SENTINEL_KEY,
+  agentRuntimeAuthMock,
+  assertKnownExposuresStillLeak,
+  axiosMock,
+  authMock,
+  buildApp,
+  caseKey,
+  caseName,
+  caseProblems,
+  entryName,
+  exposureSortKey,
+  clearStore,
+  connectMemoryMongo,
+  createSentinels,
+  defineLeakMatrix,
+  disconnectMemoryMongo,
+  findSentinels,
+  rawStoreText,
+  runCase,
+  sentinelValue,
+  toolCallMock,
+};

--- a/backend/__tests__/utils/leakMatrixSuites.js
+++ b/backend/__tests__/utils/leakMatrixSuites.js
@@ -1,0 +1,711 @@
+/**
+ * B1 leak matrix — the suites. Each suite is { name, mount(app), seed(), cases }.
+ *
+ * seed() builds a world on memory Mongo with every credential-bearing field set
+ * to a sentinel (see leakMatrix.js) and returns
+ *   { sentinels, identities: { role: { user } | { agent } }, ...ids }.
+ * Every human in every suite also carries User secrets (password, apiToken,
+ * agentRuntimeTokens/deviceTokens hashes, digestUnsubscribeToken) so a populate
+ * or projection that drags a User row along is caught on any route.
+ *
+ * A case is { method, path, role, url(ctx), expect, variant? }: `expect` is the
+ * status the route answers today, pinned so a broken harness (every call a 500)
+ * cannot pass vacuously.
+ *
+ * Models and routers are required lazily, inside mount()/seed(), so the calling
+ * test file's jest.mock()s are registered first.
+ */
+const mongoose = require('mongoose');
+const { createSentinels, sentinelValue, TOOLCALL_ARGS_SENTINEL_KEY } = require('./leakMatrix');
+
+/* eslint-disable global-require */
+const model = {
+  User: () => require('../../models/User'),
+  Pod: () => require('../../models/Pod'),
+  Integration: () => require('../../models/Integration'),
+  DiscordIntegration: () => require('../../models/DiscordIntegration'),
+  InstallableInstallation: () => require('../../models/InstallableInstallation'),
+  Installable: () => require('../../models/Installable'),
+  AgentCredential: () => require('../../models/AgentCredential'),
+  RoomGrant: () => require('../../models/RoomGrant'),
+  AgentInstallation: () => require('../../models/AgentRegistry').AgentInstallation,
+  Machine: () => require('../../models/Machine'),
+  Gateway: () => require('../../models/Gateway'),
+};
+/* eslint-enable global-require */
+
+const FUTURE = new Date('2099-01-01T00:00:00.000Z');
+
+/**
+ * A User row whose every secret field is a sentinel. Secrets are written with
+ * the raw driver after create: the password pre-save hook would bcrypt the
+ * sentinel away, and apiToken/digestUnsubscribeToken are select:false.
+ */
+const seedUser = async (s, prefix, over = {}) => {
+  const User = model.User();
+  const user = await User.create({
+    username: `${prefix.toLowerCase()}-${new mongoose.Types.ObjectId().toString().slice(-6)}`,
+    email: `${prefix.toLowerCase()}-${new mongoose.Types.ObjectId().toString().slice(-6)}@leak.test`,
+    password: 'placeholder-password',
+    ...over,
+  });
+  await User.collection.updateOne({ _id: user._id }, {
+    $set: {
+      password: s(`${prefix}_USER_PASSWORD`),
+      apiToken: s(`${prefix}_USER_APITOKEN`),
+      digestUnsubscribeToken: s(`${prefix}_USER_DIGESTUNSUBSCRIBETOKEN`),
+      agentRuntimeTokens: [{ tokenHash: s(`${prefix}_USER_AGENTRUNTIMETOKEN_HASH`), label: 'rt', createdAt: new Date() }],
+      deviceTokens: [{ _id: new mongoose.Types.ObjectId(), tokenHash: s(`${prefix}_USER_DEVICETOKEN_HASH`), label: 'laptop', createdAt: new Date() }],
+    },
+  });
+  return user._id;
+};
+
+const seedAgentUser = (s, prefix, agentName) => seedUser(s, prefix, {
+  isBot: true,
+  botType: 'agent',
+  botMetadata: { agentName, instanceId: 'default', displayName: prefix },
+});
+
+/** Every Integration secret the schema allows, each a sentinel under `prefix`. */
+const integrationSecrets = (s, prefix, { connectCode = false } = {}) => ({
+  installationClaimId: s(`${prefix}_INSTALLATIONCLAIMID`),
+  ingestTokens: [{ tokenHash: s(`${prefix}_INGEST_TOKENHASH`), label: 'ci', createdAt: new Date() }],
+  config: {
+    botToken: s(`${prefix}_BOTTOKEN`),
+    signingSecret: s(`${prefix}_SIGNINGSECRET`),
+    secretToken: s(`${prefix}_SECRETTOKEN`),
+    accessToken: s(`${prefix}_ACCESSTOKEN`),
+    refreshToken: s(`${prefix}_REFRESHTOKEN`),
+    webhookUrl: `https://hooks.example.test/services/T1/B1/${s(`${prefix}_WEBHOOKURL`)}`,
+    botTokenRef: s(`${prefix}_BOTTOKENREF`),
+    oauthStateNonce: s(`${prefix}_OAUTHSTATENONCE`),
+    oauthStateClaimId: s(`${prefix}_OAUTHSTATECLAIMID`),
+    ...(connectCode ? { connectCode: s(`${prefix}_CONNECTCODE`) } : {}),
+  },
+});
+
+const withConfig = (secrets, config) => ({ ...secrets, config: { ...secrets.config, ...config } });
+
+/**
+ * `refuse` lists roles whose correct answer is 401/403. Their `expect` is still
+ * today's status; a 2xx for one of them fails the matrix unless KNOWN_EXPOSURES
+ * lists it as ACCESS_2XX.
+ */
+const userCase = (method, path, role, url, expect, variant, refuse = false) => ({
+  method, path, role, url, expect, variant, ...(refuse ? { refuse: true } : {}),
+});
+const matrix = (method, path, url, expectByRole, variant, { refuse = [] } = {}) => Object.entries(expectByRole)
+  .map(([role, expect]) => userCase(method, path, role, url, expect, variant, refuse.includes(role)));
+
+// ---------------------------------------------------------------------------
+// 1. Integrations (+ Discord binding, admin global integrations)
+// ---------------------------------------------------------------------------
+const integrations = {
+  name: 'integrations',
+  mount(app) {
+    /* eslint-disable global-require */
+    app.use('/api/integrations', require('../../routes/integrations'));
+    app.use('/api/discord', require('../../routes/discord'));
+    app.use('/api/admin/integrations/global', require('../../routes/admin/globalIntegrations'));
+    /* eslint-enable global-require */
+  },
+  async seed() {
+    const s = createSentinels();
+    const Pod = model.Pod();
+    const Integration = model.Integration();
+    const owner = await seedUser(s, 'OWNER');
+    const member = await seedUser(s, 'MEMBER');
+    const stranger = await seedUser(s, 'STRANGER');
+    const admin = await seedUser(s, 'ADMIN', { role: 'admin' });
+    const pod = await Pod.create({ name: 'Leak Ops', createdBy: owner, members: [owner, member] });
+    const base = { podId: pod._id, scope: 'pod', status: 'connected', createdBy: owner, isActive: true };
+
+    const telegram = await Integration.create({
+      ...base,
+      type: 'telegram',
+      ...withConfig(integrationSecrets(s, 'INT_TELEGRAM', { connectCode: true }), { chatId: '-100', chatTitle: 'Ops' }),
+    });
+    const slack = await Integration.create({
+      ...base,
+      type: 'slack',
+      ...withConfig(integrationSecrets(s, 'INT_SLACK'), {
+        teamId: 'T1',
+        pendingBind: {
+          teamId: 'T1', slackUserId: 'U1', chatId: 'D1', expiresAt: FUTURE,
+          botTokenRef: s('INT_SLACK_PENDINGBIND_BOTTOKENREF'),
+        },
+      }),
+    });
+    await Integration.create({
+      ...base,
+      type: 'x',
+      ...withConfig(integrationSecrets(s, 'INT_X'), { username: 'ops' }),
+    });
+    const discord = await Integration.create({
+      ...base,
+      type: 'discord',
+      ...withConfig(integrationSecrets(s, 'INT_DISCORD'), { serverId: 'srv-1', channelId: 'chan-1' }),
+    });
+    await model.DiscordIntegration().create({
+      integrationId: discord._id,
+      serverId: 'srv-1',
+      serverName: 'Guild',
+      channelId: 'chan-1',
+      channelName: 'general',
+      webhookUrl: `https://discord.com/api/webhooks/1/${s('DISCORDINTEGRATION_WEBHOOKURL')}`,
+      webhookId: '1',
+      botToken: s('DISCORDINTEGRATION_BOTTOKEN'),
+    });
+
+    // The admin global-integrations page reads X/Instagram rows in the pod
+    // named 'Global Social Feed' (ensureGlobalSocialFeedPod finds it by name).
+    const globalPod = await Pod.create({ name: 'Global Social Feed', type: 'chat', createdBy: admin, members: [admin] });
+    await Integration.create({
+      podId: globalPod._id, scope: 'pod', status: 'connected', createdBy: admin, isActive: true,
+      type: 'x',
+      ...withConfig(integrationSecrets(s, 'GLOBAL_X'), { username: 'commonly', agentAccessEnabled: true, globalAgentAccess: true }),
+    });
+    await Integration.create({
+      podId: globalPod._id, scope: 'pod', status: 'connected', createdBy: admin, isActive: true,
+      type: 'instagram',
+      ...withConfig(integrationSecrets(s, 'GLOBAL_INSTAGRAM'), { username: 'commonly' }),
+    });
+
+    return {
+      sentinels: s.all,
+      identities: { owner: { user: owner }, member: { user: member }, stranger: { user: stranger }, admin: { user: admin } },
+      podId: String(pod._id),
+      telegramId: String(telegram._id),
+      slackId: String(slack._id),
+      discordId: String(discord._id),
+    };
+  },
+  cases: [
+    ...matrix('GET', '/api/integrations/catalog', () => '/api/integrations/catalog',
+      { owner: 200, member: 200, stranger: 200, admin: 200 }),
+    ...matrix('GET', '/api/integrations/:podId', (ctx) => `/api/integrations/${ctx.podId}`,
+      { owner: 200, member: 200, stranger: 403, admin: 200 }),
+    ...matrix('GET', '/api/integrations/admin/all', () => '/api/integrations/admin/all',
+      { owner: 403, member: 403, stranger: 403, admin: 200 }),
+    ...matrix('GET', '/api/integrations/user/all', () => '/api/integrations/user/all',
+      { owner: 200, member: 200, stranger: 200, admin: 200 }),
+    ...matrix('GET', '/api/integrations/:id/ingest-tokens', (ctx) => `/api/integrations/${ctx.telegramId}/ingest-tokens`,
+      { owner: 200, member: 403, stranger: 403, admin: 200 }),
+    ...matrix('GET', '/api/discord/binding/:podId', (ctx) => `/api/discord/binding/${ctx.podId}`,
+      { owner: 200, member: 403, stranger: 403, admin: 200 }),
+    ...matrix('GET', '/api/admin/integrations/global', () => '/api/admin/integrations/global',
+      { owner: 403, member: 403, stranger: 403, admin: 200 }),
+    // Owner-only via pod.createdBy (routes/integrations.ts); a member is 403.
+    // Discord builds a DiscordService from the row; Slack answers inline.
+    ...matrix('GET', '/api/integrations/:id/stats', (ctx) => `/api/integrations/${ctx.discordId}/stats`,
+      { owner: 200, member: 403, stranger: 403, admin: 403 }, 'discord row'),
+    ...matrix('GET', '/api/integrations/:id/stats', (ctx) => `/api/integrations/${ctx.slackId}/stats`,
+      { owner: 200, member: 403, stranger: 403, admin: 403 }, 'slack row'),
+    ...matrix('GET', '/api/integrations/:id/messages', (ctx) => `/api/integrations/${ctx.discordId}/messages`,
+      { owner: 500, member: 403, stranger: 403, admin: 403 }, 'discord row'),
+    ...matrix('GET', '/api/integrations/:id/messages', (ctx) => `/api/integrations/${ctx.slackId}/messages`,
+      { owner: 200, member: 403, stranger: 403, admin: 403 }, 'slack row'),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// 2. Installables catalog (installableCatalogService .lean() path)
+// ---------------------------------------------------------------------------
+const installables = {
+  name: 'installables',
+  mount(app) {
+    // eslint-disable-next-line global-require
+    app.use('/api/installables', require('../../routes/installables'));
+  },
+  async seed() {
+    const s = createSentinels();
+    const Integration = model.Integration();
+    const InstallableInstallation = model.InstallableInstallation();
+    const owner = await seedUser(s, 'OWNER');
+    const stranger = await seedUser(s, 'STRANGER');
+    const admin = await seedUser(s, 'ADMIN', { role: 'admin' });
+    const installation = (installableId, claimKey) => InstallableInstallation.create({
+      installableId,
+      installableVersion: '1.0.0',
+      targetType: 'user',
+      targetId: owner,
+      scope: 'user',
+      installedBy: owner,
+      installSource: 'ui',
+      status: 'active',
+      claimId: s(claimKey),
+    });
+    const tgInstall = await installation('telegram', 'INST_TELEGRAM_INSTALLATION_CLAIMID');
+    const slackInstall = await installation('slack', 'INST_SLACK_INSTALLATION_CLAIMID');
+    await Integration.create({
+      installationId: String(tgInstall._id), scope: 'user', type: 'telegram', status: 'connected', createdBy: owner, isActive: true,
+      ...withConfig(integrationSecrets(s, 'INST_TELEGRAM', { connectCode: true }), { chatId: '-100' }),
+    });
+    await Integration.create({
+      installationId: String(slackInstall._id), scope: 'user', type: 'slack', status: 'pending', createdBy: owner, isActive: true,
+      ...withConfig(integrationSecrets(s, 'INST_SLACK', { connectCode: true }), {
+        teamId: 'T1',
+        pendingBind: {
+          teamId: 'T1', slackUserId: 'U1', chatId: 'D1', expiresAt: FUTURE,
+          botTokenRef: s('INST_SLACK_PENDINGBIND_BOTTOKENREF'),
+        },
+      }),
+    });
+    // The Tools list: the seeded GitHub tool Installable and the caller's own
+    // github-app connection, which the catalog projects to connectionId/owner/repo.
+    // eslint-disable-next-line global-require
+    const { buildGithubToolInstallable } = require('../../services/installable/toolInstallables');
+    await model.Installable().create(buildGithubToolInstallable());
+    await Integration.create({
+      installationId: 'install-leak-1', scope: 'user', type: 'github-app', status: 'connected', createdBy: owner, isActive: true,
+      ...withConfig(integrationSecrets(s, 'INST_GITHUBAPP'), { installationId: 'install-leak-1', owner: 'octo', repo: 'demo' }),
+    });
+    return {
+      sentinels: s.all,
+      identities: { owner: { user: owner }, stranger: { user: stranger }, admin: { user: admin } },
+    };
+  },
+  cases: [
+    ...matrix('GET', '/api/installables', () => '/api/installables', { owner: 200, stranger: 200, admin: 200 }),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// 3. Users
+// ---------------------------------------------------------------------------
+const users = {
+  name: 'users',
+  mount(app) {
+    /* eslint-disable global-require */
+    app.use('/api/auth', require('../../routes/auth'));
+    app.use('/api/users', require('../../routes/users'));
+    app.use('/api/admin/users', require('../../routes/admin/users'));
+    /* eslint-enable global-require */
+  },
+  async seed() {
+    const s = createSentinels();
+    const self = await seedUser(s, 'SELF');
+    const stranger = await seedUser(s, 'STRANGER');
+    const admin = await seedUser(s, 'ADMIN', { role: 'admin' });
+    return {
+      sentinels: s.all,
+      identities: { self: { user: self }, stranger: { user: stranger }, admin: { user: admin } },
+      selfId: String(self),
+    };
+  },
+  cases: [
+    // Routes whose subject is always the caller: only `self` is meaningful.
+    ...matrix('GET', '/api/auth/user', () => '/api/auth/user', { self: 200 }),
+    ...matrix('GET', '/api/auth/profile', () => '/api/auth/profile', { self: 200 }),
+    ...matrix('GET', '/api/auth/api-token', () => '/api/auth/api-token', { self: 200 }),
+    ...matrix('GET', '/api/users/profile', () => '/api/users/profile', { self: 200 }),
+    // Routes with a subject: the seeded `self` user, viewed by each role.
+    ...matrix('GET', '/api/users/:id', (ctx) => `/api/users/${ctx.selfId}`, { self: 200, stranger: 200, admin: 200 }),
+    ...matrix('GET', '/api/admin/users', () => '/api/admin/users', { self: 403, stranger: 403, admin: 200 }),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// 4. Credentials
+// ---------------------------------------------------------------------------
+const credentials = {
+  name: 'credentials',
+  mount(app) {
+    // eslint-disable-next-line global-require
+    app.use('/api/credentials', require('../../routes/credentials'));
+  },
+  async seed() {
+    const s = createSentinels();
+    const AgentCredential = model.AgentCredential();
+    const owner = await seedUser(s, 'OWNER');
+    const stranger = await seedUser(s, 'STRANGER');
+    const admin = await seedUser(s, 'ADMIN', { role: 'admin' });
+    const daemon = await AgentCredential.create({
+      tokenHash: s('OWNER_CRED_DAEMON_TOKENHASH'), kind: 'daemon', ownerUserId: owner, machineId: 'm-1', label: 'laptop',
+    });
+    await AgentCredential.create({
+      tokenHash: s('OWNER_CRED_RUNTIME_TOKENHASH'), kind: 'runtime', ownerUserId: owner, parentId: daemon._id, label: 'seat',
+    });
+    await AgentCredential.create({ tokenHash: s('STRANGER_CRED_TOKENHASH'), kind: 'runtime', ownerUserId: stranger });
+    await AgentCredential.create({ tokenHash: s('ADMIN_CRED_TOKENHASH'), kind: 'runtime', ownerUserId: admin });
+    return {
+      sentinels: s.all,
+      identities: { owner: { user: owner }, stranger: { user: stranger }, admin: { user: admin } },
+    };
+  },
+  cases: [
+    ...matrix('GET', '/api/credentials', () => '/api/credentials', { owner: 200, stranger: 200, admin: 200 }),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// 5. Grants
+// ---------------------------------------------------------------------------
+const grants = {
+  name: 'grants',
+  mount(app) {
+    // eslint-disable-next-line global-require
+    const grantRoutes = require('../../routes/grants');
+    app.use('/api/pods', grantRoutes.podGrantsRouter);
+    app.use('/api/grants', grantRoutes);
+  },
+  async seed() {
+    const s = createSentinels();
+    const owner = await seedUser(s, 'OWNER'); // installed the App: every grant's granter
+    const member = await seedUser(s, 'MEMBER');
+    const stranger = await seedUser(s, 'STRANGER');
+    const admin = await seedUser(s, 'ADMIN', { role: 'admin' });
+    const seat = await seedAgentUser(s, 'SEAT', 'leakseat');
+    const pod = await model.Pod().create({ name: 'Grant Room', createdBy: owner, members: [owner, member, seat] });
+    const connectionId = s('GRANT_CONNECTIONID');
+    await model.Integration().create({
+      installationId: connectionId, scope: 'user', type: 'github-app', status: 'connected', createdBy: owner, isActive: true,
+      ...withConfig(integrationSecrets(s, 'GRANT_CONNECTION'), { installationId: 'install-1', owner: 'octo', repo: 'demo' }),
+    });
+    const RoomGrant = model.RoomGrant();
+    const shared = {
+      connectionId,
+      installationId: 'install-1',
+      tools: ['github.list_issues'],
+      writeMode: 'read',
+      budget: { calls: 10, windowMs: 60000 },
+      expiresAt: FUTURE,
+      brokerId: s('GRANT_BROKERID'),
+    };
+    await RoomGrant.create({
+      ...shared,
+      grantId: 'grant_pod_leak',
+      target: { kind: 'pod', id: String(pod._id) },
+      // A departed agent still in the snapshot: only the effective audience may go out.
+      audience: [String(seat), s('GRANT_POD_RAW_AUDIENCE')],
+    });
+    // A seat grant's audience is exactly [seat]: POST /api/grants refuses any
+    // other seat audience (routes/grants.ts, 'seat audience must be the target
+    // seat'), so a second entry here would seed an unreachable state.
+    await RoomGrant.create({
+      ...shared,
+      grantId: 'grant_seat_leak',
+      target: { kind: 'seat', id: String(seat) },
+      audience: [String(seat)],
+    });
+    s.all[TOOLCALL_ARGS_SENTINEL_KEY] = sentinelValue(TOOLCALL_ARGS_SENTINEL_KEY);
+    return {
+      sentinels: s.all,
+      boundarySentinels: [TOOLCALL_ARGS_SENTINEL_KEY], // lives in the ToolCall mock, not Mongo
+      identities: {
+        owner: { user: owner }, member: { user: member }, stranger: { user: stranger }, admin: { user: admin }, seat: { agent: seat },
+      },
+      podId: String(pod._id),
+    };
+  },
+  cases: [
+    ...matrix('GET', '/api/grants/:grantId', () => '/api/grants/grant_pod_leak',
+      { owner: 200, member: 200, stranger: 403, admin: 200, seat: 200 }, 'pod grant'),
+    ...matrix('GET', '/api/grants/:grantId', () => '/api/grants/grant_seat_leak',
+      { owner: 200, member: 403, stranger: 403, admin: 403, seat: 200 }, 'seat grant'),
+    ...matrix('GET', '/api/grants/:grantId/calls', () => '/api/grants/grant_pod_leak/calls',
+      { owner: 200, member: 200, stranger: 403, admin: 200, seat: 200 }, 'pod grant'),
+    ...matrix('GET', '/api/grants/:grantId/calls', () => '/api/grants/grant_seat_leak/calls',
+      { owner: 200, member: 403, stranger: 403, admin: 403, seat: 200 }, 'seat grant'),
+    ...matrix('GET', '/api/pods/:podId/grants', (ctx) => `/api/pods/${ctx.podId}/grants`,
+      { owner: 200, member: 200, stranger: 403, admin: 200 }),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// 6. Agent runtime integrations
+// ---------------------------------------------------------------------------
+const agentRuntime = {
+  name: 'agentRuntime',
+  mount(app) {
+    // eslint-disable-next-line global-require
+    app.use('/api/agents/runtime', require('../../routes/agentsRuntime'));
+  },
+  async seed() {
+    const s = createSentinels();
+    const Pod = model.Pod();
+    const Integration = model.Integration();
+    const AgentInstallation = model.AgentInstallation();
+    const owner = await seedUser(s, 'OWNER');
+    const agent = await seedAgentUser(s, 'AGENT', 'leakagent');
+    const unscoped = await seedAgentUser(s, 'AGENT_UNSCOPED', 'leaknoscope');
+    const outsider = await seedAgentUser(s, 'AGENT_OUTSIDER', 'leakoutsider');
+    const pod = await Pod.create({ name: 'Runtime Room', createdBy: owner, members: [owner, agent, unscoped] });
+    const otherPod = await Pod.create({ name: 'Elsewhere', createdBy: owner, members: [owner, outsider] });
+    const install = (agentName, podId, scopes) => AgentInstallation.create({
+      agentName, podId, version: '1.0.0', installedBy: owner, instanceId: 'default', status: 'active', scopes,
+    });
+    await install('leakagent', pod._id, ['integration:read']);
+    await install('leaknoscope', pod._id, ['context:read']);
+    await install('leakoutsider', otherPod._id, ['integration:read']);
+    const base = { scope: 'pod', status: 'connected', createdBy: owner, isActive: true };
+    await Integration.create({
+      ...base, podId: pod._id, type: 'telegram',
+      ...withConfig(integrationSecrets(s, 'RT_TELEGRAM'), { chatId: '-100', agentAccessEnabled: true }),
+    });
+    await Integration.create({
+      ...base, podId: pod._id, type: 'x',
+      ...withConfig(integrationSecrets(s, 'RT_X'), { username: 'ops', agentAccessEnabled: true }),
+    });
+    // Agent access OFF: must never reach an agent, scoped or not.
+    await Integration.create({
+      ...base, podId: pod._id, type: 'slack',
+      ...withConfig(integrationSecrets(s, 'RT_SLACK_NOACCESS'), { teamId: 'T1', agentAccessEnabled: false }),
+    });
+    // A global integration in another pod, shared to every agent with integration:read.
+    await Integration.create({
+      ...base, podId: otherPod._id, type: 'x',
+      ...withConfig(integrationSecrets(s, 'RT_GLOBAL_X'), { username: 'commonly', agentAccessEnabled: true, globalAgentAccess: true }),
+    });
+    return {
+      sentinels: s.all,
+      identities: { agent: { agent }, 'agent-unscoped': { agent: unscoped }, 'agent-outsider': { agent: outsider } },
+      podId: String(pod._id),
+    };
+  },
+  cases: [
+    ...matrix('GET', '/api/agents/runtime/pods/:podId/integrations', (ctx) => `/api/agents/runtime/pods/${ctx.podId}/integrations`,
+      { agent: 200, 'agent-unscoped': 403, 'agent-outsider': 403 }),
+  ],
+};
+
+/**
+ * An AgentInstallation config carrying every runtime secret the install and
+ * provision paths persist: runtime.webhookSecret (read back by
+ * agentEventService.deliverEventViaWebhook to sign deliveries), and the
+ * authProfiles / skillEnv blocks routes/registry/install.ts + provision.ts
+ * normalize and store.
+ */
+const installationConfigSecrets = (s, prefix) => ({
+  presetId: 'leak-preset',
+  heartbeat: { everyMinutes: 30 },
+  runtime: {
+    runtimeType: 'webhook',
+    status: 'provisioned',
+    accountId: 'acct-1',
+    webhookUrl: 'https://agent.example.test/events',
+    webhookSecret: s(`${prefix}_RUNTIME_WEBHOOKSECRET`),
+    authProfiles: {
+      'openai:default': { type: 'api_key', provider: 'openai', key: s(`${prefix}_RUNTIME_AUTHPROFILE_KEY`) },
+    },
+    skillEnv: { github: { GITHUB_TOKEN: s(`${prefix}_RUNTIME_SKILLENV_VALUE`) } },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// 7. Discord webhook helper routes (routes/webhooks/discord.ts: no auth on the router)
+// ---------------------------------------------------------------------------
+const webhooks = {
+  name: 'webhooks',
+  mount(app) {
+    // eslint-disable-next-line global-require
+    app.use('/api/webhooks/discord', require('../../routes/webhooks/discord'));
+  },
+  async seed() {
+    const s = createSentinels();
+    const owner = await seedUser(s, 'OWNER');
+    const stranger = await seedUser(s, 'STRANGER');
+    const pod = await model.Pod().create({ name: 'Discord Room', createdBy: owner, members: [owner] });
+    const discord = await model.Integration().create({
+      podId: pod._id, scope: 'pod', status: 'connected', createdBy: owner, isActive: true, type: 'discord',
+      ...withConfig(integrationSecrets(s, 'WH_DISCORD'), { serverId: 'srv-1', channelId: 'chan-1' }),
+    });
+    await model.DiscordIntegration().create({
+      integrationId: discord._id,
+      serverId: 'srv-1',
+      serverName: 'Guild',
+      channelId: 'chan-1',
+      channelName: 'general',
+      webhookUrl: `https://discord.com/api/webhooks/1/${s('WH_DISCORDINTEGRATION_WEBHOOKURL')}`,
+      webhookId: '1',
+      botToken: s('WH_DISCORDINTEGRATION_BOTTOKEN'),
+    });
+    return {
+      sentinels: s.all,
+      identities: { owner: { user: owner }, stranger: { user: stranger }, anonymous: {} },
+      integrationId: String(discord._id),
+    };
+  },
+  cases: [
+    // The correct answer for a stranger or an unauthenticated caller is 401/403.
+    ...matrix('GET', '/api/webhooks/discord/channels/:integrationId',
+      (ctx) => `/api/webhooks/discord/channels/${ctx.integrationId}`,
+      { owner: 500, stranger: 500, anonymous: 500 }, undefined, { refuse: ['stranger', 'anonymous'] }),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// 8. Registry: agent tokens + installed pod agent (routes/registry/agent-tokens.ts, pod-agents.ts)
+// ---------------------------------------------------------------------------
+const REG_AGENT = 'leakregagent';
+const registry = {
+  name: 'registry',
+  mount(app) {
+    // eslint-disable-next-line global-require
+    app.use('/api/registry', require('../../routes/registry'));
+  },
+  async seed() {
+    const s = createSentinels();
+    const owner = await seedUser(s, 'OWNER');
+    const member = await seedUser(s, 'MEMBER');
+    const stranger = await seedUser(s, 'STRANGER');
+    const admin = await seedUser(s, 'ADMIN', { role: 'admin' });
+    const pod = await model.Pod().create({ name: 'Registry Room', createdBy: owner, members: [owner, member] });
+    // agent-tokens looks the agent up by buildAgentUsername(type, 'default') === type.
+    // seedUser gives it an apiToken (read by GET user-token via +apiToken) and an
+    // agentRuntimeTokens[].tokenHash (read by GET runtime-tokens).
+    await seedUser(s, 'REG_AGENT', {
+      username: REG_AGENT,
+      isBot: true,
+      botType: 'agent',
+      botMetadata: { agentName: REG_AGENT, instanceId: 'default', displayName: 'Reg Agent' },
+    });
+    await model.AgentInstallation().create({
+      agentName: REG_AGENT,
+      podId: pod._id,
+      version: '1.0.0',
+      installedBy: owner,
+      instanceId: 'default',
+      displayName: 'Reg Agent',
+      status: 'active',
+      scopes: ['context:read'],
+      runtimeTokens: [{ tokenHash: s('REG_INSTALL_RUNTIMETOKEN_HASH'), label: 'rt' }],
+      config: installationConfigSecrets(s, 'REG_INSTALL'),
+    });
+    return {
+      sentinels: s.all,
+      identities: { owner: { user: owner }, member: { user: member }, stranger: { user: stranger }, admin: { user: admin } },
+      podId: String(pod._id),
+    };
+  },
+  cases: [
+    ...matrix('GET', '/api/registry/pods/:podId/agents/:name', (ctx) => `/api/registry/pods/${ctx.podId}/agents/${REG_AGENT}`,
+      { owner: 200, member: 200, stranger: 403, admin: 403 }),
+    ...matrix('GET', '/api/registry/pods/:podId/agents/:name/runtime-tokens',
+      (ctx) => `/api/registry/pods/${ctx.podId}/agents/${REG_AGENT}/runtime-tokens`,
+      { owner: 200, member: 200, stranger: 403, admin: 403 }),
+    ...matrix('GET', '/api/registry/pods/:podId/agents/:name/user-token',
+      (ctx) => `/api/registry/pods/${ctx.podId}/agents/${REG_AGENT}/user-token`,
+      { owner: 200, member: 200, stranger: 403, admin: 403 }),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// 9. Machines + gateways (routes/machines.ts, routes/gateways.ts)
+// ---------------------------------------------------------------------------
+const machines = {
+  name: 'machines',
+  mount(app) {
+    /* eslint-disable global-require */
+    app.use('/api/machines', require('../../routes/machines'));
+    app.use('/api/gateways', require('../../routes/gateways'));
+    /* eslint-enable global-require */
+  },
+  async seed() {
+    const s = createSentinels();
+    // eslint-disable-next-line global-require
+    const { hash } = require('../../utils/secret');
+    const owner = await seedUser(s, 'OWNER');
+    const stranger = await seedUser(s, 'STRANGER');
+    const admin = await seedUser(s, 'ADMIN', { role: 'admin' });
+    // Machine has no secret field of its own; its bearer is a daemon
+    // AgentCredential. The raw cm_daemon_ bearer never reaches the store (a
+    // boundary sentinel); its sha256 is the stored tokenHash, registered as a
+    // sentinel by value so a response carrying the hash is caught too.
+    const daemonBearer = async (prefix, ownerUserId, machineId) => {
+      const raw = `cm_daemon_${sentinelValue(`${prefix}_DAEMON_BEARER`)}`;
+      s.all[`${prefix}_DAEMON_BEARER`] = raw;
+      s.all[`${prefix}_DAEMON_TOKENHASH`] = hash(raw);
+      await model.AgentCredential().create({
+        tokenHash: hash(raw), kind: 'daemon', ownerUserId, machineId, scopes: ['machine:read', 'machine:heartbeat'],
+      });
+      return raw;
+    };
+    const Machine = model.Machine();
+    await Machine.create({ ownerUserId: owner, machineId: 'machine-owner-1', name: 'owner-laptop', lastSeenAt: new Date(), status: 'online' });
+    await Machine.create({ ownerUserId: stranger, machineId: 'machine-stranger-1', name: 'stranger-laptop' });
+    const ownerBearer = await daemonBearer('MACHINE_OWNER', owner, 'machine-owner-1');
+    await daemonBearer('MACHINE_STRANGER', stranger, 'machine-stranger-1');
+    const Gateway = model.Gateway();
+    await Gateway.create({ name: 'Local Gateway', slug: 'default', mode: 'local', createdBy: admin });
+    // PATCH /api/gateways/:id writes its body verbatim and reads
+    // metadata.gatewayToken from it, so a row can carry the gateway token.
+    await Gateway.create({
+      name: 'Leak Gateway', slug: 'leak-gw', mode: 'k8s', baseUrl: 'http://gw.example.test', createdBy: admin,
+      metadata: { namespace: 'ns', gatewayToken: s('GATEWAY_METADATA_GATEWAYTOKEN') },
+    });
+    return {
+      sentinels: s.all,
+      boundarySentinels: ['MACHINE_OWNER_DAEMON_BEARER', 'MACHINE_STRANGER_DAEMON_BEARER'],
+      identities: {
+        owner: { user: owner }, stranger: { user: stranger }, admin: { user: admin }, machine: { bearer: ownerBearer },
+      },
+    };
+  },
+  cases: [
+    ...matrix('GET', '/api/machines', () => '/api/machines', { owner: 200, stranger: 200, admin: 200 }),
+    // daemonAuth('machine:read') is REAL here: the machine role sends its cm_daemon_ bearer.
+    ...matrix('GET', '/api/machines/me', () => '/api/machines/me', { owner: 401, stranger: 401, admin: 401, machine: 200 }),
+    ...matrix('GET', '/api/gateways', () => '/api/gateways', { owner: 403, stranger: 403, admin: 200 }),
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// 10. Public agent profile (routes/agentProfile.ts: no auth; selects agentConfig)
+// ---------------------------------------------------------------------------
+const PROFILE_AGENT = 'leakprofile';
+const agentProfile = {
+  name: 'agentProfile',
+  mount(app) {
+    // eslint-disable-next-line global-require
+    app.use('/api/agent-profile', require('../../routes/agentProfile'));
+  },
+  async seed() {
+    const s = createSentinels();
+    const owner = await seedUser(s, 'OWNER');
+    const stranger = await seedUser(s, 'STRANGER');
+    const agent = await seedUser(s, 'PROFILE_AGENT', {
+      isBot: true,
+      botType: 'agent',
+      botMetadata: { agentName: PROFILE_AGENT, instanceId: 'default', displayName: 'Profile Agent', description: 'Answers questions.' },
+    });
+    // agentConfig is the one config block the route selects; systemPrompt is its private field.
+    await model.User().collection.updateOne({ _id: agent }, {
+      $set: {
+        agentConfig: {
+          personality: { tone: 'friendly', interests: ['ops'], behavior: 'reactive', responseStyle: 'concise' },
+          systemPrompt: s('PROFILE_AGENT_SYSTEMPROMPT'),
+          capabilities: ['chat'],
+        },
+      },
+    });
+    const pod = await model.Pod().create({ name: 'Private Room', createdBy: owner, members: [owner, agent] });
+    await model.AgentInstallation().create({
+      agentName: PROFILE_AGENT,
+      podId: pod._id,
+      version: '1.0.0',
+      installedBy: owner,
+      instanceId: 'default',
+      displayName: 'Profile Agent',
+      status: 'active',
+      scopes: ['context:read'],
+      runtimeTokens: [{ tokenHash: s('PROFILE_INSTALL_RUNTIMETOKEN_HASH'), label: 'rt' }],
+      config: installationConfigSecrets(s, 'PROFILE_INSTALL'),
+    });
+    return {
+      sentinels: s.all,
+      identities: { stranger: { user: stranger }, anonymous: {} },
+    };
+  },
+  cases: [
+    ...matrix('GET', '/api/agent-profile/:agentName/:instanceId?', () => `/api/agent-profile/${PROFILE_AGENT}/default`,
+      { stranger: 200, anonymous: 200 }),
+  ],
+};
+
+const SUITES = {
+  integrations, installables, users, credentials, grants, agentRuntime, webhooks, registry, machines, agentProfile,
+};
+
+module.exports = { SUITES, ...SUITES };


### PR DESCRIPTION
B1 from the production-readiness plan (§3B): a CI matrix asserting that no credential-bearing field appears in any 2xx body of any list or read route. Each route runs as stranger, member, owner and admin, plus anonymous and an agent token where the route takes one.

## How it works
- `backend/__tests__/utils/leakMatrix.js` is the harness.
  - Every secret field is seeded with a unique `SENTINEL_<KEY>_7f3a` value, hashes included, and every serialized 2xx body is searched for all of them.
  - Each case also pins today's status, so a harness break that turns every call into a 500 cannot pass vacuously.
  - A positive-control test per suite proves each sentinel is really in the store.
- `backend/__tests__/utils/leakMatrixSuites.js` holds 11 suites: integrations, installables, users, credentials, grants, agentRuntime, webhooks, registry, machines and agentProfile, plus the ratchet.
- Only these are mocked:
  - `middleware/auth`, from an `x-test-user` header. `adminAuth` stays real, so admin is a real `role: 'admin'` row.
  - `agentRuntimeAuth`: the real User and installation lookup, with only the token lookup skipped.
  - `ToolCall`, which is Postgres-backed.
  - `jsonwebtoken`, which is harmless on Node 22.
  - `axios`, as a network backstop in the webhooks suite. DiscordService itself stays real.
- **`KNOWN_EXPOSURES`** holds exact `(method, path, role, sentinelKey)` tuples, sorted, duplicate-free and each with a reason and a follow-up comment.
  - The matrix fails on any leak not listed.
  - The ratchet fails on a listed entry that no longer reproduces, so the list can only shrink.
  - Both directions were proved by deleting an entry (the matrix went red and named it) and by adding a bogus one (the ratchet went red and named it).
- **`ALLOWED_DISCLOSURES`** allows Telegram's `connectCode` only on the three routes where a frontend surface reads it, with file:line citations.

## What it found on main (b56e9a47)
The matrix runs 133 cases and lists 104 exposures; no stranger or anonymous row leaks anything.
- **The most serious:** `GET /api/agents/runtime/pods/:podId/integrations` returns plaintext `botToken` and `accessToken` to any agent holding `integration:read`, including global integrations from other pods.
  - Nothing consumes those fields. Its only caller, commonly-bot, reads `id` and `type`. The MCP server, CLI and openclaw extension never call it.
  - Those six rows are listed only until the strip lands in its own fix PR.
- **Integration bodies on every list route** carry `ingestTokens[].tokenHash`, `installationClaimId` and `config.oauthStateClaimId` to members, owners and admins. The toJSON transform strips only config secrets, and the installables catalog reads with `.lean()`.
- **User routes:** `/api/auth/user` and `/api/auth/profile` return `agentRuntimeTokens[].tokenHash`, and `/api/auth/api-token` serves the raw `apiToken` again on every read.
- **Other bearers:**
  - `GET /api/gateways` returns `metadata.gatewayToken` to admins.
  - The registry pod-agent route returns `runtime.webhookSecret` to pod members, because `sanitizeRuntimeConfig` passes it through.
- **Slack connectCode:** a Slack row's `connectCode`, which is its OAuth state, reaches its owner through the installables catalog.
- **Discord channels:** the unauthenticated `GET /api/webhooks/discord/channels/:integrationId` answers 500 to everyone today, because the service is never initialized. It is pinned as must-refuse rather than listed.

Each follow-up PR deletes its rows from `KNOWN_EXPOSURES`, and the ratchet makes that deletion mandatory.

## Test plan
- `npx jest __tests__/unit/security __tests__/unit/routes/routeRateLimitGuard.test.js`: 12 suites, 145 tests, all passing on b56e9a47.
- Test-only: no route or model changes, and the #1682 limiter guard is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
