### PR TITLE
fix(discord): remove unused webhook routes

### DIFF
--- a/backend/__tests__/unit/routes/discord.webhook.hardening.test.js
+++ b/backend/__tests__/unit/routes/discord.webhook.hardening.test.js
@@ -113,4 +113,10 @@ describe('Discord webhook hardening', () => {
     expect(response.body).toEqual({ type: 1 });
     expect(deliveries.create).not.toHaveBeenCalled();
   });
+
+  test('does not expose unused unauthenticated Discord routes', async () => {
+    await request(app).get('/api/webhooks/discord/channels/integration-1').expect(404);
+    await request(app).post('/api/webhooks/discord/invite').send({ clientId: 'client-1' }).expect(404);
+    await request(app).post('/api/webhooks/discord/test/integration-1').expect(404);
+  });
 });

--- a/backend/__tests__/unit/routes/routeRateLimitGuard.baseline.json
+++ b/backend/__tests__/unit/routes/routeRateLimitGuard.baseline.json
@@ -252,8 +252,5 @@
   "routes/users.ts GET /:id [unlimited]",
   "routes/users.ts GET /:id/public-activity [unlimited]",
   "routes/users.ts GET /profile [unlimited]",
-  "routes/users.ts POST /:id/follow [unlimited]",
-  "routes/webhooks/discord.ts GET /channels/:integrationId [unlimited]",
-  "routes/webhooks/discord.ts POST /invite [unlimited]",
-  "routes/webhooks/discord.ts POST /test/:integrationId [unlimited]"
+  "routes/users.ts POST /:id/follow [unlimited]"
 ]

--- a/backend/routes/webhooks/discord.ts
+++ b/backend/routes/webhooks/discord.ts
@@ -120,69 +120,6 @@ router.post('/', discordWebhookIpRateLimit, discordWebhookRateLimit, async (req:
   }
 });
 
-// Discord-specific routes
-router.get('/channels/:integrationId', async (req: any, res: any) => {
-  try {
-    const { integrationId } = req.params;
-
-    const service = new DiscordService(integrationId);
-    const channels = await service.getChannels();
-
-    res.json(channels);
-  } catch (error) {
-    console.error('Error fetching Discord channels:', error);
-    res.status(500).json({ error: 'Failed to fetch channels' });
-  }
-});
-
-// Generate bot invite link
-router.post('/invite', async (req: any, res: any) => {
-  try {
-    const { clientId, permissions, guildId } = req.body;
-
-    if (!clientId) {
-      return res.status(400).json({ error: 'Client ID is required' });
-    }
-
-    const baseUrl = 'https://discord.com/api/oauth2/authorize';
-    const scopes = ['bot', 'applications.commands'];
-    const botPermissions = permissions || '2048'; // Read Messages, Send Messages
-
-    const inviteUrl = `${baseUrl}?client_id=${clientId}&scope=${scopes.join('%20')}&permissions=${botPermissions}${
-      guildId ? `&guild_id=${guildId}` : ''
-    }`;
-
-    res.json({ inviteUrl });
-  } catch (error) {
-    console.error('Error generating invite link:', error);
-    res.status(500).json({ error: 'Failed to generate invite link' });
-  }
-});
-
-// Test webhook endpoint
-router.post('/test/:integrationId', async (req: any, res: any) => {
-  try {
-    const { integrationId } = req.params;
-
-    const service = new DiscordService(integrationId);
-    const isConnected = await service.testConnection();
-
-    if (isConnected) {
-      res.json({
-        success: true,
-        message: 'Webhook connection test successful',
-      });
-    } else {
-      res
-        .status(400)
-        .json({ success: false, message: 'Webhook connection test failed' });
-    }
-  } catch (error) {
-    console.error('Error testing webhook:', error);
-    res.status(500).json({ error: 'Failed to test webhook' });
-  }
-});
-
 module.exports = router;
 module.exports.verifyDiscordWebhookRequest = verifyDiscordWebhookRequest;
 // LEGACY: in-platform webhook. External provider service will replace this route.


### PR DESCRIPTION
Removes three unauthenticated, unused handlers from the Discord webhook router:

- `GET /api/webhooks/discord/channels/:integrationId` (the frontend uses the authenticated `/api/discord/channels/:guildId` surface)
- `POST /api/webhooks/discord/invite`
- `POST /api/webhooks/discord/test/:integrationId`

The signed `POST /api/webhooks/discord` ingress remains. The limiter baseline drops the three retired registrations and the route test pins 404s.

Stacked on #1683 (`d0dd996b`) per the B1 ruling; rebase/retarget to `main` after #1683 lands.

Validation: route guard and Discord webhook suites, 19 tests passed.