### PR TITLE
fix(runtime): make token rotation total

### DIFF
--- a/backend/__tests__/unit/routes/agentBinding.phase2.test.js
+++ b/backend/__tests__/unit/routes/agentBinding.phase2.test.js
@@ -31,7 +31,6 @@ beforeAll(async () => {
   app = express();
   app.use(express.json());
   app.use('/api/agent-binding', require('../../../routes/agentBinding'));
-  app.get('/runtime-auth-probe', agentRuntimeAuth, (_req, res) => res.json({ ok: true }));
 });
 
 afterAll(async () => { await mongoose.disconnect(); await mongod.stop(); });
@@ -108,6 +107,18 @@ const mint = (tok, body = {}) => request(app)
   .post('/api/agent-binding/runtime-token')
   .set('Authorization', `Bearer ${tok}`)
   .send({ agentName: 'wren-test', instanceId: 'default', ...body });
+
+const runtimeAuthProbe = (token) => new Promise((resolve, reject) => {
+  let status = 200;
+  const req = {
+    header: (name) => name.toLowerCase() === 'authorization' ? `Bearer ${token}` : undefined,
+  };
+  const res = {
+    status: (code) => { status = code; return res; },
+    json: (body) => resolve({ status, body }),
+  };
+  Promise.resolve(agentRuntimeAuth(req, res, () => resolve({ status: 200 }))).catch(reject);
+});
 
 describe('placement request', () => {
   it('records a directive without binding, and null withdraws it', async () => {
@@ -320,6 +331,11 @@ describe('runtime-token mint', () => {
         },
       },
     );
+    await AgentInstallation.create({
+      agentName: 'wren-test', instanceId: 'default', podId: new mongoose.Types.ObjectId(),
+      version: '1.0.0', status: 'active', installedBy: owner._id,
+      runtimeTokens: [{ tokenHash: hash(oldInstallationToken), label: 'sibling legacy', createdAt: new Date() }],
+    });
 
     const refused = await mint(DAEMON_A);
     expect(refused.status).toBe(409);
@@ -329,14 +345,12 @@ describe('runtime-token mint', () => {
     expect(rotated.status).toBe(201);
     expect(rotated.body.token).not.toBe(oldUserToken);
 
-    const userAuth = await request(app)
-      .get('/runtime-auth-probe')
-      .set('Authorization', `Bearer ${oldUserToken}`);
-    const installationAuth = await request(app)
-      .get('/runtime-auth-probe')
-      .set('Authorization', `Bearer ${oldInstallationToken}`);
+    const userAuth = await runtimeAuthProbe(oldUserToken);
+    const installationAuth = await runtimeAuthProbe(oldInstallationToken);
+    const freshAuth = await runtimeAuthProbe(rotated.body.token);
     expect(userAuth.status).toBe(401);
     expect(installationAuth.status).toBe(401);
+    expect(freshAuth.status).toBe(200);
 
     const identity = await User.findById(bot._id).lean();
     expect(identity.agentRuntimeTokens.map((token) => token.tokenHash)).not.toContain(hash(oldUserToken));
@@ -349,5 +363,19 @@ describe('runtime-token mint', () => {
     const res = await mint(DAEMON_B);
     expect(res.status).toBe(409);
     expect(res.body.boundTo).toBe('machine-a');
+  });
+
+  it('rotates installations stored with mixed-case instance IDs', async () => {
+    await AgentInstallation.updateMany(
+      { agentName: 'wren-test', instanceId: 'default' },
+      { $set: { instanceId: 'DeFaUlT' } },
+    );
+    expect((await adopt(DAEMON_A)).status).toBe(200);
+    const first = await mint(DAEMON_A);
+    expect(first.status).toBe(201);
+    const rotated = await mint(DAEMON_A, { rotate: true });
+    expect(rotated.status).toBe(201);
+    expect(rotated.body.token).not.toBe(first.body.token);
+    expect((await runtimeAuthProbe(first.body.token)).status).toBe(401);
   });
 });

--- a/backend/__tests__/unit/routes/agentBinding.phase2.test.js
+++ b/backend/__tests__/unit/routes/agentBinding.phase2.test.js
@@ -15,6 +15,7 @@ jest.mock('../../../middleware/auth', () => {
 });
 
 const { hash } = require('../../../utils/secret');
+const agentRuntimeAuth = require('../../../middleware/agentRuntimeAuth');
 
 let mongod; let app; let AgentCredential; let User; let AgentInstallation; let Machine;
 const DAEMON_A = `cm_daemon_${'a'.repeat(32)}`;
@@ -30,6 +31,7 @@ beforeAll(async () => {
   app = express();
   app.use(express.json());
   app.use('/api/agent-binding', require('../../../routes/agentBinding'));
+  app.get('/runtime-auth-probe', agentRuntimeAuth, (_req, res) => res.json({ ok: true }));
 });
 
 afterAll(async () => { await mongoose.disconnect(); await mongod.stop(); });
@@ -296,6 +298,50 @@ describe('runtime-token mint', () => {
     expect(identity.agentRuntimeTokens.map((t) => t.tokenHash)).toEqual([hash(second.body.token)]);
     const install = await AgentInstallation.findOne({ agentName: 'wren-test' }).lean();
     expect(install.runtimeTokens || []).toEqual([]);
+  });
+
+  it('detects installation-only legacy tokens and invalidates both auth paths on rotate', async () => {
+    await adopt(DAEMON_A);
+    const oldUserToken = `cm_agent_${'u'.repeat(64)}`;
+    const oldInstallationToken = `cm_agent_${'i'.repeat(64)}`;
+    await User.updateOne(
+      { _id: bot._id },
+      {
+        $set: {
+          agentRuntimeTokens: [{ tokenHash: hash(oldUserToken), label: 'user legacy', createdAt: new Date() }],
+        },
+      },
+    );
+    await AgentInstallation.updateMany(
+      { agentName: 'wren-test', instanceId: 'default' },
+      {
+        $set: {
+          runtimeTokens: [{ tokenHash: hash(oldInstallationToken), label: 'installation legacy', createdAt: new Date() }],
+        },
+      },
+    );
+
+    const refused = await mint(DAEMON_A);
+    expect(refused.status).toBe(409);
+    expect(refused.body.code).toBe('token_exists');
+
+    const rotated = await mint(DAEMON_A, { rotate: true });
+    expect(rotated.status).toBe(201);
+    expect(rotated.body.token).not.toBe(oldUserToken);
+
+    const userAuth = await request(app)
+      .get('/runtime-auth-probe')
+      .set('Authorization', `Bearer ${oldUserToken}`);
+    const installationAuth = await request(app)
+      .get('/runtime-auth-probe')
+      .set('Authorization', `Bearer ${oldInstallationToken}`);
+    expect(userAuth.status).toBe(401);
+    expect(installationAuth.status).toBe(401);
+
+    const identity = await User.findById(bot._id).lean();
+    expect(identity.agentRuntimeTokens.map((token) => token.tokenHash)).not.toContain(hash(oldUserToken));
+    const installations = await AgentInstallation.find({ agentName: 'wren-test', instanceId: 'default' }).lean();
+    expect(installations.flatMap((install) => install.runtimeTokens || [])).toEqual([]);
   });
 
   it('never mints for a daemon whose machine does not hold the binding', async () => {

--- a/backend/__tests__/unit/routes/hosted.test.js
+++ b/backend/__tests__/unit/routes/hosted.test.js
@@ -7,6 +7,7 @@ const mockFindOne = jest.fn();
 const mockFind = jest.fn();
 const mockUserFindOne = jest.fn();
 const mockIssueToken = jest.fn();
+const mockRevokeRuntimeTokens = jest.fn();
 const mockHosted = {
   HOSTED_RUNTIME_TYPE: 'hosted',
   isConfigured: jest.fn(),
@@ -38,6 +39,7 @@ jest.mock('../../../services/agentIdentityService', () => ({
 }));
 jest.mock('../../../services/hostedRuntimeService', () => mockHosted);
 jest.mock('../../../routes/registry/tokens', () => ({
+  revokeRuntimeTokensForAgent: (...args) => mockRevokeRuntimeTokens(...args),
   issueRuntimeTokenForAgent: (...args) => mockIssueToken(...args),
 }));
 
@@ -70,6 +72,21 @@ describe('/api/hosted', () => {
     mockUserFindOne.mockResolvedValue({ _id: 'bot-1', username: 'scout', agentRuntimeTokens: [] });
     mockCredentialUpdateMany.mockResolvedValue({ modifiedCount: 0 });
     mockIssueToken.mockResolvedValue({ token: 'cm_agent_secret', existing: false });
+    mockRevokeRuntimeTokens.mockImplementation(async ({ agentUser, installation }) => {
+      const hashes = Array.from(new Set((agentUser?.agentRuntimeTokens || [])
+        .concat(installation?.runtimeTokens || [])
+        .map((entry) => entry?.tokenHash)
+        .filter(Boolean)));
+      if (hashes.length) {
+        await mockCredentialUpdateMany(
+          { tokenHash: { $in: hashes }, status: 'active' },
+          { $set: { status: 'revoked', revokedAt: new Date() } },
+        );
+      }
+      if (agentUser) agentUser.agentRuntimeTokens = [];
+      if (installation) installation.runtimeTokens = [];
+      return hashes;
+    });
     mockHosted.provisionAgent.mockResolvedValue({ provisioned: true });
   });
 
@@ -204,6 +221,12 @@ describe('/api/hosted', () => {
     expect(mockIssueToken).toHaveBeenCalledWith(
       expect.objectContaining({ _id: 'bot-1' }), 'Hosted runtime', installation, { ownerUserId: 'owner-1' },
     );
+    expect(mockRevokeRuntimeTokens).toHaveBeenCalledWith({
+      agentUser: expect.objectContaining({ _id: 'bot-1' }),
+      agentName: 'scout',
+      instanceId: 'demo',
+      installation,
+    });
     expect(mockHosted.provisionAgent).toHaveBeenCalledWith({ agentName: 'scout', instanceId: 'demo', runtimeToken: 'cm_agent_secret' });
     expect(installation.config.get('hosted').provisionedAt).toBeInstanceOf(Date);
     expect(installation.save).toHaveBeenCalled();
@@ -217,6 +240,12 @@ describe('/api/hosted', () => {
     mockIssueToken.mockResolvedValue({ token: 'cm_agent_fresh', existing: false });
     const res = await request(app).post('/api/hosted/provision').send({ agentName: 'scout' });
     expect(res.status).toBe(200);
+    expect(mockRevokeRuntimeTokens).toHaveBeenCalledWith({
+      agentUser,
+      agentName: 'scout',
+      instanceId: 'default',
+      installation,
+    });
     expect(mockCredentialUpdateMany).toHaveBeenCalledWith(
       { tokenHash: { $in: ['old-hash'] }, status: 'active' },
       { $set: expect.objectContaining({ status: 'revoked' }) },

--- a/backend/__tests__/unit/routes/registry.runtime-tokens.test.js
+++ b/backend/__tests__/unit/routes/registry.runtime-tokens.test.js
@@ -14,7 +14,14 @@ jest.mock('../../../models/AgentRegistry', () => ({
   AgentRegistry: {},
   AgentInstallation: {
     findOne: jest.fn(),
+    find: jest.fn(() => ({
+      select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue([]) })),
+    })),
+    updateMany: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
   },
+}));
+jest.mock('../../../models/AgentCredential', () => ({
+  updateMany: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
 }));
 jest.mock('../../../models/User', () => ({
   findOne: jest.fn(),
@@ -33,6 +40,7 @@ jest.mock('../../../services/agentIdentityService', () => ({
 
 const Pod = require('../../../models/Pod');
 const { AgentInstallation } = require('../../../models/AgentRegistry');
+const AgentCredential = require('../../../models/AgentCredential');
 const User = require('../../../models/User');
 const AgentIdentityService = require('../../../services/agentIdentityService');
 const registryRoutes = require('../../../routes/registry');
@@ -44,6 +52,10 @@ app.use('/api/registry', registryRoutes);
 describe('agent runtime tokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    AgentInstallation.find.mockImplementation(() => ({
+      select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue([]) })),
+    }));
+    AgentCredential.updateMany.mockResolvedValue({ modifiedCount: 0 });
   });
 
   it('issues a runtime token for an installed agent', async () => {
@@ -159,6 +171,63 @@ describe('agent runtime tokens', () => {
     // The stale token is gone; only the fresh one remains.
     expect(agentUser.agentRuntimeTokens.length).toBe(1);
     expect(agentUser.agentRuntimeTokens[0].label).toBe('Re-attach');
+    expect(AgentCredential.updateMany).toHaveBeenCalledWith(
+      { tokenHash: { $in: ['stale'] }, kind: 'runtime', status: 'active' },
+      { $set: expect.objectContaining({ status: 'revoked', revokedAt: expect.any(Date) }) },
+    );
+    expect(AgentInstallation.updateMany).toHaveBeenCalledWith(
+      { agentName: 'commonly-bot', instanceId: 'default' },
+      { $set: { runtimeTokens: [] } },
+    );
+  });
+
+  it('treats an installation-only token as existing and force rotation clears its copy', async () => {
+    Pod.findById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        _id: 'pod-1', createdBy: 'user-1', members: ['user-1'],
+      }),
+    });
+    const installation = {
+      agentName: 'commonly-bot',
+      podId: 'pod-1',
+      instanceId: 'default',
+      displayName: 'Commonly Bot',
+      status: 'active',
+      runtimeTokens: [{ tokenHash: 'legacy-installation', label: 'legacy', createdAt: new Date() }],
+      save: jest.fn().mockResolvedValue(true),
+    };
+    const agentUser = {
+      agentRuntimeTokens: [],
+      save: jest.fn().mockResolvedValue(true),
+    };
+    AgentInstallation.findOne.mockResolvedValue(installation);
+    AgentInstallation.find.mockReturnValue({
+      select: jest.fn(() => ({
+        lean: jest.fn().mockResolvedValue([{ runtimeTokens: installation.runtimeTokens }]),
+      })),
+    });
+    AgentIdentityService.getOrCreateAgentUser.mockResolvedValue(agentUser);
+    AgentIdentityService.ensureAgentInPod.mockResolvedValue(true);
+
+    const existing = await request(app)
+      .post('/api/registry/pods/pod-1/agents/commonly-bot/runtime-tokens')
+      .send({ label: 'Re-attach' });
+    expect(existing.status).toBe(200);
+    expect(existing.body.existing).toBe(true);
+    expect(existing.body.token).toBeUndefined();
+
+    const rotated = await request(app)
+      .post('/api/registry/pods/pod-1/agents/commonly-bot/runtime-tokens')
+      .send({ label: 'Re-attach', force: true });
+    expect(rotated.status).toBe(200);
+    expect(rotated.body.token).toMatch(/^cm_agent_/);
+    expect(rotated.body.existing).toBe(false);
+    expect(AgentCredential.updateMany).toHaveBeenCalledWith(
+      { tokenHash: { $in: ['legacy-installation'] }, kind: 'runtime', status: 'active' },
+      { $set: expect.objectContaining({ status: 'revoked', revokedAt: expect.any(Date) }) },
+    );
+    expect(installation.runtimeTokens).toHaveLength(1);
+    expect(installation.runtimeTokens[0].tokenHash).not.toBe('legacy-installation');
   });
 
   it('lists shared runtime tokens from agent user', async () => {

--- a/backend/__tests__/unit/routes/registry.runtime-tokens.test.js
+++ b/backend/__tests__/unit/routes/registry.runtime-tokens.test.js
@@ -15,9 +15,12 @@ jest.mock('../../../models/AgentRegistry', () => ({
   AgentInstallation: {
     findOne: jest.fn(),
     find: jest.fn(() => ({
+      collation: jest.fn(function collation() { return this; }),
       select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue([]) })),
     })),
-    updateMany: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+    updateMany: jest.fn(() => ({
+      collation: jest.fn(() => Promise.resolve({ modifiedCount: 0 })),
+    })),
   },
 }));
 jest.mock('../../../models/AgentCredential', () => ({
@@ -53,6 +56,7 @@ describe('agent runtime tokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     AgentInstallation.find.mockImplementation(() => ({
+      collation: jest.fn(function collation() { return this; }),
       select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue([]) })),
     }));
     AgentCredential.updateMany.mockResolvedValue({ modifiedCount: 0 });
@@ -202,6 +206,7 @@ describe('agent runtime tokens', () => {
     };
     AgentInstallation.findOne.mockResolvedValue(installation);
     AgentInstallation.find.mockReturnValue({
+      collation: jest.fn(function collation() { return this; }),
       select: jest.fn(() => ({
         lean: jest.fn().mockResolvedValue([{ runtimeTokens: installation.runtimeTokens }]),
       })),

--- a/backend/__tests__/unit/scripts/sweep-leftover-runtime-tokens.test.js
+++ b/backend/__tests__/unit/scripts/sweep-leftover-runtime-tokens.test.js
@@ -1,0 +1,153 @@
+const mongoose = require('mongoose');
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn().mockReturnValue('test-jwt-token'),
+  verify: jest.fn(),
+}));
+const AgentCredential = require('../../../models/AgentCredential');
+const { AgentInstallation } = require('../../../models/AgentRegistry');
+const User = require('../../../models/User');
+const { sweepLeftoverRuntimeTokens } = require('../../../scripts/sweep-leftover-runtime-tokens');
+const {
+  setupMongoDb,
+  closeMongoDb,
+  clearMongoDb,
+} = require('../../utils/testUtils');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('sweep-leftover-runtime-tokens', () => {
+  beforeAll(async () => {
+    await setupMongoDb();
+  });
+
+  afterEach(async () => {
+    await clearMongoDb();
+  });
+
+  afterAll(async () => {
+    await closeMongoDb();
+  });
+
+  const seed = async () => {
+    const owner = await User.create({
+      username: 'owner',
+      email: 'owner@example.com',
+      password: 'hashed',
+      verified: true,
+    });
+    const bot = await User.create({
+      username: 'openclaw-nova',
+      email: 'openclaw-nova@agents.commonly.local',
+      password: 'hashed',
+      verified: true,
+      isBot: true,
+      botMetadata: { agentName: 'openclaw', instanceId: 'nova' },
+      agentRuntimeTokens: [{ tokenHash: 'user-live', createdAt: new Date() }],
+    });
+    const podA = new mongoose.Types.ObjectId();
+    const podB = new mongoose.Types.ObjectId();
+    const staleAt = new Date(Date.now() - 8 * DAY_MS);
+    const recentAt = new Date(Date.now() - 2 * DAY_MS);
+    const makeInstallation = (podId, agentName, instanceId, runtimeTokens) => AgentInstallation.create({
+      agentName,
+      podId,
+      instanceId,
+      version: '1.0.0',
+      installedBy: owner._id,
+      runtimeTokens,
+    });
+
+    const first = await makeInstallation(podA, 'openclaw', 'nova', [
+      { tokenHash: 'stale', createdAt: staleAt, lastUsedAt: staleAt },
+      { tokenHash: 'recent', createdAt: recentAt, lastUsedAt: recentAt },
+      { tokenHash: 'user-live', createdAt: staleAt, lastUsedAt: staleAt },
+      { tokenHash: 'revoked', createdAt: staleAt, lastUsedAt: staleAt },
+    ]);
+    const second = await makeInstallation(podB, 'openclaw', 'nova', [
+      { tokenHash: 'stale', createdAt: staleAt },
+    ]);
+    const other = await makeInstallation(new mongoose.Types.ObjectId(), 'pixel', 'default', [
+      { tokenHash: 'no-ledger', createdAt: staleAt },
+    ]);
+    await AgentCredential.create({
+      tokenHash: 'stale',
+      kind: 'runtime',
+      ownerUserId: owner._id,
+      agentUserId: bot._id,
+      status: 'active',
+      lastUsedAt: staleAt,
+    });
+    await AgentCredential.create({
+      tokenHash: 'recent',
+      kind: 'runtime',
+      ownerUserId: owner._id,
+      agentUserId: bot._id,
+      status: 'active',
+      lastUsedAt: recentAt,
+    });
+    await AgentCredential.create({
+      tokenHash: 'revoked',
+      kind: 'runtime',
+      ownerUserId: owner._id,
+      agentUserId: bot._id,
+      status: 'revoked',
+      revokedAt: staleAt,
+      lastUsedAt: staleAt,
+    });
+    return { first, second, other, bot };
+  };
+
+  it('defaults to dry-run and reports per-identity candidates without mutating', async () => {
+    const { first, second, other } = await seed();
+
+    const result = await sweepLeftoverRuntimeTokens();
+
+    expect(result.apply).toBe(false);
+    expect(result.copiesToPull).toBe(3);
+    expect(result.copiesSkippedRecent).toBe(1);
+    expect(result.candidateHashes).toBe(2);
+    expect(result.identities).toEqual([
+      expect.objectContaining({ agentName: 'openclaw', instanceId: 'nova', count: 2, skippedRecent: 1 }),
+      expect.objectContaining({ agentName: 'pixel', instanceId: 'default', count: 1, skippedRecent: 0 }),
+    ]);
+
+    await expect(AgentInstallation.findById(first._id).lean()).resolves.toEqual(
+      expect.objectContaining({ runtimeTokens: expect.arrayContaining([
+        expect.objectContaining({ tokenHash: 'stale' }),
+        expect.objectContaining({ tokenHash: 'recent' }),
+      ]) }),
+    );
+    await expect(AgentInstallation.findById(second._id).lean()).resolves.toEqual(
+      expect.objectContaining({ runtimeTokens: [expect.objectContaining({ tokenHash: 'stale' })] }),
+    );
+    await expect(AgentInstallation.findById(other._id).lean()).resolves.toEqual(
+      expect.objectContaining({ runtimeTokens: [expect.objectContaining({ tokenHash: 'no-ledger' })] }),
+    );
+    await expect(AgentCredential.findOne({ tokenHash: 'stale' }).lean()).resolves.toEqual(
+      expect.objectContaining({ status: 'active' }),
+    );
+  });
+
+  it('apply removes stale installation copies and revokes their active ledger rows', async () => {
+    const { first, second, other, bot } = await seed();
+
+    const result = await sweepLeftoverRuntimeTokens({ apply: true });
+
+    expect(result.apply).toBe(true);
+    expect(result.copiesToPull).toBe(3);
+    expect(result.installationRowsChanged).toBe(3);
+    expect(result.credentialsRevoked).toBe(1);
+
+    const firstTokens = (await AgentInstallation.findById(first._id).lean()).runtimeTokens;
+    const secondTokens = (await AgentInstallation.findById(second._id).lean()).runtimeTokens;
+    const otherTokens = (await AgentInstallation.findById(other._id).lean()).runtimeTokens;
+    expect(firstTokens.map((token) => token.tokenHash)).toEqual(['recent', 'user-live', 'revoked']);
+    expect(secondTokens).toEqual([]);
+    expect(otherTokens).toEqual([]);
+    expect((await AgentCredential.findOne({ tokenHash: 'stale' }).lean()).status).toBe('revoked');
+    expect((await AgentCredential.findOne({ tokenHash: 'recent' }).lean()).status).toBe('active');
+    expect((await AgentCredential.findOne({ tokenHash: 'revoked' }).lean()).status).toBe('revoked');
+    expect((await User.findById(bot._id).lean()).agentRuntimeTokens.map((token) => token.tokenHash))
+      .toEqual(['user-live']);
+  });
+});

--- a/backend/__tests__/unit/scripts/sweep-leftover-runtime-tokens.test.js
+++ b/backend/__tests__/unit/scripts/sweep-leftover-runtime-tokens.test.js
@@ -103,12 +103,12 @@ describe('sweep-leftover-runtime-tokens', () => {
     const result = await sweepLeftoverRuntimeTokens();
 
     expect(result.apply).toBe(false);
-    expect(result.copiesToPull).toBe(3);
+    expect(result.copiesToPull).toBe(2);
     expect(result.copiesSkippedRecent).toBe(1);
-    expect(result.candidateHashes).toBe(2);
+    expect(result.candidateHashes).toBe(1);
     expect(result.identities).toEqual([
       expect.objectContaining({ agentName: 'openclaw', instanceId: 'nova', count: 2, skippedRecent: 1 }),
-      expect.objectContaining({ agentName: 'pixel', instanceId: 'default', count: 1, skippedRecent: 0 }),
+      expect.objectContaining({ agentName: 'pixel', instanceId: 'default', count: 0, skippedRecent: 0, legacyOnly: 1 }),
     ]);
 
     await expect(AgentInstallation.findById(first._id).lean()).resolves.toEqual(
@@ -134,8 +134,8 @@ describe('sweep-leftover-runtime-tokens', () => {
     const result = await sweepLeftoverRuntimeTokens({ apply: true });
 
     expect(result.apply).toBe(true);
-    expect(result.copiesToPull).toBe(3);
-    expect(result.installationRowsChanged).toBe(3);
+    expect(result.copiesToPull).toBe(2);
+    expect(result.installationRowsChanged).toBe(2);
     expect(result.credentialsRevoked).toBe(1);
 
     const firstTokens = (await AgentInstallation.findById(first._id).lean()).runtimeTokens;
@@ -143,7 +143,7 @@ describe('sweep-leftover-runtime-tokens', () => {
     const otherTokens = (await AgentInstallation.findById(other._id).lean()).runtimeTokens;
     expect(firstTokens.map((token) => token.tokenHash)).toEqual(['recent', 'user-live', 'revoked']);
     expect(secondTokens).toEqual([]);
-    expect(otherTokens).toEqual([]);
+    expect(otherTokens).toEqual([expect.objectContaining({ tokenHash: 'no-ledger' })]);
     expect((await AgentCredential.findOne({ tokenHash: 'stale' }).lean()).status).toBe('revoked');
     expect((await AgentCredential.findOne({ tokenHash: 'recent' }).lean()).status).toBe('active');
     expect((await AgentCredential.findOne({ tokenHash: 'revoked' }).lean()).status).toBe('revoked');

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "bootstrap:clawd-bot": "node scripts/bootstrap-clawd-bot.js",
     "backfill:attention-items": "ts-node scripts/backfill-attention-items.ts",
     "sweep:resolved-mention-attention": "ts-node scripts/sweep-resolved-mention-attention.ts",
+    "sweep:leftover-runtime-tokens": "ts-node scripts/sweep-leftover-runtime-tokens.ts",
     "set:agent-descriptions": "ts-node scripts/set-agent-descriptions.ts",
     "tsc:check": "tsc --noEmit -p tsconfig.typescheck.json",
     "tsc:check:all": "tsc --noEmit"

--- a/backend/routes/agentBinding.ts
+++ b/backend/routes/agentBinding.ts
@@ -13,6 +13,11 @@ import daemonAuth, { DaemonAuthedRequest } from '../middleware/daemonAuth';
 const auth = require('../middleware/auth');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const User = require('../models/User');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {
+  getRuntimeTokenHashesForAgent,
+  revokeRuntimeTokensForAgent,
+} = require('./registry/tokens');
 
 const router = express.Router();
 
@@ -351,9 +356,14 @@ router.post('/runtime-token', bindingRateLimit, daemonAuth('agents:adopt'), asyn
       });
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const AgentCredential = require('../models/AgentCredential');
-    const hasToken = (agentUser.agentRuntimeTokens || []).length > 0;
+    // Runtime auth accepts both the portable User row and legacy installation
+    // copies. Count both stores before deciding whether rotate is required.
+    const runtimeTokenHashes = await getRuntimeTokenHashesForAgent({
+      agentUser,
+      agentName,
+      instanceId,
+    });
+    const hasToken = runtimeTokenHashes.length > 0;
     if (hasToken && req.body?.rotate !== true) {
       return res.status(409).json({
         message: 'Agent already has a runtime token — pass rotate:true to invalidate it and mint one for this machine',
@@ -361,20 +371,11 @@ router.post('/runtime-token', bindingRateLimit, daemonAuth('agents:adopt'), asyn
       });
     }
     if (hasToken) {
-      // Rotation must be total: revoke the ledger rows AND clear both legacy
-      // stores (User + installation copies), or the old bearer keeps working
-      // through the legacy auth fallback.
-      const hashes = (agentUser.agentRuntimeTokens || []).map((t: { tokenHash: string }) => t.tokenHash);
-      await AgentCredential.updateMany(
-        { tokenHash: { $in: hashes }, kind: 'runtime' },
-        { $set: { status: 'revoked', revokedAt: new Date() } },
-      );
-      agentUser.agentRuntimeTokens = [];
-      await agentUser.save();
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { AgentInstallation } = require('../models/AgentRegistry');
-      await AgentInstallation.updateMany({ agentName, instanceId }, { $set: { runtimeTokens: [] } });
+      await revokeRuntimeTokensForAgent({ agentUser, agentName, instanceId });
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const AgentCredential = require('../models/AgentCredential');
 
     // req.machine is deliberately a minimal projection (Vera's S1 ruling), so
     // re-derive the issuing daemon credential for parent lineage.

--- a/backend/routes/agentBinding.ts
+++ b/backend/routes/agentBinding.ts
@@ -39,6 +39,7 @@ const bindingRateLimit = rateLimit({
 });
 
 const normalize = (v: unknown): string => String(v ?? '').trim().toLowerCase();
+const RUNTIME_INSTALLATION_COLLATION = { locale: 'en', strength: 2 };
 
 // The daemon needs the driver-neutral ADR-008 shape, but its bearer must not
 // become a read-all projection of an installation's opaque config. Keep this
@@ -147,11 +148,11 @@ const ownsAgent = async (
   const { AgentInstallation } = require('../models/AgentRegistry');
   const mine = await AgentInstallation.findOne({
     agentName, instanceId, installedBy: ownerUserId, status: 'active',
-  }).select('_id').lean();
+  }).collation(RUNTIME_INSTALLATION_COLLATION).select('_id').lean();
   if (!mine) return { owned: false, failure: 'owner_installation_missing' };
   const others = await AgentInstallation.findOne({
     agentName, instanceId, status: 'active', installedBy: { $ne: ownerUserId },
-  }).select('installedBy').lean();
+  }).collation(RUNTIME_INSTALLATION_COLLATION).select('installedBy').lean();
   if (!others) return { owned: true };
   // MongoDB $ne also matches a missing field. Keep that legacy state safely
   // non-adoptable, but report it separately so an owner can repair it.

--- a/backend/routes/hosted.ts
+++ b/backend/routes/hosted.ts
@@ -18,11 +18,13 @@ import { createHash } from 'crypto';
 
 const auth = require('../middleware/auth');
 const { AgentInstallation } = require('../models/AgentRegistry');
-const AgentCredential = require('../models/AgentCredential');
 const User = require('../models/User');
 const AgentIdentityService = require('../services/agentIdentityService');
 const hostedRuntime = require('../services/hostedRuntimeService');
-const { issueRuntimeTokenForAgent } = require('./registry/tokens');
+const {
+  revokeRuntimeTokensForAgent,
+  issueRuntimeTokenForAgent,
+} = require('./registry/tokens');
 
 const router = express.Router();
 
@@ -188,22 +190,9 @@ router.post('/provision', hostedRateLimit, auth, async (req: any, res: any) => {
       return res.status(409).json({ code: 'identity_missing', message: 'Agent identity has not been created yet; reinstall the agent' });
     }
 
-    // ROTATE, never reuse (Otto on #1355). Two pollers on one token is the
-    // case D6 does not cover — both post before either acks, duplicates land
-    // in the pod, nothing errors. A fresh token turns an orphaned poller (a
-    // still-running CLI wrapper, a DO that was never deprovisioned) into a
-    // 401 it dies on, and self-heals the case where the old runtime is gone.
-    const staleHashes = (agentUser.agentRuntimeTokens || [])
-      .map((entry: any) => entry?.tokenHash)
-      .filter(Boolean);
-    if (staleHashes.length) {
-      await AgentCredential.updateMany(
-        { tokenHash: { $in: staleHashes }, status: 'active' },
-        { $set: { status: 'revoked', revokedAt: new Date() } },
-      );
-    }
-    agentUser.agentRuntimeTokens = [];
-    installation.runtimeTokens = [];
+    // ROTATE, never reuse (Otto on #1355). Both runtime-auth paths must lose
+    // the old bearer, including legacy installation-only copies.
+    await revokeRuntimeTokensForAgent({ agentUser, agentName, instanceId, installation });
     const token = await issueRuntimeTokenForAgent(
       agentUser,
       'Hosted runtime',

--- a/backend/routes/registry/agent-tokens.ts
+++ b/backend/routes/registry/agent-tokens.ts
@@ -43,6 +43,7 @@ const {
 } = require('./helpers');
 const {
   normalizeScopes,
+  revokeRuntimeTokensForAgent,
   issueRuntimeTokenForAgent,
   issueUserTokenForInstallation,
 } = require('./tokens');
@@ -152,27 +153,23 @@ agentTokensRouter.post('/pods/:podId/agents/:name/runtime-tokens', tokenRouteLim
     });
     await AgentIdentityService.ensureAgentInPod(agentUser, podId);
 
-    let issued = await issueRuntimeTokenForAgent(
+    // ADR-005 §detach + reattach: force rotation is a replacement operation,
+    // not merely clearing the User row. Runtime auth accepts both the shared
+    // User token and legacy installation copies, so revoke every hash before
+    // issuing the replacement.
+    if (force) {
+      await revokeRuntimeTokensForAgent({
+        agentUser,
+        agentName: installation.agentName || name,
+        instanceId: normalizedInstanceId,
+        installation,
+      });
+    }
+    const issued = await issueRuntimeTokenForAgent(
       agentUser,
       label || `Provisioned ${normalizedInstanceId}`,
       installation,
     );
-    // ADR-005 §detach + reattach: a fresh attach after detach has no local
-    // copy of the prior token (the file was deleted on detach), but the
-    // agent User row's hashed token persists per ADR-001 identity-continuity.
-    // issueRuntimeTokenForAgent then returns `{existing: true}` with no
-    // usable raw token, leaving the CLI with nothing to save. The same
-    // workaround already lives in reprovision.ts/provision.ts; surfacing it
-    // here as an explicit `force` body flag keeps the install flow honest.
-    if (issued.existing && force) {
-      agentUser.agentRuntimeTokens = [];
-      const fresh = await issueRuntimeTokenForAgent(
-        agentUser,
-        label || `Provisioned ${normalizedInstanceId}`,
-        installation,
-      );
-      issued = { ...issued, ...fresh };
-    }
     return res.json(issued);
   } catch (error) {
     console.error('Error issuing agent runtime token:', error);

--- a/backend/routes/registry/provision.ts
+++ b/backend/routes/registry/provision.ts
@@ -31,6 +31,7 @@ const {
   resolveRuntimeInstanceId,
 } = require('./helpers');
 const {
+  revokeRuntimeTokensForAgent,
   issueRuntimeTokenForAgent,
   issueUserTokenForInstallation,
 } = require('./tokens');
@@ -180,23 +181,20 @@ provisionRouter.post('/pods/:podId/agents/:name/provision', provisionRateLimit, 
     });
     await AgentIdentityService.ensureAgentInPod(agentUser, podId);
 
+    if (force) {
+      await revokeRuntimeTokensForAgent({
+        agentUser,
+        agentName: installation.agentName || name,
+        instanceId: normalizedInstanceId,
+        installation,
+      });
+    }
     const runtimeIssued = await issueRuntimeTokenForAgent(
       agentUser,
       label || `Provisioned ${normalizedInstanceId}`,
       installation,
       { ownerUserId: req.user?.id || req.user?._id },
     );
-
-    if (runtimeIssued.existing && force) {
-      agentUser.agentRuntimeTokens = [];
-      const freshToken = await issueRuntimeTokenForAgent(
-        agentUser,
-        label || `Provisioned ${normalizedInstanceId}`,
-        installation,
-        { ownerUserId: req.user?.id || req.user?._id },
-      );
-      Object.assign(runtimeIssued, freshToken);
-    }
 
     let userIssued = null;
     if (includeUserToken || runtimeType === 'moltbot') {

--- a/backend/routes/registry/reprovision.ts
+++ b/backend/routes/registry/reprovision.ts
@@ -22,6 +22,7 @@ const {
   buildAgentProfileId,
 } = require('./helpers');
 const {
+  revokeRuntimeTokensForAgent,
   issueRuntimeTokenForAgent,
   issueUserTokenForInstallation,
 } = require('./tokens');
@@ -69,12 +70,15 @@ const reprovisionInstallation = async ({
     label: issueLabel,
   };
   if (!runtimeToken) {
-    runtimeIssued = await issueRuntimeTokenForAgent(agentUser, issueLabel, installation);
-    if (runtimeIssued.existing && force) {
-      agentUser.agentRuntimeTokens = [];
-      const freshToken = await issueRuntimeTokenForAgent(agentUser, issueLabel, installation);
-      runtimeIssued = { ...runtimeIssued, ...freshToken };
+    if (force) {
+      await revokeRuntimeTokensForAgent({
+        agentUser,
+        agentName: name,
+        instanceId: normalizedInstanceId,
+        installation,
+      });
     }
+    runtimeIssued = await issueRuntimeTokenForAgent(agentUser, issueLabel, installation);
     runtimeToken = runtimeIssued.token || null;
     if (runtimeToken) {
       runtimeTokenCache.set(identityKey, runtimeToken);

--- a/backend/routes/registry/tokens.ts
+++ b/backend/routes/registry/tokens.ts
@@ -43,6 +43,92 @@ const normalizeContextPolicy = (policy: any) => {
   return next;
 };
 
+type RuntimeTokenOwner = {
+  agentUser: any;
+  agentName: string;
+  instanceId?: string;
+  installation?: any;
+};
+
+const normalizeRuntimeIdentity = (agentName: any, instanceId: any) => ({
+  agentName: String(agentName || '').trim().toLowerCase(),
+  instanceId: String(instanceId || 'default').trim().toLowerCase() || 'default',
+});
+
+/**
+ * Return every legacy hash for an agent identity, across the portable User
+ * row and every installation copy. The two stores are both authentication
+ * paths, so a rotation that sees only one is incomplete.
+ */
+const getRuntimeTokenHashesForAgent = async ({
+  agentUser,
+  agentName,
+  instanceId,
+  installation = null,
+}: RuntimeTokenOwner): Promise<string[]> => {
+  const identity = normalizeRuntimeIdentity(agentName, instanceId);
+  const userTokens = Array.isArray(agentUser?.agentRuntimeTokens) ? agentUser.agentRuntimeTokens : [];
+  const localInstallationTokens = Array.isArray(installation?.runtimeTokens)
+    ? installation.runtimeTokens
+    : [];
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const { AgentInstallation } = require('../../models/AgentRegistry');
+  const installations = await AgentInstallation.find({
+    agentName: identity.agentName,
+    instanceId: identity.instanceId,
+  }).select('runtimeTokens').lean();
+  const persistedInstallationTokens = (installations || []).flatMap((row: any) => row.runtimeTokens || []);
+  return Array.from(new Set([
+    ...userTokens,
+    ...localInstallationTokens,
+    ...persistedInstallationTokens,
+  ].map((token: any) => token?.tokenHash).filter(Boolean)));
+};
+
+/**
+ * Revoke runtime credentials and clear both legacy token stores for one
+ * identity. Call this immediately before minting a replacement token.
+ */
+const revokeRuntimeTokensForAgent = async (owner: RuntimeTokenOwner): Promise<string[]> => {
+  const identity = normalizeRuntimeIdentity(owner.agentName, owner.instanceId);
+  const hashes = await getRuntimeTokenHashesForAgent(owner);
+
+  if (hashes.length) {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+    const AgentCredential = require('../../models/AgentCredential');
+    await AgentCredential.updateMany(
+      { tokenHash: { $in: hashes }, kind: 'runtime', status: 'active' },
+      { $set: { status: 'revoked', revokedAt: new Date() } },
+    );
+  }
+
+  if (Array.isArray(owner.agentUser?.agentRuntimeTokens) && owner.agentUser.agentRuntimeTokens.length) {
+    owner.agentUser.agentRuntimeTokens = [];
+    await owner.agentUser.save();
+  }
+
+  // Clear every installation, not only the row that happened to receive the
+  // request. Runtime auth accepts any active installation copy for the same
+  // identity, so leaving a sibling row would leave the old bearer alive.
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const { AgentInstallation } = require('../../models/AgentRegistry');
+  await AgentInstallation.updateMany(
+    { agentName: identity.agentName, instanceId: identity.instanceId },
+    { $set: { runtimeTokens: [] } },
+  );
+
+  // A route may hold a hydrated installation that is not represented by the
+  // mocked query above (or has a pending in-memory mutation). Keep that
+  // object aligned too; a fresh issue call appends to it immediately after.
+  if (owner.installation && Array.isArray(owner.installation.runtimeTokens)
+      && owner.installation.runtimeTokens.length) {
+    owner.installation.runtimeTokens = [];
+    if (typeof owner.installation.save === 'function') await owner.installation.save();
+  }
+
+  return hashes;
+};
+
 /**
  * Issue a runtime token for an agent.
  * Tokens are stored on the User model (shared across all pod installations).
@@ -60,8 +146,8 @@ const normalizeContextPolicy = (policy: any) => {
 // (additive migration; auth falls back for those).
 const issueRuntimeTokenForAgent = async (agentUser: any, label: any, installation: any = null, issuer: any = null) => {
   // Check if agent already has a runtime token (reuse existing)
-  if (agentUser.agentRuntimeTokens?.length > 0) {
-    const existingToken = agentUser.agentRuntimeTokens[0];
+  const existingToken = agentUser.agentRuntimeTokens?.[0] || installation?.runtimeTokens?.[0];
+  if (existingToken) {
     // Backfill a credential row for the pre-substrate token so the existing
     // fleet becomes listable and cascade-revocable (Vera on #1312: without
     // this the collection stays near-empty while coverage looks fine).
@@ -202,6 +288,8 @@ module.exports = {
   sanitizeStringList,
   normalizeToolPolicy,
   normalizeContextPolicy,
+  getRuntimeTokenHashesForAgent,
+  revokeRuntimeTokensForAgent,
   issueRuntimeTokenForAgent,
   issueRuntimeTokenForInstallation,
   issueUserTokenForInstallation,

--- a/backend/routes/registry/tokens.ts
+++ b/backend/routes/registry/tokens.ts
@@ -60,6 +60,20 @@ const normalizeRuntimeIdentity = (agentName: any, instanceId: any) => ({
 // but match legacy rows case-insensitively during a rotation.
 const RUNTIME_INSTALLATION_COLLATION = { locale: 'en', strength: 2 };
 
+/** Revoke selected runtime ledger rows, optionally guarded by a freshness filter. */
+export const revokeRuntimeCredentials = async (
+  hashes: string[],
+  extraFilter: Record<string, unknown> = {},
+) => {
+  if (!hashes.length) return { modifiedCount: 0 };
+  // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
+  const AgentCredential = require('../../models/AgentCredential');
+  return AgentCredential.updateMany(
+    { tokenHash: { $in: hashes }, kind: 'runtime', status: 'active', ...extraFilter },
+    { $set: { status: 'revoked', revokedAt: new Date() } },
+  );
+};
+
 /**
  * Return every legacy hash for an agent identity, across the portable User
  * row and every installation copy. The two stores are both authentication
@@ -99,12 +113,7 @@ const revokeRuntimeTokensForAgent = async (owner: RuntimeTokenOwner): Promise<st
   const hashes = await getRuntimeTokenHashesForAgent(owner);
 
   if (hashes.length) {
-    // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports
-    const AgentCredential = require('../../models/AgentCredential');
-    await AgentCredential.updateMany(
-      { tokenHash: { $in: hashes }, kind: 'runtime', status: 'active' },
-      { $set: { status: 'revoked', revokedAt: new Date() } },
-    );
+    await revokeRuntimeCredentials(hashes);
   }
 
   if (Array.isArray(owner.agentUser?.agentRuntimeTokens) && owner.agentUser.agentRuntimeTokens.length) {
@@ -294,6 +303,7 @@ module.exports = {
   normalizeToolPolicy,
   normalizeContextPolicy,
   getRuntimeTokenHashesForAgent,
+  revokeRuntimeCredentials,
   revokeRuntimeTokensForAgent,
   issueRuntimeTokenForAgent,
   issueRuntimeTokenForInstallation,

--- a/backend/routes/registry/tokens.ts
+++ b/backend/routes/registry/tokens.ts
@@ -55,6 +55,11 @@ const normalizeRuntimeIdentity = (agentName: any, instanceId: any) => ({
   instanceId: String(instanceId || 'default').trim().toLowerCase() || 'default',
 });
 
+// AgentInstallation.instanceId predates the normalized intake path and may
+// still be stored with mixed casing. Keep identity normalization for callers,
+// but match legacy rows case-insensitively during a rotation.
+const RUNTIME_INSTALLATION_COLLATION = { locale: 'en', strength: 2 };
+
 /**
  * Return every legacy hash for an agent identity, across the portable User
  * row and every installation copy. The two stores are both authentication
@@ -76,7 +81,7 @@ const getRuntimeTokenHashesForAgent = async ({
   const installations = await AgentInstallation.find({
     agentName: identity.agentName,
     instanceId: identity.instanceId,
-  }).select('runtimeTokens').lean();
+  }).collation(RUNTIME_INSTALLATION_COLLATION).select('runtimeTokens').lean();
   const persistedInstallationTokens = (installations || []).flatMap((row: any) => row.runtimeTokens || []);
   return Array.from(new Set([
     ...userTokens,
@@ -115,7 +120,7 @@ const revokeRuntimeTokensForAgent = async (owner: RuntimeTokenOwner): Promise<st
   await AgentInstallation.updateMany(
     { agentName: identity.agentName, instanceId: identity.instanceId },
     { $set: { runtimeTokens: [] } },
-  );
+  ).collation(RUNTIME_INSTALLATION_COLLATION);
 
   // A route may hold a hydrated installation that is not represented by the
   // mocked query above (or has a pending in-memory mutation). Keep that

--- a/backend/scripts/sweep-leftover-runtime-tokens.ts
+++ b/backend/scripts/sweep-leftover-runtime-tokens.ts
@@ -49,6 +49,7 @@ export type LeftoverRuntimeTokenIdentity = {
   instanceId: string;
   count: number;
   skippedRecent: number;
+  legacyOnly: number;
   newestLastUsedAt: Date | null;
 };
 
@@ -90,11 +91,15 @@ const buildCandidates = (
   credentials: CredentialRow[],
   cutoff: Date,
 ) => {
-  const userHashes = new Set<string>();
+  const userHashesByIdentity = new Map<string, Set<string>>();
   for (const user of users) {
+    if (!user.botMetadata?.agentName) continue;
+    const key = identityKey(user.botMetadata?.agentName, user.botMetadata?.instanceId);
+    const userHashes = userHashesByIdentity.get(key) || new Set<string>();
     for (const token of user.agentRuntimeTokens || []) {
       if (token?.tokenHash) userHashes.add(token.tokenHash);
     }
+    userHashesByIdentity.set(key, userHashes);
   }
 
   const credentialByHash = new Map<string, CredentialRow>();
@@ -133,15 +138,24 @@ const buildCandidates = (
   let copiesSkippedRecent = 0;
   for (const [key, tokensByHash] of byIdentity) {
     const [agentName, instanceId] = key.split(':');
+    const userHashes = userHashesByIdentity.get(key);
     const selectedHashes: string[] = [];
     let count = 0;
     let skippedRecent = 0;
+    let legacyOnly = 0;
     let newestLastUsedAt: Date | null = null;
     for (const candidate of tokensByHash.values()) {
       newestLastUsedAt = newestDate(newestLastUsedAt, candidate.newestLastUsedAt);
-      // A token hash should belong to one identity, but excluding it if it is
-      // present on any bot User row is the safe failure mode for a malformed
-      // duplicate: never pull a bearer that still has a User auth path.
+      // An installation-only identity has no replacement bearer. Leave every
+      // copy untouched and report it for an operator-led migration instead of
+      // deleting its only authentication path.
+      if (!userHashes?.size) {
+        legacyOnly += candidate.copies;
+        continue;
+      }
+      // Excluding a hash present on this identity's User row preserves its
+      // portable authentication path without letting another identity's hash
+      // suppress a legitimate stale candidate.
       if (userHashes.has(candidate.hash) || candidate.revoked) continue;
       if (candidate.recentlyUsed) {
         skippedRecent += candidate.copies;
@@ -152,8 +166,8 @@ const buildCandidates = (
       count += candidate.copies;
       copiesToPull += candidate.copies;
     }
-    if (count || skippedRecent) {
-      identities.push({ agentName, instanceId, count, skippedRecent, newestLastUsedAt });
+    if (count || skippedRecent || legacyOnly) {
+      identities.push({ agentName, instanceId, count, skippedRecent, legacyOnly, newestLastUsedAt });
       selectedHashesByIdentity.set(key, selectedHashes);
     }
   }
@@ -186,7 +200,7 @@ export const sweepLeftoverRuntimeTokens = async (
     'runtimeTokens.0': { $exists: true },
   }).select('agentName instanceId runtimeTokens').lean() as InstallationRow[];
   const users = await User.find({ isBot: true })
-    .select('agentRuntimeTokens')
+    .select('agentRuntimeTokens botMetadata')
     .lean() as any[];
   const allHashes = Array.from(new Set(
     installations.flatMap((installation) => (installation.runtimeTokens || [])
@@ -220,7 +234,7 @@ export const sweepLeftoverRuntimeTokens = async (
             },
           },
         },
-      );
+      ).collation({ locale: 'en', strength: 2 });
       installationRowsChanged += modifiedCount(pulled);
     }
     if (plan.candidateHashes) {

--- a/backend/scripts/sweep-leftover-runtime-tokens.ts
+++ b/backend/scripts/sweep-leftover-runtime-tokens.ts
@@ -15,6 +15,7 @@ import mongoose from 'mongoose';
 import AgentCredential from '../models/AgentCredential';
 import { AgentInstallation } from '../models/AgentRegistry';
 import User from '../models/User';
+import { revokeRuntimeCredentials } from '../routes/registry/tokens';
 
 const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -223,18 +224,15 @@ export const sweepLeftoverRuntimeTokens = async (
       installationRowsChanged += modifiedCount(pulled);
     }
     if (plan.candidateHashes) {
-      const revoked = await AgentCredential.updateMany(
+      const revoked = await revokeRuntimeCredentials(
+        Array.from(plan.selectedHashesByIdentity.values()).flat(),
         {
-          tokenHash: { $in: Array.from(plan.selectedHashesByIdentity.values()).flat() },
-          kind: 'runtime',
-          status: 'active',
           $or: [
             { lastUsedAt: { $exists: false } },
             { lastUsedAt: null },
             { lastUsedAt: { $lt: cutoff } },
           ],
         },
-        { $set: { status: 'revoked', revokedAt: new Date() } },
       );
       credentialsRevoked = modifiedCount(revoked);
     }

--- a/backend/scripts/sweep-leftover-runtime-tokens.ts
+++ b/backend/scripts/sweep-leftover-runtime-tokens.ts
@@ -1,0 +1,272 @@
+/**
+ * Remove installation-only runtime-token copies left by pre-rotation mints.
+ *
+ * Dry run is the default:
+ *   npm run sweep:leftover-runtime-tokens
+ * Apply the measured, stale-only candidates:
+ *   npm run sweep:leftover-runtime-tokens -- --apply
+ *
+ * The sweep never reads or writes local token files. It only removes bearer
+ * hashes from active AgentInstallation rows and revokes their runtime ledger
+ * rows. Tokens used in the last seven days are left for an operator to review.
+ */
+/* eslint-disable no-console */
+import mongoose from 'mongoose';
+import AgentCredential from '../models/AgentCredential';
+import { AgentInstallation } from '../models/AgentRegistry';
+import User from '../models/User';
+
+const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+type TokenCopy = {
+  tokenHash?: string;
+  lastUsedAt?: Date | string | null;
+};
+
+type InstallationRow = {
+  agentName: string;
+  instanceId?: string;
+  runtimeTokens?: TokenCopy[];
+};
+
+type CredentialRow = {
+  tokenHash: string;
+  status: string;
+  lastUsedAt?: Date | string | null;
+};
+
+type TokenCandidate = {
+  hash: string;
+  copies: number;
+  newestLastUsedAt: Date | null;
+  recentlyUsed: boolean;
+  revoked: boolean;
+};
+
+export type LeftoverRuntimeTokenIdentity = {
+  agentName: string;
+  instanceId: string;
+  count: number;
+  skippedRecent: number;
+  newestLastUsedAt: Date | null;
+};
+
+export type SweepLeftoverRuntimeTokensResult = {
+  apply: boolean;
+  cutoff: Date;
+  identities: LeftoverRuntimeTokenIdentity[];
+  candidateHashes: number;
+  copiesToPull: number;
+  copiesSkippedRecent: number;
+  installationRowsChanged: number;
+  credentialsRevoked: number;
+};
+
+const normalize = (value: unknown, fallback = 'default'): string => {
+  const normalized = String(value || '').trim().toLowerCase();
+  return normalized || fallback;
+};
+
+const identityKey = (agentName: unknown, instanceId: unknown): string => (
+  `${normalize(agentName, '')}:${normalize(instanceId)}`
+);
+
+const dateOrNull = (value: unknown): Date | null => {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const newestDate = (left: Date | null, right: Date | null): Date | null => {
+  if (!left) return right;
+  if (!right) return left;
+  return left > right ? left : right;
+};
+
+const buildCandidates = (
+  installations: InstallationRow[],
+  users: any[],
+  credentials: CredentialRow[],
+  cutoff: Date,
+) => {
+  const userHashes = new Set<string>();
+  for (const user of users) {
+    for (const token of user.agentRuntimeTokens || []) {
+      if (token?.tokenHash) userHashes.add(token.tokenHash);
+    }
+  }
+
+  const credentialByHash = new Map<string, CredentialRow>();
+  for (const credential of credentials) credentialByHash.set(credential.tokenHash, credential);
+
+  const byIdentity = new Map<string, Map<string, TokenCandidate>>();
+  for (const installation of installations) {
+    const agentName = normalize(installation.agentName, '');
+    const instanceId = normalize(installation.instanceId);
+    const key = identityKey(agentName, instanceId);
+    if (!byIdentity.has(key)) byIdentity.set(key, new Map());
+    const tokensByHash = byIdentity.get(key)!;
+    for (const token of installation.runtimeTokens || []) {
+      const hash = token?.tokenHash;
+      if (!hash) continue;
+      const previous = tokensByHash.get(hash) || {
+        hash,
+        copies: 0,
+        newestLastUsedAt: null,
+        recentlyUsed: false,
+        revoked: false,
+      };
+      previous.copies += 1;
+      previous.newestLastUsedAt = newestDate(previous.newestLastUsedAt, dateOrNull(token.lastUsedAt));
+      const credential = credentialByHash.get(hash);
+      previous.newestLastUsedAt = newestDate(previous.newestLastUsedAt, dateOrNull(credential?.lastUsedAt));
+      previous.recentlyUsed = Boolean(previous.newestLastUsedAt && previous.newestLastUsedAt >= cutoff);
+      previous.revoked = credential?.status === 'revoked';
+      tokensByHash.set(hash, previous);
+    }
+  }
+
+  const identities: LeftoverRuntimeTokenIdentity[] = [];
+  const selectedHashesByIdentity = new Map<string, string[]>();
+  let copiesToPull = 0;
+  let copiesSkippedRecent = 0;
+  for (const [key, tokensByHash] of byIdentity) {
+    const [agentName, instanceId] = key.split(':');
+    const selectedHashes: string[] = [];
+    let count = 0;
+    let skippedRecent = 0;
+    let newestLastUsedAt: Date | null = null;
+    for (const candidate of tokensByHash.values()) {
+      newestLastUsedAt = newestDate(newestLastUsedAt, candidate.newestLastUsedAt);
+      // A token hash should belong to one identity, but excluding it if it is
+      // present on any bot User row is the safe failure mode for a malformed
+      // duplicate: never pull a bearer that still has a User auth path.
+      if (userHashes.has(candidate.hash) || candidate.revoked) continue;
+      if (candidate.recentlyUsed) {
+        skippedRecent += candidate.copies;
+        copiesSkippedRecent += candidate.copies;
+        continue;
+      }
+      selectedHashes.push(candidate.hash);
+      count += candidate.copies;
+      copiesToPull += candidate.copies;
+    }
+    if (count || skippedRecent) {
+      identities.push({ agentName, instanceId, count, skippedRecent, newestLastUsedAt });
+      selectedHashesByIdentity.set(key, selectedHashes);
+    }
+  }
+
+  identities.sort((left, right) => (
+    `${left.agentName}:${left.instanceId}`.localeCompare(`${right.agentName}:${right.instanceId}`)
+  ));
+  return {
+    identities,
+    selectedHashesByIdentity,
+    candidateHashes: Array.from(selectedHashesByIdentity.values()).reduce((total, hashes) => total + hashes.length, 0),
+    copiesToPull,
+    copiesSkippedRecent,
+  };
+};
+
+const modifiedCount = (result: any): number => Number(result?.modifiedCount ?? result?.nModified ?? 0);
+
+/**
+ * Find installation-only runtime bearers and, when requested, remove only
+ * candidates whose latest observed use is outside the seven-day safety window.
+ */
+export const sweepLeftoverRuntimeTokens = async (
+  options: { apply?: boolean } = {},
+): Promise<SweepLeftoverRuntimeTokensResult> => {
+  const apply = options.apply === true;
+  const cutoff = new Date(Date.now() - RECENT_WINDOW_MS);
+  const installations = await AgentInstallation.find({
+    status: 'active',
+    'runtimeTokens.0': { $exists: true },
+  }).select('agentName instanceId runtimeTokens').lean() as InstallationRow[];
+  const users = await User.find({ isBot: true })
+    .select('agentRuntimeTokens')
+    .lean() as any[];
+  const allHashes = Array.from(new Set(
+    installations.flatMap((installation) => (installation.runtimeTokens || [])
+      .map((token) => token?.tokenHash)
+      .filter(Boolean) as string[]),
+  ));
+  const credentials = allHashes.length
+    ? await AgentCredential.find({ tokenHash: { $in: allHashes }, kind: 'runtime' })
+      .select('tokenHash status lastUsedAt')
+      .lean() as CredentialRow[]
+    : [];
+  const plan = buildCandidates(installations, users, credentials, cutoff);
+
+  let installationRowsChanged = 0;
+  let credentialsRevoked = 0;
+  if (apply) {
+    for (const [key, hashes] of plan.selectedHashesByIdentity) {
+      if (!hashes.length) continue;
+      const [agentName, instanceId] = key.split(':');
+      const pulled = await AgentInstallation.updateMany(
+        { agentName, instanceId, status: 'active' },
+        {
+          $pull: {
+            runtimeTokens: {
+              tokenHash: { $in: hashes },
+              $or: [
+                { lastUsedAt: { $exists: false } },
+                { lastUsedAt: null },
+                { lastUsedAt: { $lt: cutoff } },
+              ],
+            },
+          },
+        },
+      );
+      installationRowsChanged += modifiedCount(pulled);
+    }
+    if (plan.candidateHashes) {
+      const revoked = await AgentCredential.updateMany(
+        {
+          tokenHash: { $in: Array.from(plan.selectedHashesByIdentity.values()).flat() },
+          kind: 'runtime',
+          status: 'active',
+          $or: [
+            { lastUsedAt: { $exists: false } },
+            { lastUsedAt: null },
+            { lastUsedAt: { $lt: cutoff } },
+          ],
+        },
+        { $set: { status: 'revoked', revokedAt: new Date() } },
+      );
+      credentialsRevoked = modifiedCount(revoked);
+    }
+  }
+
+  return {
+    apply,
+    cutoff,
+    identities: plan.identities,
+    candidateHashes: plan.candidateHashes,
+    copiesToPull: plan.copiesToPull,
+    copiesSkippedRecent: plan.copiesSkippedRecent,
+    installationRowsChanged,
+    credentialsRevoked,
+  };
+};
+
+export const main = async (): Promise<void> => {
+  if (!process.env.MONGO_URI) throw new Error('MONGO_URI is required');
+  await mongoose.connect(process.env.MONGO_URI);
+  try {
+    const result = await sweepLeftoverRuntimeTokens({ apply: process.argv.includes('--apply') });
+    console.log(JSON.stringify(result, null, 2));
+    if (!result.apply) console.log('DRY RUN — no runtime tokens changed. Re-run with --apply after review.');
+  } finally {
+    await mongoose.disconnect();
+  }
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('leftover runtime-token sweep failed:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- centralize runtime-token revocation across User, installation copies, and active AgentCredential rows
- make registry force re-mint, daemon binding rotate, provision/reprovision, and hosted provision use the shared rotation
- detect installation-only legacy tokens before refusing a daemon mint
- add a dry-run-by-default, `--apply` stale-only sweep for pre-existing installation copies; recent (7-day) bearers are skipped and no local token files are touched
- add in-memory Mongo coverage proving both User and installation bearers return 401 after rotation and sweep dry-run/apply behavior

## Verification
- `npm test -- --runInBand __tests__/unit/routes/agentBinding.phase2.test.js __tests__/unit/routes/registry.runtime-tokens.test.js __tests__/unit/routes/hosted.test.js` (41 passed)
- `npm test -- --runInBand __tests__/unit/scripts/sweep-leftover-runtime-tokens.test.js` (2 passed)
- `npx tsc --noEmit -p tsconfig.json` (existing unrelated errors in cleanup/test-discord scripts; no changed-file errors)
