### PR TITLE
fix(security): strip claim ids and ingest-token hashes from Integration JSON

### DIFF
--- a/backend/__tests__/unit/models/integrationPublicConfig.test.js
+++ b/backend/__tests__/unit/models/integrationPublicConfig.test.js
@@ -1,0 +1,55 @@
+// Claim ids and ingest-token hashes are references to server-side state: they
+// fence an install or an OAuth bind, or authenticate an ingest call. They must
+// leave through neither the model's toJSON nor the lean catalog read.
+
+const Integration = require('../../../models/Integration');
+const { toPublicIntegration } = require('../../../models/integrationPublicConfig');
+
+const TOKEN_HASH = 'hash_of_an_ingest_token';
+const INSTALL_CLAIM = 'install_claim_fence';
+const OAUTH_CLAIM = 'oauth_state_claim_fence';
+
+const row = () => ({
+  type: 'telegram',
+  podId: '64b000000000000000000010',
+  createdBy: '64b000000000000000000011',
+  installationClaimId: INSTALL_CLAIM,
+  ingestTokens: [{
+    tokenHash: TOKEN_HASH, label: 'ci', createdBy: '64b000000000000000000011', createdAt: new Date('2026-09-01T00:00:00Z'),
+  }],
+  config: { connectCode: 'ENABLE123', oauthStateClaimId: OAUTH_CLAIM, botToken: 'bot_secret' },
+});
+
+const expectPublic = (out) => {
+  const text = JSON.stringify(out);
+  expect(text).not.toContain(TOKEN_HASH);
+  expect(text).not.toContain(INSTALL_CLAIM);
+  expect(text).not.toContain(OAUTH_CLAIM);
+  expect(text).not.toContain('bot_secret');
+  expect(out.ingestTokens).toHaveLength(1);
+  expect(out.ingestTokens[0]).toMatchObject({ label: 'ci' });
+  expect(out.ingestTokens[0]).not.toHaveProperty('tokenHash');
+  expect(out.config.connectCode).toBe('ENABLE123');
+};
+
+describe('toPublicIntegration', () => {
+  it('strips claim ids and ingest-token hashes through the model toJSON', () => {
+    expectPublic(new Integration(row()).toJSON());
+  });
+
+  it('strips the same fields from a lean row', () => {
+    expectPublic(toPublicIntegration(JSON.parse(JSON.stringify(row()))));
+  });
+
+  it('leaves toObject intact for server code that reads the hash', () => {
+    const doc = new Integration(row()).toObject();
+    expect(doc.installationClaimId).toBe(INSTALL_CLAIM);
+    expect(doc.ingestTokens[0].tokenHash).toBe(TOKEN_HASH);
+    expect(doc.config.oauthStateClaimId).toBe(OAUTH_CLAIM);
+  });
+
+  it('passes null and non-objects through', () => {
+    expect(toPublicIntegration(null)).toBeNull();
+    expect(toPublicIntegration(undefined)).toBeUndefined();
+  });
+});

