### PR TITLE
fix(security): hide agent-facing integration and runtime secrets

### DIFF
--- a/backend/__tests__/service/integrations-e2e.test.js
+++ b/backend/__tests__/service/integrations-e2e.test.js
@@ -1464,7 +1464,11 @@ describe('Integrations E2E Tests', () => {
         expect(res.status).toBe(200);
         expect(res.body.integrations).toHaveLength(1);
         expect(res.body.integrations[0].type).toBe('discord');
-        expect(res.body.integrations[0].botToken).toBe('discord-bot-token');
+        expect(res.body.integrations[0]).not.toHaveProperty('botToken');
+        expect(res.body.integrations[0]).toMatchObject({
+          channelId: 'discord-channel-123',
+          channelName: 'general',
+        });
       });
 
       test('should include availableIntegrations in heartbeat payload for eligible agents', async () => {

--- a/backend/__tests__/unit/routes/agentsRuntime.integrations.global-access.test.js
+++ b/backend/__tests__/unit/routes/agentsRuntime.integrations.global-access.test.js
@@ -3,6 +3,7 @@ jest.mock('../../../middleware/auth', () => (req, res, next) => next());
 jest.mock('../../../middleware/apiTokenScopes', () => ({
   requireApiTokenScopes: () => (req, res, next) => next(),
 }));
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
 
 jest.mock('../../../models/Integration', () => ({
   find: jest.fn(),
@@ -112,9 +113,15 @@ describe('agentsRuntime integrations global access', () => {
 
     expect(res.json).toHaveBeenCalledWith({
       integrations: expect.arrayContaining([
-        expect.objectContaining({ id: 'pod-int-1', type: 'discord', botToken: 'discord-token' }),
-        expect.objectContaining({ id: 'global-x-1', type: 'x', accessToken: 'x-token' }),
+        expect.objectContaining({
+          id: 'pod-int-1', type: 'discord', channelId: 'c1', channelName: 'general',
+        }),
+        expect.objectContaining({ id: 'global-x-1', type: 'x' }),
       ]),
     });
+
+    const [podIntegration, globalIntegration] = res.json.mock.calls[0][0].integrations;
+    expect(podIntegration).not.toHaveProperty('botToken');
+    expect(globalIntegration).not.toHaveProperty('accessToken');
   });
 });

--- a/backend/__tests__/unit/routes/registry.list-agents-config.test.js
+++ b/backend/__tests__/unit/routes/registry.list-agents-config.test.js
@@ -1,6 +1,8 @@
 const request = require('supertest');
 const express = require('express');
 
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 't'), verify: jest.fn(), decode: jest.fn() }));
+
 jest.mock('../../../middleware/auth', () => (req, res, next) => {
   req.user = { id: 'user-1' };
   req.userId = 'user-1';
@@ -117,6 +119,15 @@ describe('registry list pod agents config payload', () => {
           skillSync: {
             mode: 'all', allPods: true, podIds: [], skillNames: [],
           },
+          runtime: {
+            runtimeType: 'webhook',
+            webhookUrl: 'https://agent.example.test/events',
+            webhookSecret: 'member-only-secret',
+            authProfiles: {
+              'openai:default': { type: 'api_key', provider: 'openai', key: 'member-api-key' },
+            },
+            skillEnv: { github: { GITHUB_TOKEN: 'member-github-token' } },
+          },
         })),
       },
     ]);
@@ -149,6 +160,15 @@ describe('registry list pod agents config payload', () => {
         mode: 'all', allPods: true, podIds: [], skillNames: [],
       },
     });
