### PR TITLE
fix(security): drop connect codes from surfaces with no reader

### DIFF
--- a/backend/__tests__/unit/models/integrationPublicConfig.test.js
+++ b/backend/__tests__/unit/models/integrationPublicConfig.test.js
@@ -3,7 +3,7 @@
 // leave through neither the model's toJSON nor the lean catalog read.
 
 const Integration = require('../../../models/Integration');
-const { toPublicIntegration } = require('../../../models/integrationPublicConfig');
+const { toPublicIntegration, withoutConnectCode } = require('../../../models/integrationPublicConfig');
 
 const TOKEN_HASH = 'hash_of_an_ingest_token';
 const INSTALL_CLAIM = 'install_claim_fence';
@@ -51,5 +51,19 @@ describe('toPublicIntegration', () => {
   it('passes null and non-objects through', () => {
     expect(toPublicIntegration(null)).toBeNull();
     expect(toPublicIntegration(undefined)).toBeUndefined();
+  });
+});
+
+describe('withoutConnectCode', () => {
+  it('drops the connect code and its expiry and keeps the rest of config', () => {
+    const out = withoutConnectCode(toPublicIntegration(JSON.parse(JSON.stringify({
+      ...row(), config: { connectCode: 'ENABLE123', connectCodeExpiresAt: '2026-09-12T00:10:00Z', chatTitle: 'Ops' },
+    }))));
+    expect(out.config).toEqual({ chatTitle: 'Ops' });
+  });
+
+  it('passes a row without config through', () => {
+    expect(withoutConnectCode({ type: 'slack' })).toEqual({ type: 'slack' });
+    expect(withoutConnectCode(null)).toBeNull();
   });
 });

--- a/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
+++ b/backend/__tests__/unit/routes/integrations.platformIntegration.test.js
@@ -183,7 +183,10 @@ describe('platformIntegration virtual (#1672)', () => {
       expect(slack.config.pendingBind).toEqual({ teamId: 'T1' });
       const serialized = JSON.stringify(body);
       Object.values(SECRETS).forEach((value) => expect(serialized).not.toContain(value));
-      expect(body.find((entry) => entry.type === 'telegram').config.connectCode).toBe('CODE-1');
     }
+    // The enable code survives the secret strip on the pod list, which ChatRoom
+    // reads it from; the admin list has no reader for it and drops it.
+    expect(pod.body.find((entry) => entry.type === 'telegram').config.connectCode).toBe('CODE-1');
+    expect(admin.body.find((entry) => entry.type === 'telegram').config).not.toHaveProperty('connectCode');
   });
 });

--- a/backend/__tests__/utils/leakMatrix.js
+++ b/backend/__tests__/utils/leakMatrix.js
@@ -186,11 +186,6 @@ const ALLOWED_DISCLOSURES = [
  */
 const ACCESS_2XX = 'ACCESS_2XX';
 
-/* eslint-disable max-len */
-const R_INT_CONNECTCODE = 'config.connectCode reaches a caller that is not the owner reading it from a surface that needs it';
-const R_SLACK_OAUTH_STATE = 'a Slack row\'s config.connectCode is its OAuth state; no surface reads it';
-/* eslint-enable max-len */
-
 /**
  * Leaks that reproduce on main today, sorted by (path, variant, method, role,
  * sentinelKey). Each entry is an exact (method, path, role, sentinelKey) tuple
@@ -198,14 +193,7 @@ const R_SLACK_OAUTH_STATE = 'a Slack row\'s config.connectCode is its OAuth stat
  * leak not listed; the ratchet fails on any entry that no longer reproduces,
  * so the list only shrinks. Remove an entry when its fix lands.
  */
-/* eslint-disable max-len */
-const KNOWN_EXPOSURES = [
-  // GET /api/installables — follow-up: a Slack row's connectCode is its OAuth state; keep it off the catalog
-  { method: 'GET', path: '/api/installables', role: 'owner', sentinelKey: 'INST_SLACK_CONNECTCODE', reason: R_SLACK_OAUTH_STATE },
-  // GET /api/integrations/admin/all — follow-up: drop connectCode from the admin list
-  { method: 'GET', path: '/api/integrations/admin/all', role: 'admin', sentinelKey: 'INT_TELEGRAM_CONNECTCODE', reason: R_INT_CONNECTCODE },
-];
-/* eslint-enable max-len */
+const KNOWN_EXPOSURES = [];
 
 // `variant` distinguishes two cases on one route template (a pod grant vs a
 // seat grant on GET /api/grants/:grantId); an entry must name it to match.

--- a/backend/models/integrationPublicConfig.ts
+++ b/backend/models/integrationPublicConfig.ts
@@ -10,8 +10,10 @@
  * accessToken from the pod list because it happened to be there.
  * `connectCode` is deliberately NOT here: it is the one-time enable code a
  * member pastes into Telegram, and ChatRoom and the Connectors page read it
- * from the pod list. Ingest tokens are listed without their hash by
- * GET /api/integrations/:id/ingest-tokens.
+ * from the pod list and the owner's list. Surfaces with no reader drop it
+ * through withoutConnectCode instead: the admin list, and a Slack row in the
+ * catalog, where the code is the OAuth state. Ingest tokens are listed without
+ * their hash by GET /api/integrations/:id/ingest-tokens.
  *
  * Every JSON path an Integration takes out of the server runs through
  * toPublicIntegration: the model's toJSON, and the lean catalog read in
@@ -60,6 +62,19 @@ export const toPublicIntegration = (
     });
   }
   toPublicIntegrationConfig(integration.config as Record<string, unknown> | null | undefined);