--- a/backend/__tests__/utils/leakMatrix.js
+++ b/backend/__tests__/utils/leakMatrix.js
@@ -187,9 +187,7 @@ const ALLOWED_DISCLOSURES = [
 const ACCESS_2XX = 'ACCESS_2XX';
 
 /* eslint-disable max-len */
-const R_INT_SECRETS = 'Integration toJSON strips config secrets but not ingestTokens[].tokenHash, installationClaimId or config.oauthStateClaimId';
 const R_INT_CONNECTCODE = 'config.connectCode reaches a caller that is not the owner reading it from a surface that needs it';
-const R_INST_LEAN = 'installableCatalogService reads Integration with .lean(), bypassing the toJSON transform';
 const R_SLACK_OAUTH_STATE = 'a Slack row\'s config.connectCode is its OAuth state; no surface reads it';
 /* eslint-enable max-len */
 
@@ -202,104 +200,10 @@ const R_SLACK_OAUTH_STATE = 'a Slack row\'s config.connectCode is its OAuth stat
  */
 /* eslint-disable max-len */
 const KNOWN_EXPOSURES = [
-  // GET /api/admin/integrations/global — follow-up: strip hashes/claim ids in the Integration toJSON transform
-  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/admin/integrations/global', role: 'admin', sentinelKey: 'GLOBAL_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  // GET /api/discord/binding/:podId — follow-up: strip hashes/claim ids in the Integration toJSON transform
-  { method: 'GET', path: '/api/discord/binding/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/discord/binding/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/discord/binding/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/discord/binding/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/discord/binding/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/discord/binding/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  // GET /api/installables — follow-up: project Integration through toJSON/integrationPublicConfig in installableCatalogService
+  // GET /api/installables — follow-up: a Slack row's connectCode is its OAuth state; keep it off the catalog
   { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_SLACK_CONNECTCODE', reason: R_SLACK_OAUTH_STATE },
-  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_SLACK_INGEST_TOKENHASH', reason: R_INST_LEAN },
-  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_SLACK_INSTALLATIONCLAIMID', reason: R_INST_LEAN },
-  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_SLACK_OAUTHSTATECLAIMID', reason: R_INST_LEAN },
-  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_TELEGRAM_INGEST_TOKENHASH', reason: R_INST_LEAN },
-  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INST_LEAN },
-  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INST_LEAN },
-  // GET /api/integrations/:podId — follow-up: strip hashes/claim ids in the Integration toJSON transform
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'admin', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'member', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/:podId', role: 'owner', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  // GET /api/integrations/admin/all — follow-up: strip hashes/claim ids in toJSON; drop connectCode from the admin list
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'GLOBAL_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
+  // GET /api/integrations/admin/all — follow-up: drop connectCode from the admin list
   { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_TELEGRAM_CONNECTCODE', reason: R_INT_CONNECTCODE },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  // GET /api/integrations/user/all — follow-up: strip hashes/claim ids in the Integration toJSON transform
-  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_INSTAGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'admin', sentinelKey: 'GLOBAL_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_DISCORD_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_DISCORD_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_DISCORD_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_SLACK_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_SLACK_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_SLACK_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_TELEGRAM_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_TELEGRAM_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_TELEGRAM_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_X_INGEST_TOKENHASH', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_X_INSTALLATIONCLAIMID', reason: R_INT_SECRETS },
-  { method: 'GET', path: '/api/integrations/user/all', role: 'owner', sentinelKey: 'INT_X_OAUTHSTATECLAIMID', reason: R_INT_SECRETS },
 ];
 /* eslint-enable max-len */
 

--- a/backend/models/Integration.ts
+++ b/backend/models/Integration.ts
@@ -1,5 +1,5 @@
 import mongoose, { Document, Schema, Types } from 'mongoose';
-import { toPublicIntegrationConfig } from './integrationPublicConfig';
+import { toPublicIntegration } from './integrationPublicConfig';
 
 export type IntegrationType =
   | 'discord'
@@ -355,14 +355,15 @@ IntegrationSchema.virtual('platformIntegration', {
   justOne: true,
 });
 
-// Bearer credentials and the references that point at one are server-only in
-// every normal JSON response, including the pending OAuth bind that needs to
-// show its workspace/user details. The key list lives in
-// integrationPublicConfig so the lean catalog read strips the same fields.
+// Bearer credentials and the references that point at one (claim ids, ingest
+// token hashes) are server-only in every normal JSON response, including the
+// pending OAuth bind that needs to show its workspace/user details. The list
+// lives in integrationPublicConfig so the lean catalog read strips the same
+// fields.
 IntegrationSchema.set('toJSON', {
   virtuals: true,
-  transform: (_doc: unknown, returned: { config?: Record<string, unknown> }) => {
-    toPublicIntegrationConfig(returned.config);
+  transform: (_doc: unknown, returned: Record<string, unknown>) => {
+    toPublicIntegration(returned);
     return returned;
   },
 });

--- a/backend/models/integrationPublicConfig.ts
+++ b/backend/models/integrationPublicConfig.ts
@@ -1,17 +1,20 @@
 /**
- * The one list of Integration config keys that never leave the server.
+ * The one list of Integration fields that never leave the server.
  *
  * Bearer credentials (bot tokens, signing secrets, OAuth access and refresh
  * tokens, webhook URLs that embed their secret) and the references that point
- * at one (a ConnectorSecret ref, a browser-bound OAuth nonce). The providers
- * read all of them off the document; no browser needs any of them, and until
- * #1673 the X and Instagram edit forms prefilled accessToken from the pod list
- * because it happened to be there. `connectCode` is deliberately NOT here: it
- * is the one-time enable code a member pastes into Telegram, and ChatRoom and
- * the Connectors page read it from the pod list.
+ * at one (a ConnectorSecret ref, a browser-bound OAuth nonce, the claim ids
+ * that fence an install or an OAuth bind, and the stored hash of every ingest
+ * token). The providers read all of them off the document; no browser needs
+ * any of them, and until #1673 the X and Instagram edit forms prefilled
+ * accessToken from the pod list because it happened to be there.
+ * `connectCode` is deliberately NOT here: it is the one-time enable code a
+ * member pastes into Telegram, and ChatRoom and the Connectors page read it
+ * from the pod list. Ingest tokens are listed without their hash by
+ * GET /api/integrations/:id/ingest-tokens.
  *
  * Every JSON path an Integration takes out of the server runs through
- * toPublicIntegrationConfig: the model's toJSON, and the lean catalog read in
+ * toPublicIntegration: the model's toJSON, and the lean catalog read in
  * installableCatalogService that bypasses toJSON. Add a key here, not at the
  * call sites.
  */
@@ -24,6 +27,7 @@ export const INTEGRATION_SECRET_CONFIG_KEYS = [
   'webhookUrl',
   'botTokenRef',
   'oauthStateNonce',
+  'oauthStateClaimId',
 ] as const;
 
 export const toPublicIntegrationConfig = (
@@ -41,6 +45,22 @@ export const toPublicIntegrationConfig = (
     config.adminPause = { reason, at };
   }
   return config;
+};
+
+export const toPublicIntegration = (
+  integration: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null | undefined => {
+  if (!integration || typeof integration !== 'object') return integration;
+  delete integration.installationClaimId;
+  if (Array.isArray(integration.ingestTokens)) {
+    integration.ingestTokens = integration.ingestTokens.map((token) => {
+      if (!token || typeof token !== 'object') return token;
+      const { tokenHash: _omit, ...rest } = token as Record<string, unknown>;
+      return rest;
+    });
+  }
+  toPublicIntegrationConfig(integration.config as Record<string, unknown> | null | undefined);
+  return integration;
 };
 
 // CJS compat: let require() return the named exports directly

--- a/backend/services/installable/installableCatalogService.ts
+++ b/backend/services/installable/installableCatalogService.ts
@@ -5,7 +5,7 @@ const InstallableInstallation = require('../../models/InstallableInstallation');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
 const Integration = require('../../models/Integration');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
-const { toPublicIntegrationConfig } = require('../../models/integrationPublicConfig');
+const { toPublicIntegration } = require('../../models/integrationPublicConfig');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
 const { manifests } = require('../../integrations/manifests');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
@@ -38,9 +38,7 @@ const publicIntegration = (integration: unknown): unknown => {
     ? (integration as { toJSON: () => unknown }).toJSON()
     : JSON.parse(JSON.stringify(integration));
   if (!raw || typeof raw !== 'object') return raw;
-  const result = raw as { config?: Record<string, unknown> };
-  toPublicIntegrationConfig(result.config);
-  return result;
+  return toPublicIntegration(raw as Record<string, unknown>);
 };
 
 // The parent has operational fields that are useful to the owner's state


### PR DESCRIPTION
## Summary

Integration's `toJSON` removed config secrets, but three references to server-side state still went out in every serialized row:

- `ingestTokens[].tokenHash`: the stored hash an ingest bearer is looked up by (`routes/integrations.ts`).
- `installationClaimId`: the fence on an install.
- `config.oauthStateClaimId`: the fence on an OAuth bind.

Owners, members and admins received them from `/api/integrations/:podId`, `/user/all`, `/admin/all`, `/api/admin/integrations/global` and `/api/discord/binding/:podId`. `/api/installables` returned them too, through the lean catalog read's own copy of the strip. Together that was 90 KNOWN_EXPOSURES rows.

## Changes

- `models/integrationPublicConfig.ts`: new `toPublicIntegration`, the document-level projection.
  - It drops `installationClaimId`.
  - It drops `tokenHash` from each ingest token, keeping `label`, `createdBy`, `createdAt` and `lastUsedAt`.
  - It runs `toPublicIntegrationConfig`, whose key list now also includes `oauthStateClaimId`.
- `models/Integration.ts`: `toJSON` calls `toPublicIntegration`.
- `installableCatalogService.publicIntegration` calls `toPublicIntegration`, so both paths still share one list.
- `toObject` is untouched. Server code that reads the hash or the claim ids reads the document or queries, never the JSON.
- 90 rows are removed from KNOWN_EXPOSURES (84 via toJSON, 6 via the lean catalog read), along with their two reason strings. The two `connectCode` rows remain, since they have a different cause.

No client reads any of these fields. `frontend/src`, `cli` and the MCP package have no references. AppsManagement lists ingest tokens from `GET /api/integrations/:id/ingest-tokens`, which already leaves out the hash.

## Test plan

- [x] New `__tests__/unit/models/integrationPublicConfig.test.js`:
  - the model toJSON and a lean row are both stripped, `connectCode` and the token label survive;
  - `toObject` still carries the hash;
  - null and undefined pass through.
- [x] All leak-matrix suites and the ratchet pass: 130/130.
- [x] Control: with main's model and catalog code and the shrunk list, the integrations and installables matrices fail 10 tests. The listed leaks reproduce there as unlisted.
- [x] eslint on the three changed `.ts` files shows 0 errors, and `tsc` reports nothing in them.
- [x] Full backend suite locally: 67 failing suites / 42 failing tests. Against the local baseline, the one extra is `agentsRuntime.rateLimitTiers`, which hit "socket hang up" while firing 3,001 requests under full-suite load.
  - It passes 3/3 alone at this head, and 3/3 on a main-equivalent tree.
  - It mocks `models/Integration` and `../integrations` outright, so none of this change loads in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