+    expect(res.body.agents[0].runtime).toEqual(expect.objectContaining({
+      runtimeType: 'webhook',
+      webhookUrl: 'https://agent.example.test/events',
+      authProviders: ['openai'],
+      hasCustomAuthProfiles: true,
+      hasCustomSkillEnv: true,
+      skillEnvKeys: ['github'],
+    }));
+    expect(res.body.agents[0].runtime).not.toHaveProperty('webhookSecret');
   });
 
   it('keeps a pod-scoped label when the portable principal has a different label', async () => {

--- a/backend/__tests__/unit/security/leakMatrix.registry.test.js
+++ b/backend/__tests__/unit/security/leakMatrix.registry.test.js
@@ -6,7 +6,8 @@
  *   GET /api/registry/pods/:podId/agents/:name/user-token      (selects +apiToken)
  * The agent User carries apiToken / agentRuntimeTokens[].tokenHash sentinels;
  * the AgentInstallation carries runtimeTokens[].tokenHash and a config with
- * runtime.webhookSecret, authProfiles[].key and skillEnv values as sentinels.
+ * runtime.webhookSecret, authProfiles[].key and skillEnv values as sentinels;
+ * the member-facing payload must project these out.
  * The full /api/registry router is mounted, as server.ts does.
  * Skipped routes: none of the three. Harness and KNOWN_EXPOSURES: __tests__/utils/leakMatrix.js.
  */

--- a/backend/__tests__/utils/leakMatrix.js
+++ b/backend/__tests__/utils/leakMatrix.js
@@ -193,9 +193,7 @@ const R_INST_LEAN = 'installableCatalogService reads Integration with .lean(), b
 const R_SLACK_OAUTH_STATE = 'a Slack row\'s config.connectCode is its OAuth state; no surface reads it';
 const R_USER_RUNTIME_HASH = 'User serialization keeps agentRuntimeTokens[].tokenHash';
 const R_USER_APITOKEN = 'returns the caller\'s raw apiToken; decide whether the browser may ever re-read it';
-const R_RT_PLAINTEXT = 'fix PR pending: stripped from the agent route (68039 item 1)';
 const R_GATEWAY_TOKEN = 'GET /api/gateways returns lean rows verbatim, including metadata.gatewayToken';
-const R_REG_WEBHOOKSECRET = 'sanitizeRuntimeConfig strips authProfiles/skillEnv but passes runtime.webhookSecret through';
 /* eslint-enable max-len */
 
 /**
@@ -214,13 +212,6 @@ const KNOWN_EXPOSURES = [
   { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
   { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
   { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  // GET /api/agents/runtime/pods/:podId/integrations — follow-up: the 68039 item-1 fix PR (plaintext botToken/accessToken to agents)
-  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_GLOBAL_X_ACCESSTOKEN', reason: R_RT_PLAINTEXT },
-  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_GLOBAL_X_BOTTOKEN', reason: R_RT_PLAINTEXT },
-  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_TELEGRAM_ACCESSTOKEN', reason: R_RT_PLAINTEXT },
-  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_TELEGRAM_BOTTOKEN', reason: R_RT_PLAINTEXT },
-  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_X_ACCESSTOKEN', reason: R_RT_PLAINTEXT },
-  { method: 'GET', path: '/api/agents/runtime/pods/:podId/integrations', role: 'agent', sentinelKey: 'RT_X_BOTTOKEN', reason: R_RT_PLAINTEXT },
   // GET /api/auth/api-token — follow-up: decide whether GET may return the raw apiToken at all
   { method: 'GET', path: '/api/auth/api-token', role: 'self', sentinelKey: 'SELF_USER_APITOKEN', reason: R_USER_APITOKEN },
   // GET /api/auth/profile — follow-up: drop agentRuntimeTokens[].tokenHash from User serialization
@@ -320,9 +311,6 @@ const KNOWN_EXPOSURES = [
   { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
   { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
   { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  // GET /api/registry/pods/:podId/agents/:name — follow-up: strip runtime.webhookSecret in sanitizeRuntimeConfig
-  { method: 'GET', path: '/api/registry/pods/:podId/agents/:name', role: 'member', sentinelKey: 'REG_INSTALL_RUNTIME_WEBHOOKSECRET', reason: R_REG_WEBHOOKSECRET },
-  { method: 'GET', path: '/api/registry/pods/:podId/agents/:name', role: 'owner', sentinelKey: 'REG_INSTALL_RUNTIME_WEBHOOKSECRET', reason: R_REG_WEBHOOKSECRET },
 ];
 /* eslint-enable max-len */
 

--- a/backend/routes/agentsRuntime.ts
+++ b/backend/routes/agentsRuntime.ts
@@ -28,6 +28,7 @@ const { AgentInstallation } = require('../models/AgentRegistry');
 const File = require('../models/File');
 const { getObjectStore } = require('../services/objectStore');
 const { requireApiTokenScopes } = require('../middleware/apiTokenScopes');
+const { toPublicIntegrationConfig } = require('../models/integrationPublicConfig');
 const { isGlobalAdminUser } = require('./registry/helpers');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { agentRateLimitKeyGenerator } = require('../middleware/agentRateLimit');
@@ -3252,19 +3253,21 @@ router.get('/pods/:podId/integrations', agentRuntimeAuth, async (req: any, res: 
       index === list.findIndex((item) => item._id?.toString() === integration._id?.toString())
     ));
 
-    // Return sanitized integration data
+    // Keep this projection on the shared Integration public-config boundary.
+    // The runtime caller needs routing metadata only; bearer credentials are
+    // never part of the agent-facing response, including global integrations.
     return res.json({
-      integrations: integrations.map((integration) => ({
-        id: integration._id,
-        type: integration.type,
-        channelId: integration.config?.channelId,
-        channelName: integration.config?.channelName,
-        groupId: integration.config?.groupId,
-        groupName: integration.config?.groupName,
-        // Bot tokens exposed ONLY to agents with proper scopes
-        botToken: integration.config?.botToken,
-        accessToken: integration.config?.accessToken,
-      })),
+      integrations: integrations.map((integration) => {
+        const publicConfig = toPublicIntegrationConfig({ ...(integration.config || {}) }) || {};
+        return {
+          id: integration._id,
+          type: integration.type,
+          channelId: publicConfig.channelId,
+          channelName: publicConfig.channelName,
+          groupId: publicConfig.groupId,
+          groupName: publicConfig.groupName,
+        };
+      }),
     });
   } catch (error: any) {
     console.error('Error fetching integrations for agent:', error);

--- a/backend/routes/registry/helpers.ts
+++ b/backend/routes/registry/helpers.ts
@@ -152,6 +152,11 @@ const LEGACY_RUNTIME_RENAME: Record<string, string> = {
   claude: 'claude-code',
 };
 
+// Runtime secrets follow the same explicit key-list rule as Integration
+// config. Keep the response projection here so a member of a pod can inspect
+// runtime metadata without receiving the webhook signing secret.
+const AGENT_RUNTIME_SECRET_CONFIG_KEYS = ['webhookSecret'];
+
 const normalizeRuntimeIdentity = (rest: any, agentName?: string) => {
   let runtimeType: string | undefined = rest.runtimeType ? String(rest.runtimeType) : undefined;
   let host: 'cloud' | 'byo' | undefined = rest.host === 'byo' || rest.host === 'cloud' ? rest.host : undefined;
@@ -187,6 +192,7 @@ const normalizeRuntimeIdentity = (rest: any, agentName?: string) => {
 const sanitizeRuntimeConfig = (runtimeConfig: any, agentName?: string) => {
   const cfg = runtimeConfig && typeof runtimeConfig === 'object' ? runtimeConfig : {};
   const { authProfiles, skillEnv, ...rest } = cfg;
+  AGENT_RUNTIME_SECRET_CONFIG_KEYS.forEach((key) => { delete rest[key]; });
   const providers = authProfiles && typeof authProfiles === 'object'
     ? Array.from(new Set(
       Object.values(authProfiles)


### PR DESCRIPTION
## Summary
- remove botToken/accessToken from the agent integration listing (including global rows) via the shared public-config projection
- strip runtime.webhookSecret from member-visible registry agent payloads
- shrink the B1 KNOWN_EXPOSURES list and pin both projections in tests

## Verification
- targeted Jest: 4 suites, 20 tests passed
- `npx tsc --noEmit -p tsconfig.typescheck.json`
- service E2E could not start locally because the existing Node 26/jsonwebtoken buffer-equal-constant-time incompatibility occurs before tests load