+  return integration;
+};
+
+// For an already-public Integration on a surface that has no reader for the
+// connect code: drops the code and its expiry together.
+export const withoutConnectCode = (
+  integration: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null | undefined => {
+  const config = integration?.config;
+  if (config && typeof config === 'object') {
+    delete (config as Record<string, unknown>).connectCode;
+    delete (config as Record<string, unknown>).connectCodeExpiresAt;
+  }
   return integration;
 };
 

--- a/backend/routes/integrations.ts
+++ b/backend/routes/integrations.ts
@@ -30,6 +30,8 @@ const { hash, randomSecret } = require('../utils/secret');
 const { mintConnectCode } = require('../services/telegramConnectCode');
 // eslint-disable-next-line global-require
 const isPodMember = require('../utils/isPodMember');
+// eslint-disable-next-line global-require
+const { withoutConnectCode } = require('../models/integrationPublicConfig');
 import { Types } from 'mongoose';
 // Keep this as an ESM import: static analysis recognizes the rate limiter at
 // the route sink, while the middleware owns the shared token/IP bucket.
@@ -509,7 +511,8 @@ router.post('/:id/send', auth, async (req: AuthReq, res: Res) => {
 router.get('/admin/all', auth, adminAuth, async (_req: AuthReq, res: Res) => {
   try {
     const integrations = await Integration.find({ isActive: true }).populate('podId', 'name type createdBy').populate('createdBy', 'username email').populate('platformIntegration').sort({ createdAt: -1 });
-    res.json(integrations);
+    // The connect code is a member's one-time enable code; the admin list has no reader for it.
+    res.json(integrations.map((integration: { toJSON: () => Record<string, unknown> }) => withoutConnectCode(integration.toJSON())));
   } catch (error) {
     console.error('Error fetching all integrations:', error);
     res.status(500).json({ message: 'Server error' });

--- a/backend/services/installable/installableCatalogService.ts
+++ b/backend/services/installable/installableCatalogService.ts
@@ -5,7 +5,7 @@ const InstallableInstallation = require('../../models/InstallableInstallation');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
 const Integration = require('../../models/Integration');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
-const { toPublicIntegration } = require('../../models/integrationPublicConfig');
+const { toPublicIntegration, withoutConnectCode } = require('../../models/integrationPublicConfig');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
 const { manifests } = require('../../integrations/manifests');
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
@@ -38,7 +38,10 @@ const publicIntegration = (integration: unknown): unknown => {
     ? (integration as { toJSON: () => unknown }).toJSON()
     : JSON.parse(JSON.stringify(integration));
   if (!raw || typeof raw !== 'object') return raw;
-  return toPublicIntegration(raw as Record<string, unknown>);
+  const result = toPublicIntegration(raw as Record<string, unknown>);
+  // A Slack row's connect code is its OAuth state. The catalog has no reader
+  // for it; the Connectors page polls on it from the owner's list.
+  return result?.type === 'slack' ? withoutConnectCode(result) : result;
 };
 
 // The parent has operational fields that are useful to the owner's state


### PR DESCRIPTION
## Summary

This closes the last two B1 KNOWN_EXPOSURES rows. The list is now empty.

Both rows are `config.connectCode` on a surface that never reads it:

| Row | What leaked | Who does read it |
|---|---|---|
| `GET /api/installables`, owner, `INST_SLACK_CONNECTCODE` | A Slack row's connect code, which is its OAuth `state` | The Connectors page polls on it from `/api/integrations/user/all` (`codeIsLive` → `hasPending`), never from the catalog. The catalog is read only for `entry.installation.status`. |
| `GET /api/integrations/admin/all`, admin, `INT_TELEGRAM_CONNECTCODE` | A member's one-time Telegram enable code | The admin Apps list (`AppsManagement.tsx`) doesn't read it. ChatRoom reads it from the pod list. |

## Changes

- `models/integrationPublicConfig.ts`: new `withoutConnectCode`, which drops `connectCode` and `connectCodeExpiresAt` together, applied to an already-public row. `connectCode` stays off the always-stripped list because the pod list and the owner's list need it.
- `installableCatalogService.publicIntegration` applies it to Slack rows.
- `GET /api/integrations/admin/all` applies it to every row.
- `leakMatrix.js`: KNOWN_EXPOSURES becomes `[]`, and `R_INT_CONNECTCODE` / `R_SLACK_OAUTH_STATE` are removed.
- `integrations.platformIntegration.test.js` (#1672) asserted that the admin list still carries the Telegram code. It now asserts the pod list keeps it and the admin list doesn't.

The allowed disclosures are unchanged: the Telegram code to owner, member and admin on the pod list; to the owner on `/user/all`; and to the owner on the catalog.

## Test plan

- [x] `integrationPublicConfig.test.js` gains `withoutConnectCode` cases: the code and its expiry go, and the rest of config stays.
- [x] All leak-matrix suites, the ratchet and the helper test pass: 136/136.
- [x] Control: with main's catalog and route plus the empty list, exactly the two target cases fail, `INST_SLACK_CONNECTCODE` on `/api/installables` and `INT_TELEGRAM_CONNECTCODE` on `/admin/all`.
- [x] `integrations.platformIntegration` passes 6/6 with the updated assertion. At this head, before the update, it failed 1/6 on the old admin-list expectation; on main's tree it passes 6/6.
- [x] Full backend suite locally: 66 failing suites / 41 failing tests. Every failure is in the local baseline; none is new.
- [x] eslint on the three changed `.ts` files shows 0 errors; `tsc` reports nothing in them.

## Not in this PR

A Slack row still sends its OAuth state to its owner on `/user/all`, because the Connectors page uses it only to decide whether to keep polling. A derived `awaitingAuthorization` boolean would let that list drop the code too. That's a small UI follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
